### PR TITLE
Build setup-worktree.sh script

### DIFF
--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Set up a new worktree with dev dependencies and git hooks.
+#
+# This script is called automatically by the post_worktree_create hook
+# when a new worktree is created via `wade implement-task`.
+#
+# It installs:
+# - Dev dependencies via `uv pip install -e ".[dev]"`
+# - Git hooks via `scripts/install-hooks.sh`
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Setting up worktree in ${ROOT_DIR}..."
+echo ""
+
+# Create/ensure virtual environment and install dev dependencies
+echo "Installing dev dependencies..."
+uv sync --all-extras
+echo ""
+
+# Install git hooks
+echo "Installing git hooks..."
+"${SCRIPT_DIR}/install-hooks.sh"
+echo ""
+
+echo "✓ Worktree setup complete!"


### PR DESCRIPTION
Implements #49

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
WADE's worktree hook system is fully wired — `bootstrap_worktree()` in `work_service.py` copies files, installs skills, and executes a `post_worktree_create` hook with a 60-second timeout. However, WADE's own repo lacks an actual `scripts/setup-worktree.sh` and `.wade.yml` has no `hooks` section. New worktrees created via `wade implement-task` don't get dev dependencies installed, so `fmt.sh`, `check.sh`, `test.sh` fail because `ruff`, `mypy`, `pytest` aren't available.

## Proposed Solution
Create `scripts/setup-worktree.sh` that installs dev dependencies via `uv pip install -e ".[dev]"` and git hooks via `scripts/install-hooks.sh`. Wire it up in `.wade.yml` with a `hooks.post_worktree_create` entry.

## Tasks
- [ ] Create `scripts/setup-worktree.sh` with `uv pip install -e ".[dev]"` and `scripts/install-hooks.sh`
- [ ] Make the script executable (`chmod +x`)
- [ ] Add `hooks: post_worktree_create: scripts/setup-worktree.sh` to `.wade.yml`

## Acceptance Criteria
- [ ] `scripts/setup-worktree.sh` exists and is executable
- [ ] `.wade.yml` has `hooks.post_worktree_create` pointing to the script
- [ ] Running the script in a worktree installs all dev dependencies so `fmt.sh`, `check.sh`, `test.sh` work

<!-- wade:plan:end -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | **9,488** |
| Input tokens | **888** |
| Output tokens | **8,600** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `6276bab3-cb04-45dc-872d-949d576ee88a` |

<!-- wade:sessions:end -->
