### PR TITLE
Make bootstrap_worktree self-init aware for wade development

### DIFF
--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -24,6 +24,7 @@ from wade.models.config import (
     ComplexityModelMapping,
 )
 from wade.skills import installer, pointer
+from wade.skills.installer import get_wade_repo_root
 from wade.ui.console import console
 
 logger = structlog.get_logger()
@@ -57,8 +58,12 @@ MANIFEST_FILENAME = ".wade-managed"
 
 
 def get_wade_root() -> Path:
-    """Get the wade package root (for self-init detection)."""
-    return Path(__file__).parent.parent.parent.parent
+    """Get the wade package root (for self-init detection).
+
+    Delegates to installer.get_wade_repo_root() — kept as a local alias
+    for backward compatibility.
+    """
+    return get_wade_repo_root()
 
 
 # ---------------------------------------------------------------------------

--- a/src/wade/services/work_service.py
+++ b/src/wade/services/work_service.py
@@ -136,9 +136,15 @@ def bootstrap_worktree(
             logger.debug("work.bootstrap_copy", file=filename)
 
     # Install skill files — not tracked by git so worktrees don't inherit them
-    from wade.skills.installer import install_skills
+    from wade.skills.installer import get_wade_repo_root, install_skills
 
-    install_skills(worktree_path, is_self_init=False, force=True)
+    is_self = repo_root.resolve() == get_wade_repo_root().resolve()
+    if is_self:
+        # Worktree has its own templates/ checkout — symlink to those
+        wt_templates = worktree_path / "templates" / "skills"
+        install_skills(worktree_path, is_self_init=True, force=True, templates_dir=wt_templates)
+    else:
+        install_skills(worktree_path, is_self_init=False, force=True)
     logger.debug("work.bootstrap_skills", path=str(worktree_path))
 
     # Propagate allowlist from project root to worktree if already configured

--- a/src/wade/skills/installer.py
+++ b/src/wade/skills/installer.py
@@ -11,6 +11,14 @@ import structlog
 logger = structlog.get_logger()
 
 
+def get_wade_repo_root() -> Path:
+    """Get the wade package repository root (for self-init detection).
+
+    Works in both editable installs (dev) and regular installs.
+    """
+    return Path(__file__).parent.parent.parent.parent
+
+
 def get_templates_dir() -> Path:
     """Get the path to the templates directory.
 
@@ -64,6 +72,7 @@ def install_skills(
     project_root: Path,
     is_self_init: bool = False,
     force: bool = False,
+    templates_dir: Path | None = None,
 ) -> list[str]:
     """Install all skill files to a project.
 
@@ -71,12 +80,15 @@ def install_skills(
         project_root: Root of the target project.
         is_self_init: If True, create symlinks instead of copies.
         force: If True, overwrite existing files.
+        templates_dir: Override the skills templates directory.
+            Useful for worktrees where templates live in the worktree itself.
 
     Returns:
         List of installed file paths (relative to project root).
     """
     installed: list[str] = []
-    templates_dir = get_skills_templates_dir()
+    if templates_dir is None:
+        templates_dir = get_skills_templates_dir()
 
     if not templates_dir.is_dir():
         logger.warning("skills.templates_not_found", path=str(templates_dir))

--- a/tests/unit/test_services/test_work_service.py
+++ b/tests/unit/test_services/test_work_service.py
@@ -120,6 +120,49 @@ class TestBootstrapWorktree:
 
         assert not (worktree / ".claude" / "settings.json").is_file()
 
+    def test_self_init_creates_symlinks(self, tmp_path: Path) -> None:
+        """When repo_root is the wade package root, skills are symlinked from worktree templates."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        # Create templates in the worktree (mimics a wade repo worktree checkout)
+        skills_tpl = worktree / "templates" / "skills"
+        for skill_name in ("task", "plan-session", "work-session", "deps"):
+            (skills_tpl / skill_name).mkdir(parents=True, exist_ok=True)
+            (skills_tpl / skill_name / "SKILL.md").write_text(f"# {skill_name}\n")
+
+        config = ProjectConfig()
+        with patch("wade.skills.installer.get_wade_repo_root", return_value=repo_root):
+            bootstrap_worktree(worktree, config, repo_root)
+
+        # Skills should be symlinks, not copies
+        task_skill = worktree / ".claude" / "skills" / "task"
+        assert task_skill.is_symlink()
+        assert (task_skill / "SKILL.md").read_text() == "# task\n"
+
+    def test_non_self_init_creates_copies(self, tmp_path: Path) -> None:
+        """When repo_root is NOT the wade package root, skills are copied (not symlinked)."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        config = ProjectConfig()
+        # get_wade_repo_root returns a different path — not self-init
+        with patch(
+            "wade.skills.installer.get_wade_repo_root",
+            return_value=tmp_path / "some-other-path",
+        ):
+            bootstrap_worktree(worktree, config, repo_root)
+
+        # Skills should be regular files, not symlinks
+        task_skill = worktree / ".claude" / "skills" / "task"
+        assert not task_skill.is_symlink()
+
 
 class TestBuildWorkPrompt:
     def test_includes_issue_info(self) -> None:


### PR DESCRIPTION
Closes #55

<!-- wade:plan:start -->

When developing wade itself, bootstrap_worktree hardcodes is_self_init=False so worktree skills are copies instead of symlinks. Detect self-init and use symlinks so template edits are immediately reflected.

<!-- wade:plan:end -->

## Summary

## What was done
Made `bootstrap_worktree` self-init aware so that when developing wade itself, worktree skills are installed as symlinks to the worktree's own `templates/` directory instead of copies.

## Changes
- Added `get_wade_repo_root()` to `installer.py` as a shared self-init detection helper
- Added optional `templates_dir` parameter to `install_skills()` for worktree template override
- Updated `bootstrap_worktree` in `work_service.py` to detect self-init and pass worktree templates with symlink mode
- DRY'd up `init_service.py` to delegate to the shared `get_wade_repo_root()`
- Added 2 new tests: self-init creates symlinks, non-self-init creates copies

## Testing
- All 40 work service tests pass (including 2 new ones)
- Full suite: 896 passed, 1 pre-existing failure unrelated to this change
- Lint + type check: all clean

## Notes for reviewers
The key insight is that worktree symlinks must point to the **worktree's own** `templates/skills/` (not the main checkout's) so that template edits within the worktree are immediately reflected in `.claude/skills/`.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

| Metric | Value |
| --- | --- |
| Tool | `copilot` |
| Model | `claude-opus-4.6` |
| Total tokens | **3,617,600** |
| Input tokens | **1,900,000** |
| Output tokens | **17,600** |
| Cached tokens | **1,700,000** |
| Premium requests (est.) | **12** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `copilot` | `7fd666d0-4aa0-4a6a-a58f-6eff32171fda` |

<!-- wade:sessions:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved repository root detection for more reliable initialization across various deployment scenarios
  * Enhanced skill installation with optimized template handling specifically for self-contained worktree environments
  * Skills now intelligently use symlinks for template management in self-owned repositories, with automatic fallback to copying in external contexts

* **Tests**
  * Expanded test coverage for worktree initialization and skill installation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->