### PR TITLE
Improve multiline input UX: fix Ctrl+D hint and tip shown to user

### DIFF
--- a/src/wade/services/task_service.py
+++ b/src/wade/services/task_service.py
@@ -384,7 +384,7 @@ def create_interactive(
         console.error("Title is required")
         return None
 
-    console.hint("Enter task body (press Ctrl+D when done, or leave empty):")
+    console.hint("Enter task body (press Enter then Ctrl+D when done, or leave empty):")
     body_lines: list[str] = []
     if not sys.stdin.isatty():
         body = ""


### PR DESCRIPTION
Closes #32

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
When creating a task interactively (`wade new-task`), the hint shown to the user says:

> "Enter task body (press Ctrl+D when done, or leave empty):"

This is misleading because Ctrl+D only signals EOF after a newline. If the user presses Ctrl+D mid-line without first pressing Enter, it doesn't work as expected. The hint should explicitly tell the user to press Enter before Ctrl+D.

The relevant code is at `src/wade/services/task_service.py:387`.

## Proposed Solution
Update the hint string at `task_service.py:387` to clarify that the user must press Enter (to move to a new line) and then Ctrl+D to finish input:

```python
console.hint("Enter task body (press Enter then Ctrl+D when done, or leave empty):")
```

Also search the entire codebase for any other occurrences of similar Ctrl+D hints or tips and apply the same wording update for consistency.

## Tasks
- [ ] Update the hint at `src/wade/services/task_service.py:387` to say "press Enter then Ctrl+D when done"
- [ ] Search for any other Ctrl+D hints in the codebase (CLI, UI, prompts) and apply the same fix
- [ ] Verify the change looks correct by reviewing the modified line(s)

## Acceptance Criteria
- [ ] The hint shown during `wade new-task` body input says "press Enter then Ctrl+D when done" (or equivalent clear wording)
- [ ] No other location in the codebase still shows the old misleading hint
- [ ] No functional behaviour is changed — only the displayed hint string

<!-- wade:plan:end -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | **181** |
| Input tokens | **181** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `0f14bbe7-ed3b-4c8a-b79d-e55a8ace9228` |

<!-- wade:sessions:end -->
