### PR TITLE
test: fix 5 CI failures in work service and CLI flag tests

### DIFF
--- a/tests/unit/test_cli/test_work_ai_flags.py
+++ b/tests/unit/test_cli/test_work_ai_flags.py
@@ -14,9 +14,12 @@ class TestWorkAIFlagCLI:
 
     def test_work_start_help_documents_ai_flag(self) -> None:
         """work start --help should document the --ai flag."""
+        import re
+
         result = runner.invoke(app, ["work", "start", "--help"])
         assert result.exit_code == 0
-        assert "--ai" in result.output
+        output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "--ai" in output
 
     def test_work_start_ai_flag_accepted(self) -> None:
         """--ai with a value should be accepted by Typer (no option-parse error)."""

--- a/tests/unit/test_services/test_work_service.py
+++ b/tests/unit/test_services/test_work_service.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ghaiw.ai_tools.base import AbstractAITool
 from ghaiw.ai_tools.claude import ClaudeAdapter
 from ghaiw.ai_tools.codex import CodexAdapter
 from ghaiw.ai_tools.copilot import CopilotAdapter
@@ -257,7 +258,10 @@ class TestWorkLaunchCommandAssembly:
         adapter = ClaudeAdapter()
         transcript = tmp_path / "transcript.jsonl"
 
-        with patch("ghaiw.ai_tools.claude.subprocess.run") as mock_run:
+        with (
+            patch("ghaiw.utils.process.shutil.which", return_value=None),
+            patch("ghaiw.utils.process.subprocess.run") as mock_run,
+        ):
             mock_run.return_value = MagicMock(returncode=0)
             adapter.launch(
                 worktree_path=tmp_path,
@@ -289,7 +293,10 @@ class TestWorkLaunchCommandAssembly:
         """Copilot launch should NOT include --output-file (no transcript support)."""
         adapter = CopilotAdapter()
 
-        with patch("ghaiw.ai_tools.copilot.subprocess.run") as mock_run:
+        with (
+            patch("ghaiw.utils.process.shutil.which", return_value=None),
+            patch("ghaiw.utils.process.subprocess.run") as mock_run,
+        ):
             mock_run.return_value = MagicMock(returncode=0)
             adapter.launch(
                 worktree_path=tmp_path,
@@ -323,7 +330,10 @@ class TestWorkLaunchCommandAssembly:
         """Codex launch should use 'codex' binary with --model."""
         adapter = CodexAdapter()
 
-        with patch("ghaiw.ai_tools.codex.subprocess.run") as mock_run:
+        with (
+            patch("ghaiw.utils.process.shutil.which", return_value=None),
+            patch("ghaiw.utils.process.subprocess.run") as mock_run,
+        ):
             mock_run.return_value = MagicMock(returncode=0)
             adapter.launch(
                 worktree_path=tmp_path,
@@ -337,14 +347,17 @@ class TestWorkLaunchCommandAssembly:
 
     def test_no_plan_mode_in_work_session(self, tmp_path: Path) -> None:
         """Work session launches should NOT include plan/approval mode flags."""
-        adapters = [
-            ("ghaiw.ai_tools.claude.subprocess.run", ClaudeAdapter()),
-            ("ghaiw.ai_tools.copilot.subprocess.run", CopilotAdapter()),
-            ("ghaiw.ai_tools.gemini.subprocess.run", GeminiAdapter()),
-            ("ghaiw.ai_tools.codex.subprocess.run", CodexAdapter()),
+        adapters: list[AbstractAITool] = [
+            ClaudeAdapter(),
+            CopilotAdapter(),
+            GeminiAdapter(),
+            CodexAdapter(),
         ]
-        for patch_target, adapter in adapters:
-            with patch(patch_target) as mock_run:
+        for adapter in adapters:
+            with (
+                patch("ghaiw.utils.process.shutil.which", return_value=None),
+                patch("ghaiw.utils.process.subprocess.run") as mock_run,
+            ):
                 mock_run.return_value = MagicMock(returncode=0)
                 adapter.launch(
                     worktree_path=tmp_path,


### PR DESCRIPTION
## Summary

- Strip ANSI escape codes in `test_work_start_help_documents_ai_flag` before asserting `--ai` appears (Rich ANSI coloring split the flag string)
- Fix `test_claude_launch_with_transcript`: patch `ghaiw.utils.process.subprocess.run` + mock `shutil.which=None` so `run_with_transcript` stays on the single-call fallback path (Linux CI has `script` available, causing 2 calls)
- Fix `test_copilot_launch_no_transcript_support` and `test_codex_launch_command`: `copilot.py`/`codex.py` don't import `subprocess` directly, so the old `patch("ghaiw.ai_tools.copilot.subprocess.run")` raised `AttributeError`; now targets `ghaiw.utils.process.subprocess.run`
- Fix `test_no_plan_mode_in_work_session`: same root cause for copilot/codex patch targets
- Add `AbstractAITool` import for type annotation

## Test plan

- [ ] All 5 previously-failing tests now pass locally
- [ ] Full unit suite: 827 passed, 7 skipped (the one remaining failure is a pre-existing local-env artifact unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)