### PR TITLE
fix: use repo name as subdirectory for worktree paths

### DIFF
--- a/src/ghaiw/services/work_service.py
+++ b/src/ghaiw/services/work_service.py
@@ -505,7 +505,7 @@ def start(
 
     worktrees_dir = _resolve_worktrees_dir(config, repo_root)
     repo_name = repo_root.name
-    worktree_path = worktrees_dir / f"{repo_name}-{branch_name.replace('/', '-')}"
+    worktree_path = worktrees_dir / repo_name / branch_name.replace("/", "-")
 
     # Reuse the worktree if the branch already exists (idempotent re-run)
     existing_wt = next(


### PR DESCRIPTION
## Summary
- Worktrees are now placed at `<worktrees_dir>/<repo_name>/<branch>` instead of `<worktrees_dir>/<repo_name>-<branch>`
- Gives a cleaner directory layout when multiple projects share the same parent worktrees dir

## Test plan
- [ ] All 33 unit tests in `test_work_service.py` pass
- [ ] Verify worktree is created at `../.worktrees/<repo_name>/<branch>` after `ghaiwpy work start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wade:deps:start -->

## Dependencies

**Blocks:** #2

<!-- wade:deps:end -->
