### PR TITLE
fix: plan token usage not reported (transcript never captured)

### DIFF
--- a/src/ghaiw/ai_tools/antigravity.py
+++ b/src/ghaiw/ai_tools/antigravity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from typing import ClassVar
 
@@ -16,6 +15,7 @@ from ghaiw.models.ai import (
     AIToolType,
     TokenUsage,
 )
+from ghaiw.utils.process import run_with_transcript
 
 logger = structlog.get_logger()
 
@@ -49,8 +49,7 @@ class AntigravityAdapter(AbstractAITool):
     ) -> int:
         cmd = [self.capabilities().binary, "."]
         logger.info("ai_tool.launch", tool="antigravity", cwd=str(worktree_path))
-        result = subprocess.run(cmd, cwd=worktree_path)
-        return result.returncode
+        return run_with_transcript(cmd, transcript_path, cwd=worktree_path)
 
     def parse_transcript(self, transcript_path: Path) -> TokenUsage:
         return TokenUsage()

--- a/src/ghaiw/ai_tools/claude.py
+++ b/src/ghaiw/ai_tools/claude.py
@@ -22,6 +22,7 @@ from ghaiw.models.ai import (
     AIToolType,
     TokenUsage,
 )
+from ghaiw.utils.process import run_with_transcript
 
 logger = structlog.get_logger()
 
@@ -94,8 +95,7 @@ class ClaudeAdapter(AbstractAITool):
 
         logger.info("ai_tool.launch", tool="claude", model=model, cwd=str(worktree_path))
 
-        result = subprocess.run(cmd, cwd=worktree_path)
-        return result.returncode
+        return run_with_transcript(cmd, transcript_path, cwd=worktree_path)
 
     def parse_transcript(self, transcript_path: Path) -> TokenUsage:
         # Delegated to transcript.py — this is a stub

--- a/src/ghaiw/ai_tools/codex.py
+++ b/src/ghaiw/ai_tools/codex.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-import subprocess
 from pathlib import Path
 from typing import ClassVar
 
@@ -21,6 +20,7 @@ from ghaiw.models.ai import (
     AIToolType,
     TokenUsage,
 )
+from ghaiw.utils.process import run_with_transcript
 
 logger = structlog.get_logger()
 
@@ -65,8 +65,7 @@ class CodexAdapter(AbstractAITool):
     ) -> int:
         cmd = self.build_launch_command(model=model)
         logger.info("ai_tool.launch", tool="codex", model=model, cwd=str(worktree_path))
-        result = subprocess.run(cmd, cwd=worktree_path)
-        return result.returncode
+        return run_with_transcript(cmd, transcript_path, cwd=worktree_path)
 
     def parse_transcript(self, transcript_path: Path) -> TokenUsage:
         from ghaiw.ai_tools.transcript import parse_codex_transcript

--- a/src/ghaiw/ai_tools/copilot.py
+++ b/src/ghaiw/ai_tools/copilot.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from typing import ClassVar
 
@@ -20,6 +19,7 @@ from ghaiw.models.ai import (
     AIToolType,
     TokenUsage,
 )
+from ghaiw.utils.process import run_with_transcript
 
 logger = structlog.get_logger()
 
@@ -77,8 +77,7 @@ class CopilotAdapter(AbstractAITool):
     ) -> int:
         cmd = self.build_launch_command(model=model, prompt=prompt)
         logger.info("ai_tool.launch", tool="copilot", model=model, cwd=str(worktree_path))
-        result = subprocess.run(cmd, cwd=worktree_path)
-        return result.returncode
+        return run_with_transcript(cmd, transcript_path, cwd=worktree_path)
 
     def parse_transcript(self, transcript_path: Path) -> TokenUsage:
         from ghaiw.ai_tools.transcript import parse_copilot_transcript

--- a/src/ghaiw/ai_tools/gemini.py
+++ b/src/ghaiw/ai_tools/gemini.py
@@ -22,6 +22,7 @@ from ghaiw.models.ai import (
     AIToolType,
     TokenUsage,
 )
+from ghaiw.utils.process import run_with_transcript
 
 logger = structlog.get_logger()
 
@@ -92,8 +93,7 @@ class GeminiAdapter(AbstractAITool):
     ) -> int:
         cmd = self.build_launch_command(model=model)
         logger.info("ai_tool.launch", tool="gemini", model=model, cwd=str(worktree_path))
-        result = subprocess.run(cmd, cwd=worktree_path)
-        return result.returncode
+        return run_with_transcript(cmd, transcript_path, cwd=worktree_path)
 
     def parse_transcript(self, transcript_path: Path) -> TokenUsage:
         from ghaiw.ai_tools.transcript import parse_gemini_transcript

--- a/src/ghaiw/services/plan_service.py
+++ b/src/ghaiw/services/plan_service.py
@@ -36,6 +36,7 @@ from ghaiw.services.task_service import (
 )
 from ghaiw.ui.console import console
 from ghaiw.utils.clipboard import copy_to_clipboard
+from ghaiw.utils.process import run_with_transcript
 
 logger = structlog.get_logger()
 
@@ -183,8 +184,7 @@ def run_ai_planning_session(
         cmd=" ".join(cmd),
     )
 
-    result = subprocess.run(cmd, cwd=Path.cwd())
-    return result.returncode
+    return run_with_transcript(cmd, transcript_path, cwd=Path.cwd())
 
 
 # ---------------------------------------------------------------------------

--- a/src/ghaiw/utils/process.py
+++ b/src/ghaiw/utils/process.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shlex
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -73,6 +75,48 @@ def run(
         raise CommandError(command, result.returncode, stderr)
 
     return result
+
+
+def run_with_transcript(
+    cmd: list[str],
+    transcript_path: Path | None,
+    cwd: Path | str | None = None,
+) -> int:
+    """Run a command, capturing terminal output to transcript_path via `script`.
+
+    Uses the `script` utility (BSD on macOS, GNU on Linux) to record the
+    interactive session. Falls back to plain subprocess.run when transcript_path
+    is None or `script` is not available.
+
+    Behavioral reference: lib/task/tokens.sh:_task_run_with_transcript()
+    """
+    if transcript_path is None or not shutil.which("script"):
+        result = subprocess.run(cmd, cwd=cwd)
+        return result.returncode
+
+    # Detect GNU vs BSD script: GNU accepts --version; BSD does not.
+    version_check = subprocess.run(
+        ["script", "--version"],
+        capture_output=True,
+    )
+
+    if version_check.returncode == 0:
+        # GNU script (Linux): script -q -c "cmd" transcript_file
+        cmd_str = " ".join(shlex.quote(c) for c in cmd)
+        full_cmd = ["script", "-q", "-c", cmd_str, str(transcript_path)]
+    else:
+        # BSD script (macOS): script -q transcript_file cmd...
+        full_cmd = ["script", "-q", str(transcript_path), *cmd]
+
+    logger.debug(
+        "subprocess.run_with_transcript",
+        cmd=cmd,
+        transcript=str(transcript_path),
+        cwd=str(cwd) if cwd else None,
+    )
+
+    result = subprocess.run(full_cmd, cwd=cwd)
+    return result.returncode
 
 
 def run_silent(

--- a/tests/unit/test_services/test_plan_service.py
+++ b/tests/unit/test_services/test_plan_service.py
@@ -210,18 +210,21 @@ class TestPlanFile:
 
 class TestTranscriptWiring:
     def test_claude_no_output_file_flag(self, tmp_path: Path) -> None:
-        """run_ai_planning_session must NOT add --output-file (flag doesn't exist in Claude CLI)."""
+        """run_ai_planning_session must NOT add --output-file (flag doesn't exist in Claude CLI).
+
+        Transcript capture is handled by run_with_transcript, not a CLI flag.
+        """
         transcript = tmp_path / ".transcript"
 
         with (
             patch("ghaiw.services.plan_service.AbstractAITool.get") as mock_get,
-            patch("ghaiw.services.plan_service.subprocess") as mock_sp,
+            patch("ghaiw.services.plan_service.run_with_transcript") as mock_rwt,
         ):
             adapter = MagicMock()
             adapter.build_launch_command.return_value = ["claude", "--permission-mode", "plan"]
             adapter.plan_dir_args.return_value = ["--add-dir", str(tmp_path)]
             mock_get.return_value = adapter
-            mock_sp.run.return_value = MagicMock(returncode=0)
+            mock_rwt.return_value = 0
 
             run_ai_planning_session(
                 ai_tool="claude",
@@ -230,20 +233,43 @@ class TestTranscriptWiring:
                 transcript_path=transcript,
             )
 
-            cmd = mock_sp.run.call_args[0][0]
+            cmd = mock_rwt.call_args[0][0]
             assert "--output-file" not in cmd
 
-    def test_no_output_file_without_transcript(self) -> None:
-        """run_ai_planning_session should not add --output-file when no transcript."""
+    def test_transcript_path_forwarded_to_run_with_transcript(self, tmp_path: Path) -> None:
+        """run_ai_planning_session forwards transcript_path to run_with_transcript."""
+        transcript = tmp_path / ".transcript"
+
         with (
             patch("ghaiw.services.plan_service.AbstractAITool.get") as mock_get,
-            patch("ghaiw.services.plan_service.subprocess") as mock_sp,
+            patch("ghaiw.services.plan_service.run_with_transcript") as mock_rwt,
+        ):
+            adapter = MagicMock()
+            adapter.build_launch_command.return_value = ["claude", "--permission-mode", "plan"]
+            adapter.plan_dir_args.return_value = []
+            mock_get.return_value = adapter
+            mock_rwt.return_value = 0
+
+            run_ai_planning_session(
+                ai_tool="claude",
+                plan_dir=str(tmp_path),
+                model=None,
+                transcript_path=transcript,
+            )
+
+            assert mock_rwt.call_args[0][1] == transcript
+
+    def test_no_transcript_path_passes_none(self) -> None:
+        """When transcript_path is None, run_with_transcript receives None."""
+        with (
+            patch("ghaiw.services.plan_service.AbstractAITool.get") as mock_get,
+            patch("ghaiw.services.plan_service.run_with_transcript") as mock_rwt,
         ):
             adapter = MagicMock()
             adapter.build_launch_command.return_value = ["claude", "--permission-mode", "plan"]
             adapter.plan_dir_args.return_value = ["--add-dir", "/tmp/test"]
             mock_get.return_value = adapter
-            mock_sp.run.return_value = MagicMock(returncode=0)
+            mock_rwt.return_value = 0
 
             run_ai_planning_session(
                 ai_tool="claude",
@@ -252,26 +278,25 @@ class TestTranscriptWiring:
                 transcript_path=None,
             )
 
-            cmd = mock_sp.run.call_args[0][0]
-            assert "--output-file" not in cmd
+            assert mock_rwt.call_args[0][1] is None
 
     def test_includes_plan_dir_args(self, tmp_path: Path) -> None:
         """run_ai_planning_session should include plan_dir_args from adapter."""
         with (
             patch("ghaiw.services.plan_service.AbstractAITool.get") as mock_get,
-            patch("ghaiw.services.plan_service.subprocess") as mock_sp,
+            patch("ghaiw.services.plan_service.run_with_transcript") as mock_rwt,
         ):
             adapter = MagicMock()
             adapter.build_launch_command.return_value = ["copilot", "--model", "test"]
             adapter.plan_dir_args.return_value = ["--add-dir", str(tmp_path)]
             mock_get.return_value = adapter
-            mock_sp.run.return_value = MagicMock(returncode=0)
+            mock_rwt.return_value = 0
 
             run_ai_planning_session(
                 ai_tool="copilot",
                 plan_dir=str(tmp_path),
             )
 
-            cmd = mock_sp.run.call_args[0][0]
+            cmd = mock_rwt.call_args[0][0]
             assert "--add-dir" in cmd
             assert str(tmp_path) in cmd

--- a/tests/unit/test_utils/test_process.py
+++ b/tests/unit/test_utils/test_process.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from ghaiw.utils.process import CommandError, run, run_silent
+from ghaiw.utils.process import CommandError, run, run_silent, run_with_transcript
 
 
 class TestRun:
@@ -34,3 +37,106 @@ class TestRunSilent:
 
     def test_failure(self) -> None:
         assert run_silent(["false"]) is False
+
+
+class TestRunWithTranscript:
+    def test_no_transcript_path_runs_cmd_directly(self, tmp_path: Path) -> None:
+        """When transcript_path is None, run the command without script."""
+        with patch("ghaiw.utils.process.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = run_with_transcript(["echo", "hi"], transcript_path=None)
+        assert result == 0
+        mock_run.assert_called_once_with(["echo", "hi"], cwd=None)
+
+    def test_script_not_found_falls_back(self, tmp_path: Path) -> None:
+        """When `script` binary is missing, fall back to plain subprocess.run."""
+        transcript = tmp_path / ".transcript"
+        with (
+            patch("ghaiw.utils.process.shutil.which", return_value=None),
+            patch("ghaiw.utils.process.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            result = run_with_transcript(["echo", "hi"], transcript_path=transcript)
+        assert result == 0
+        mock_run.assert_called_once_with(["echo", "hi"], cwd=None)
+
+    def test_gnu_script_linux_syntax(self, tmp_path: Path) -> None:
+        """When script --version succeeds (GNU), use: script -q -c 'cmd' transcript."""
+        transcript = tmp_path / ".transcript"
+        with (
+            patch("ghaiw.utils.process.shutil.which", return_value="/usr/bin/script"),
+            patch("ghaiw.utils.process.subprocess.run") as mock_run,
+        ):
+            # First call: script --version (returncode=0 → GNU)
+            # Second call: actual script invocation
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # script --version
+                MagicMock(returncode=0),  # script -q -c ... transcript
+            ]
+            result = run_with_transcript(
+                ["claude", "--permission-mode", "plan"],
+                transcript_path=transcript,
+            )
+        assert result == 0
+        actual_cmd = mock_run.call_args[0][0]
+        assert actual_cmd[0] == "script"
+        assert actual_cmd[1] == "-q"
+        assert actual_cmd[2] == "-c"
+        # The quoted command string should contain all parts
+        assert "claude" in actual_cmd[3]
+        assert "--permission-mode" in actual_cmd[3]
+        assert actual_cmd[4] == str(transcript)
+
+    def test_bsd_script_macos_syntax(self, tmp_path: Path) -> None:
+        """When script --version fails (BSD), use: script -q transcript cmd..."""
+        transcript = tmp_path / ".transcript"
+        with (
+            patch("ghaiw.utils.process.shutil.which", return_value="/usr/bin/script"),
+            patch("ghaiw.utils.process.subprocess.run") as mock_run,
+        ):
+            # First call: script --version (returncode=1 → BSD)
+            # Second call: actual script invocation
+            mock_run.side_effect = [
+                MagicMock(returncode=1),  # script --version (BSD returns non-zero)
+                MagicMock(returncode=0),  # script -q transcript cmd...
+            ]
+            result = run_with_transcript(
+                ["claude", "--permission-mode", "plan"],
+                transcript_path=transcript,
+            )
+        assert result == 0
+        actual_cmd = mock_run.call_args[0][0]
+        assert actual_cmd == [
+            "script",
+            "-q",
+            str(transcript),
+            "claude",
+            "--permission-mode",
+            "plan",
+        ]  # BSD: script -q transcript cmd...
+
+    def test_cwd_is_passed_through(self, tmp_path: Path) -> None:
+        """cwd is forwarded to the subprocess call."""
+        cwd = tmp_path / "work"
+        cwd.mkdir()
+        with (
+            patch("ghaiw.utils.process.shutil.which", return_value=None),
+            patch("ghaiw.utils.process.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            run_with_transcript(["true"], transcript_path=None, cwd=cwd)
+        mock_run.assert_called_once_with(["true"], cwd=cwd)
+
+    def test_returns_script_exit_code(self, tmp_path: Path) -> None:
+        """The exit code from the script invocation is returned."""
+        transcript = tmp_path / ".transcript"
+        with (
+            patch("ghaiw.utils.process.shutil.which", return_value="/usr/bin/script"),
+            patch("ghaiw.utils.process.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                MagicMock(returncode=1),  # BSD script --version
+                MagicMock(returncode=42),  # actual run
+            ]
+            result = run_with_transcript(["somecommand"], transcript_path=transcript)
+        assert result == 42


### PR DESCRIPTION
## Summary

- `run_ai_planning_session()` accepted a `transcript_path` parameter but called `subprocess.run()` directly, silently dropping it — the transcript file was never written
- `_extract_token_usage()` always returned empty `TokenUsage`, so GitHub issues were updated with "unavailable" token data for both Claude Code and Copilot sessions
- Same gap existed in all five adapter `launch()` methods (affecting `work start` sessions too)

## Changes

- **`utils/process.py`** — New `run_with_transcript(cmd, transcript_path, cwd)` helper matching the Bash reference `_task_run_with_transcript()` in `lib/task/tokens.sh`: uses `script` utility (GNU/Linux or BSD/macOS syntax auto-detected via `script --version`), falls back to plain `subprocess.run` when `script` is absent
- **`services/plan_service.py`** — `run_ai_planning_session()` now calls `run_with_transcript()` instead of `subprocess.run()`
- **All 5 adapters** (`claude`, `copilot`, `gemini`, `codex`, `antigravity`) — `launch()` now calls `run_with_transcript()` so work sessions also capture token usage

## Test plan

- [ ] Updated `TestTranscriptWiring` in `test_plan_service.py`: replaced weak negative assertions ("no `--output-file` flag") with positive contracts asserting `transcript_path` is forwarded — the missing test that would have caught this bug originally
- [ ] Added `TestRunWithTranscript` (6 tests) in `test_process.py` covering: no transcript path, `script` not found fallback, GNU/Linux syntax, BSD/macOS syntax, `cwd` passthrough, exit code propagation
- [ ] All 37 tests pass, mypy strict clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wade:deps:start -->

## Dependencies

**Depends on:** #1

<!-- wade:deps:end -->
