### PR TITLE
fix: strip ANSI fragments from transcripts and warn on token extraction failure

### DIFF
--- a/src/ghaiw/ai_tools/transcript.py
+++ b/src/ghaiw/ai_tools/transcript.py
@@ -101,6 +101,12 @@ def read_transcript_excerpt(transcript_path: Path, max_lines: int = 400) -> str:
             cleaned.append(b)
 
     text = cleaned.decode("ascii", errors="ignore")
+    # Strip remaining ANSI parameter fragments left after ESC removal.
+    # ESC is 0x1B (stripped above), but the trailing "[NNN;NNNm" sequences
+    # remain as literal ASCII and must be removed too, otherwise token
+    # counts like "in:[33m166[0m" fail to match.
+    # Mirrors: gsub(/\[[0-9;?]*[[:alpha:]]/, "", raw) in tokens.sh
+    text = re.sub(r"\[[0-9;?]*[a-zA-Z]", "", text)
     # Replace CR with newline
     text = text.replace("\r", "\n")
 

--- a/src/ghaiw/services/plan_service.py
+++ b/src/ghaiw/services/plan_service.py
@@ -10,6 +10,7 @@ Behavioral reference: lib/task/crud.sh (_task_do_plan, _task_run_ai_planning)
 from __future__ import annotations
 
 import contextlib
+import os
 import shutil
 import subprocess
 import tempfile
@@ -200,6 +201,30 @@ def _extract_token_usage(transcript_path: Path | None) -> TokenUsage:
     return extract_token_usage_from_text(text)
 
 
+def _warn_token_extraction(transcript_path: Path | None) -> None:
+    """Warn the user that token usage could not be extracted.
+
+    If a transcript file exists, copies it to a stable debug path so the
+    user can inspect it after the temp plan directory is cleaned up.
+    """
+    if not transcript_path or not transcript_path.is_file():
+        logger.warning("plan.transcript_not_captured", path=str(transcript_path))
+        console.warn("Session transcript was not captured — token usage unavailable.")
+        return
+
+    fd, debug_path_str = tempfile.mkstemp(prefix="ghaiw-transcript-", suffix=".txt")
+    os.close(fd)
+    debug_path = Path(debug_path_str)
+    try:
+        shutil.copy2(transcript_path, debug_path)
+        logger.warning("plan.token_extraction_failed", transcript=str(debug_path))
+        console.warn("Could not extract token usage from session transcript.")
+        console.hint(f"Transcript saved for inspection: {debug_path}")
+    except OSError:
+        logger.warning("plan.token_extraction_failed", transcript=str(transcript_path))
+        console.warn("Could not extract token usage from session transcript.")
+
+
 # ---------------------------------------------------------------------------
 # Main plan orchestrator
 # ---------------------------------------------------------------------------
@@ -265,6 +290,8 @@ def plan(
 
     # Post-session: extract token usage
     usage = _extract_token_usage(transcript_path)
+    if not usage.total_tokens:
+        _warn_token_extraction(transcript_path)
 
     # Path A: Check for issues created during AI session
     after_snapshot = provider.snapshot_task_numbers(

--- a/tests/unit/test_transcript/test_parser.py
+++ b/tests/unit/test_transcript/test_parser.py
@@ -346,6 +346,24 @@ class TestReadTranscriptExcerpt:
         assert "HelloWorld" in text
         assert "in:100" in text
 
+    def test_ansi_fragments_stripped(self, tmp_path: Path) -> None:
+        """ANSI parameter fragments left after ESC removal must be stripped.
+
+        When script(1) captures a session, ESC (0x1B) is kept by the byte
+        filter but the trailing "[NNNm" sequences remain as literal ASCII.
+        If Claude Code colors token counts (e.g. in:[33m166[0m), the regex
+        must still match after those fragments are removed.
+        """
+        path = tmp_path / "transcript.txt"
+        # Simulate a status bar line where ESC has already been stripped,
+        # leaving raw ANSI fragments around the token numbers.
+        path.write_bytes(b"status: in:[33m166[0m out:[33m5.2k[0m\n")
+        text = read_transcript_excerpt(path)
+        assert "in:166" in text
+        assert "out:5.2k" in text
+        assert "[33m" not in text
+        assert "[0m" not in text
+
     def test_max_lines_respected(self, tmp_path: Path) -> None:
         path = tmp_path / "long.txt"
         lines = [f"line {i}" for i in range(1000)]


### PR DESCRIPTION
## Summary

- **Root cause**: Claude Code colorizes its token status bar (e.g. `in:[33m166[0m`). Python's `read_transcript_excerpt` stripped ESC (0x1B) but left ANSI parameter fragments (`[33m`, `[0m`) as literal ASCII, breaking the token regex and silently recording usage as unavailable.
- **Fix**: Added `re.sub(r"\[[0-9;?]*[a-zA-Z]", "", text)` in `read_transcript_excerpt` — the single shared entry point for all AI tool parsers — mirroring `tokens.sh`'s `gsub(/\[[0-9;?]*[[:alpha:]]/, "", raw)`.
- **Fail loudly**: Added `_warn_token_extraction()` in `plan_service.py` to notify the user when token parsing fails, with a unique debug transcript copy via `tempfile.mkstemp` (safe for parallel sessions).

## Test plan

- [x] New regression test `test_ansi_fragments_stripped` in `tests/unit/test_transcript/test_parser.py`
- [x] All 846 tests pass (`uv run pytest tests/ --ignore=tests/live -q`)
- [x] mypy strict + ruff pass (verified via pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)