### PR TITLE
fix: wire work-context.md into build_work_prompt, remove inline fallbacks

### DIFF
--- a/src/ghaiw/services/deps_service.py
+++ b/src/ghaiw/services/deps_service.py
@@ -38,13 +38,9 @@ def get_deps_prompt_template() -> str:
     from ghaiw.skills.installer import get_templates_dir
 
     template = get_templates_dir() / "prompts" / "deps-analysis.md"
-    if template.is_file():
-        return template.read_text(encoding="utf-8")
-    return (
-        "Analyze dependencies between the GitHub issues below.\n"
-        "Output ONLY: <number> -> <number> # reason\n"
-        "Context:\n{context}"
-    )
+    if not template.is_file():
+        raise FileNotFoundError(f"Prompt template not found: {template}")
+    return template.read_text(encoding="utf-8")
 
 
 def get_deps_interactive_template() -> str:
@@ -52,12 +48,9 @@ def get_deps_interactive_template() -> str:
     from ghaiw.skills.installer import get_templates_dir
 
     template = get_templates_dir() / "prompts" / "deps-interactive.md"
-    if template.is_file():
-        return template.read_text(encoding="utf-8").strip()
-    return (
-        "Write your dependency output to: {output_file}\n"
-        "Format: one line per edge: <number> -> <number> # reason"
-    )
+    if not template.is_file():
+        raise FileNotFoundError(f"Prompt template not found: {template}")
+    return template.read_text(encoding="utf-8").strip()
 
 
 # ---------------------------------------------------------------------------

--- a/src/ghaiw/services/plan_service.py
+++ b/src/ghaiw/services/plan_service.py
@@ -46,13 +46,9 @@ def get_plan_prompt_template() -> str:
     from ghaiw.skills.installer import get_templates_dir
 
     template = get_templates_dir() / "prompts" / "plan-session.md"
-    if template.is_file():
-        return template.read_text(encoding="utf-8")
-    # Fallback inline prompt
-    return (
-        "Planning session — no implementation yet. Start by asking what "
-        "feature or problem to plan, then break it down into GitHub issues."
-    )
+    if not template.is_file():
+        raise FileNotFoundError(f"Prompt template not found: {template}")
+    return template.read_text(encoding="utf-8")
 
 
 def render_plan_prompt(plan_dir: str) -> str:

--- a/src/ghaiw/services/work_service.py
+++ b/src/ghaiw/services/work_service.py
@@ -280,11 +280,13 @@ def build_work_prompt(task: Task, ai_tool: str | None = None) -> str:
 
     Behavioral reference: lib/work/bootstrap.sh:_work_copy_prompt()
     """
-    return (
-        "Let's implement PLAN.md. ALWAYS follow @.claude/skills/workflow/SKILL.md"
-        f"for session rules.\n\n"
-        f"Working on Issue #{task.id}: {task.title}\n"
-    )
+    from ghaiw.skills.installer import get_templates_dir
+
+    template_path = get_templates_dir() / "prompts" / "work-context.md"
+    if not template_path.is_file():
+        raise FileNotFoundError(f"Prompt template not found: {template_path}")
+    template = template_path.read_text(encoding="utf-8")
+    return template.format(issue_number=task.id, issue_title=task.title)
 
 
 def _post_work_lifecycle(

--- a/templates/prompts/work-context.md
+++ b/templates/prompts/work-context.md
@@ -1,4 +1,3 @@
-Let's implement @plan.md. Working on Issue #{issue_number}: {issue_title}
+Let's implement @PLAN.md. Working on Issue #{issue_number}: {issue_title}
 
-Read the issue context in @.issue-context.md for details.
 Follow @.claude/skills/workflow/SKILL.md for session rules.


### PR DESCRIPTION
## Summary

- `build_work_prompt()` now loads `templates/prompts/work-context.md` instead of a hardcoded string (which had a missing-space bug: `"SKILL.md"` + `"for session rules."` concatenated without a space)
- `work-context.md`: use `@PLAN.md` (uppercase, matches the actual filename written to the worktree), drop the redundant `@.issue-context.md` reference (legacy — same content as `PLAN.md`)
- Remove all inline fallback strings from all template loaders (`get_plan_prompt_template`, `get_deps_prompt_template`, `get_deps_interactive_template`, `build_work_prompt`) — raise `FileNotFoundError` instead to surface packaging/install errors rather than silently serving stale prompts

## Test plan

- [ ] `ghaiwpy work start <issue>` — verify clipboard prompt is `Let's implement @PLAN.md. Working on Issue #N: <title>\n\nFollow @.claude/skills/workflow/SKILL.md for session rules.`
- [ ] Verify no regressions in `ghaiwpy task plan` and `ghaiwpy task deps`
- [ ] Confirm `uv run pytest tests/ --ignore=tests/live` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)