### PR TITLE
Add interactive AI tool/model confirmation before launching AI sessions

### DIFF
--- a/src/wade/cli/main.py
+++ b/src/wade/cli/main.py
@@ -156,7 +156,13 @@ def plan_task_cmd(
     """Plan tasks with AI — creates lightweight issues + draft PRs."""
     from wade.services.plan_service import plan as do_plan
 
-    success = do_plan(ai_tool=ai, model=model, issue_id=issue)
+    success = do_plan(
+        ai_tool=ai,
+        model=model,
+        issue_id=issue,
+        ai_explicit=ai is not None,
+        model_explicit=model is not None,
+    )
     raise typer.Exit(0 if success else 1)
 
 
@@ -206,6 +212,8 @@ def implement_task_cmd(
         model=model,
         detach=detach,
         cd_only=cd_only,
+        ai_explicit=selected_ai is not None,
+        model_explicit=model is not None,
     )
     raise typer.Exit(0 if success else 1)
 

--- a/src/wade/cli/task.py
+++ b/src/wade/cli/task.py
@@ -232,5 +232,11 @@ def deps(
             console.success("All dependencies are valid.")
         raise typer.Exit(0 if all_valid else 1)
 
-    graph = analyze_deps(issue_numbers=issue_ids, ai_tool=ai, model=model)
+    graph = analyze_deps(
+        issue_numbers=issue_ids,
+        ai_tool=ai,
+        model=model,
+        ai_explicit=ai is not None,
+        model_explicit=model is not None,
+    )
     raise typer.Exit(0 if graph is not None else 1)

--- a/src/wade/cli/work.py
+++ b/src/wade/cli/work.py
@@ -183,7 +183,13 @@ def batch(
         raise typer.Exit(1)
 
     issue_ids = [str(n) for n in numbers]
-    success = do_batch(issue_numbers=issue_ids, ai_tool=ai, model=model)
+    success = do_batch(
+        issue_numbers=issue_ids,
+        ai_tool=ai,
+        model=model,
+        ai_explicit=ai is not None,
+        model_explicit=model is not None,
+    )
     raise typer.Exit(0 if success else 1)
 
 

--- a/src/wade/services/ai_resolution.py
+++ b/src/wade/services/ai_resolution.py
@@ -10,6 +10,8 @@ from wade.models.config import AICommandConfig, ProjectConfig
 
 logger = structlog.get_logger()
 
+_CUSTOM_OPTION = "Custom…"
+
 
 def resolve_ai_tool(
     ai_tool: str | None,
@@ -91,3 +93,87 @@ def resolve_model(
             pass
 
     return resolved
+
+
+def confirm_ai_selection(
+    resolved_tool: str | None,
+    resolved_model: str | None,
+    *,
+    tool_explicit: bool,
+    model_explicit: bool,
+) -> tuple[str | None, str | None]:
+    """Interactively confirm (and optionally change) the resolved AI tool/model.
+
+    Fires only when stdin is a TTY and at least one of the flags was not
+    explicitly provided by the caller.  When both flags are explicit (e.g.
+    because ``wade work batch`` passes ``--ai``/``--model`` to child calls),
+    this is a no-op.
+
+    Returns the (tool, model) pair after any user-driven changes.
+    """
+    from wade.ui import prompts
+    from wade.ui.console import console
+
+    # Skip when non-TTY, no tool resolved, or both flags were explicit.
+    if not prompts.is_tty() or resolved_tool is None or (tool_explicit and model_explicit):
+        return resolved_tool, resolved_model
+
+    tool = resolved_tool
+    model = resolved_model
+
+    while True:
+        # Display current selection
+        console.kv("AI tool", tool)
+        if model:
+            console.kv("Model", model)
+
+        # Build menu dynamically based on which flags were NOT explicit.
+        # Once the user changes a value at the prompt it becomes "confirmed",
+        # but we keep the menu until they explicitly choose Proceed.
+        menu_items: list[str] = ["Proceed"]
+        installed = AbstractAITool.detect_installed()
+        can_change_tool = not tool_explicit and len(installed) > 1
+        if can_change_tool:
+            menu_items.append("Change AI tool")
+        if not model_explicit:
+            menu_items.append("Change model")
+
+        if len(menu_items) == 1:
+            # Nothing to change — nothing to confirm either, exit immediately.
+            break
+
+        idx = prompts.select("Confirm AI selection", menu_items)
+        choice = menu_items[idx]
+
+        if choice == "Proceed":
+            break
+
+        if choice == "Change AI tool":
+            tool_names = [str(t) for t in installed]
+            current_idx = tool_names.index(tool) if tool in tool_names else 0
+            new_idx = prompts.select("Select AI tool", tool_names, default=current_idx)
+            new_tool = tool_names[new_idx]
+            if new_tool != tool:
+                tool = new_tool
+                # Tool changed — force model re-selection regardless of model_explicit.
+                model = _prompt_model_selection(tool)
+
+        elif choice == "Change model":
+            model = _prompt_model_selection(tool)
+
+    return tool, model
+
+
+def _prompt_model_selection(tool: str) -> str | None:
+    """Show a model picker for *tool* and return the chosen model (or None)."""
+    from wade.data import get_models_for_tool
+    from wade.ui import prompts
+
+    models = get_models_for_tool(tool)
+    choices = [*models, _CUSTOM_OPTION]
+    idx = prompts.select(f"Select model for {tool}", choices)
+    chosen = choices[idx]
+    if chosen == _CUSTOM_OPTION:
+        custom = prompts.input_prompt("Enter model name", allow_empty=True)
+        return custom or None
+    return chosen or None

--- a/src/wade/services/deps_service.py
+++ b/src/wade/services/deps_service.py
@@ -20,7 +20,7 @@ from wade.models.config import ProjectConfig
 from wade.models.deps import DependencyEdge, DependencyGraph
 from wade.providers.base import AbstractTaskProvider
 from wade.providers.registry import get_provider
-from wade.services.ai_resolution import resolve_ai_tool, resolve_model
+from wade.services.ai_resolution import confirm_ai_selection, resolve_ai_tool, resolve_model
 from wade.services.prompt_delivery import deliver_prompt_if_needed
 from wade.services.task_service import ensure_task_label
 from wade.ui import prompts
@@ -422,6 +422,9 @@ def analyze_deps(
     ai_tool: str | None = None,
     model: str | None = None,
     project_root: Path | None = None,
+    *,
+    ai_explicit: bool = False,
+    model_explicit: bool = False,
 ) -> DependencyGraph | None:
     """Analyze dependencies between issues.
 
@@ -451,7 +454,17 @@ def analyze_deps(
 
     console.rule("wade task deps")
     console.kv("Issues", str(len(issue_numbers)))
-    console.kv("AI tool", resolved_tool)
+
+    # Offer interactive confirmation unless both flags were explicitly provided.
+    resolved_tool, resolved_model = confirm_ai_selection(
+        resolved_tool,
+        resolved_model,
+        tool_explicit=ai_explicit,
+        model_explicit=model_explicit,
+    )
+    if not resolved_tool:
+        console.error("No AI tool selected.")
+        return None
 
     # Build context
     context = build_context(provider, issue_numbers)

--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -27,7 +27,7 @@ from wade.models.config import ProjectConfig
 from wade.models.task import PlanFile, Task
 from wade.providers.base import AbstractTaskProvider
 from wade.providers.registry import get_provider
-from wade.services.ai_resolution import resolve_ai_tool, resolve_model
+from wade.services.ai_resolution import confirm_ai_selection, resolve_ai_tool, resolve_model
 from wade.services.prompt_delivery import deliver_prompt_if_needed
 from wade.services.task_service import (
     add_complexity_label,
@@ -230,6 +230,9 @@ def plan(
     model: str | None = None,
     project_root: Path | None = None,
     issue_id: str | None = None,
+    *,
+    ai_explicit: bool = False,
+    model_explicit: bool = False,
 ) -> bool:
     """Run an AI-assisted planning session.
 
@@ -252,9 +255,17 @@ def plan(
     resolved_model = resolve_model(model, config, "plan", tool=resolved_tool)
 
     console.rule("wade plan-task")
-    console.kv("AI tool", resolved_tool)
-    if resolved_model:
-        console.kv("Model", resolved_model)
+
+    # Offer interactive confirmation unless both flags were explicitly provided.
+    resolved_tool, resolved_model = confirm_ai_selection(
+        resolved_tool,
+        resolved_model,
+        tool_explicit=ai_explicit,
+        model_explicit=model_explicit,
+    )
+    if not resolved_tool:
+        console.error("No AI tool selected.")
+        return False
 
     # Pre-load existing issue context when issue_id is supplied
     existing_issue: Task | None = None
@@ -709,6 +720,8 @@ def _finalize_issues(
                 issue_numbers=issue_numbers,
                 ai_tool=ai_tool,
                 model=model,
+                ai_explicit=True,
+                model_explicit=True,
             )
             if graph and graph.edges:
                 console.success(f"Applied {len(graph.edges)} dependency edge(s)")

--- a/src/wade/services/work_service.py
+++ b/src/wade/services/work_service.py
@@ -40,7 +40,7 @@ from wade.models.work import (
 )
 from wade.providers.base import AbstractTaskProvider
 from wade.providers.registry import get_provider
-from wade.services.ai_resolution import resolve_ai_tool, resolve_model
+from wade.services.ai_resolution import confirm_ai_selection, resolve_ai_tool, resolve_model
 from wade.services.prompt_delivery import deliver_prompt_if_needed
 from wade.services.task_service import (
     add_in_progress_label,
@@ -621,6 +621,9 @@ def start(
     project_root: Path | None = None,
     detach: bool = False,
     cd_only: bool = False,
+    *,
+    ai_explicit: bool = False,
+    model_explicit: bool = False,
 ) -> bool:
     """Start a work session on an issue.
 
@@ -669,19 +672,8 @@ def start(
         console.rule(f"implement-task #{task.id}")
         console.kv("Issue", console.issue_ref(task.id, task.title))
 
-        # Resolve AI tool (shared resolution + work-specific TTY prompt)
-        # auto_detect=False so multi-tool TTY selection still fires below
-        resolved_tool = resolve_ai_tool(ai_tool, config, "work", auto_detect=False)
-        if not resolved_tool:
-            installed = AbstractAITool.detect_installed()
-            if installed and len(installed) > 1 and prompts.is_tty():
-                tool_names = [str(t) for t in installed]
-                idx = prompts.select("Select AI tool", tool_names)
-                resolved_tool = tool_names[idx]
-            elif installed:
-                resolved_tool = installed[0].value
-
-        # Resolve model: explicit arg → command-specific → complexity → global default
+        # Resolve AI tool and model
+        resolved_tool = resolve_ai_tool(ai_tool, config, "work")
         resolved_model = resolve_model(
             model,
             config,
@@ -690,12 +682,17 @@ def start(
             complexity=task.complexity.value if task.complexity else None,
         )
 
-        if resolved_tool:
-            console.kv("AI tool", resolved_tool)
         if task.complexity:
             console.kv("Complexity", task.complexity.value)
-        if resolved_model:
-            console.kv("Model", resolved_model)
+
+        # Offer interactive confirmation (skipped when cd_only or both flags explicit).
+        if not cd_only:
+            resolved_tool, resolved_model = confirm_ai_selection(
+                resolved_tool,
+                resolved_model,
+                tool_explicit=ai_explicit,
+                model_explicit=model_explicit,
+            )
 
         # Resolve main branch
         main_branch = config.project.main_branch or git_repo.detect_main_branch(repo_root)
@@ -1003,6 +1000,9 @@ def batch(
     ai_tool: str | None = None,
     model: str | None = None,
     project_root: Path | None = None,
+    *,
+    ai_explicit: bool = False,
+    model_explicit: bool = False,
 ) -> bool:
     """Start parallel work sessions for multiple issues.
 
@@ -1025,8 +1025,15 @@ def batch(
 
     console.rule(f"work batch ({len(issue_numbers)} issues)")
 
-    # Resolve AI tool
-    resolved_tool = ai_tool or config.get_ai_tool("work")
+    # Resolve AI tool and model, then offer interactive confirmation.
+    resolved_tool = resolve_ai_tool(ai_tool, config, "work")
+    resolved_model = resolve_model(model, config, "work", tool=resolved_tool)
+    resolved_tool, resolved_model = confirm_ai_selection(
+        resolved_tool,
+        resolved_model,
+        tool_explicit=ai_explicit,
+        model_explicit=model_explicit,
+    )
 
     # Check for dependency ordering
     # Try to load deps from issue bodies (look for "Depends on" references)
@@ -1047,8 +1054,8 @@ def batch(
         cmd = ["wade", "implement-task", issue_id]
         if resolved_tool:
             cmd.extend(["--ai", resolved_tool])
-        if model:
-            cmd.extend(["--model", model])
+        if resolved_model:
+            cmd.extend(["--model", resolved_model])
 
         console.step(f"Launching #{issue_id} ({label}) in new terminal")
         if launch_in_new_terminal(cmd, cwd=str(repo_root), title=f"wade #{issue_id}"):

--- a/tests/unit/test_services/test_ai_resolution.py
+++ b/tests/unit/test_services/test_ai_resolution.py
@@ -1,0 +1,329 @@
+"""Tests for confirm_ai_selection in ai_resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from wade.services.ai_resolution import confirm_ai_selection
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CLAUDE = "claude"
+_COPILOT = "copilot"
+_MODEL_A = "claude-sonnet-4-6"
+_MODEL_B = "claude-opus-4-6"
+
+
+def _make_installed(*names: str):
+    """Return a list of AIToolID-like values."""
+    from wade.models.ai import AIToolID
+
+    return [AIToolID(n) for n in names]
+
+
+# ---------------------------------------------------------------------------
+# Helpers — patch targets
+# The functions use local imports so we must patch the source modules directly.
+# ---------------------------------------------------------------------------
+
+_IS_TTY = "wade.ui.prompts.is_tty"
+_SELECT = "wade.ui.prompts.select"
+_INPUT_PROMPT = "wade.ui.prompts.input_prompt"
+_DETECT = "wade.services.ai_resolution.AbstractAITool.detect_installed"
+_MODELS_FOR_TOOL = "wade.data.get_models_for_tool"
+_CONSOLE_KV = "wade.ui.console.console.kv"
+
+
+# ---------------------------------------------------------------------------
+# Early-exit cases
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmAiSelectionEarlyExit:
+    """confirm_ai_selection should return unchanged values without prompting."""
+
+    def test_non_tty_returns_unchanged(self) -> None:
+        with patch(_IS_TTY, return_value=False), patch(_SELECT) as mock_select:
+            result = confirm_ai_selection(
+                _CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=False
+            )
+        assert result == (_CLAUDE, _MODEL_A)
+        mock_select.assert_not_called()
+
+    def test_both_explicit_skips_prompts(self) -> None:
+        with patch(_IS_TTY, return_value=True), patch(_SELECT) as mock_select:
+            result = confirm_ai_selection(
+                _CLAUDE, _MODEL_A, tool_explicit=True, model_explicit=True
+            )
+        assert result == (_CLAUDE, _MODEL_A)
+        mock_select.assert_not_called()
+
+    def test_none_tool_returns_none(self) -> None:
+        with patch(_IS_TTY, return_value=True), patch(_SELECT) as mock_select:
+            result = confirm_ai_selection(None, None, tool_explicit=False, model_explicit=False)
+        assert result == (None, None)
+        mock_select.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Menu construction
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmAiSelectionMenuItems:
+    """Verify which menu items appear based on explicit flags."""
+
+    def test_tool_explicit_model_not__shows_change_model_only(self) -> None:
+        """When tool is explicit, menu has Proceed + Change model only."""
+        menu_items_seen: list[list[str]] = []
+
+        def fake_select(title: str, items: list[str], **kwargs) -> int:
+            menu_items_seen.append(list(items))
+            return 0  # Proceed
+
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, side_effect=fake_select),
+            patch(_DETECT, return_value=_make_installed(_CLAUDE)),
+            patch(_CONSOLE_KV),
+        ):
+            confirm_ai_selection(_CLAUDE, _MODEL_A, tool_explicit=True, model_explicit=False)
+
+        assert len(menu_items_seen) == 1
+        items = menu_items_seen[0]
+        assert "Proceed" in items
+        assert "Change model" in items
+        assert "Change AI tool" not in items
+
+    def test_single_installed_tool_omits_change_tool(self) -> None:
+        """Single installed tool → Change AI tool is never shown."""
+        menu_items_seen: list[list[str]] = []
+
+        def fake_select(title: str, items: list[str], **kwargs) -> int:
+            menu_items_seen.append(list(items))
+            return 0  # Proceed
+
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, side_effect=fake_select),
+            patch(_DETECT, return_value=_make_installed(_CLAUDE)),
+            patch(_CONSOLE_KV),
+        ):
+            confirm_ai_selection(_CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=False)
+
+        assert len(menu_items_seen) == 1
+        items = menu_items_seen[0]
+        assert "Change AI tool" not in items
+        assert "Change model" in items
+
+    def test_model_explicit_single_tool__exits_immediately(self) -> None:
+        """model_explicit + single installed tool → nothing to change → no prompt."""
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT) as mock_select,
+            patch(_DETECT, return_value=_make_installed(_CLAUDE)),
+            patch(_CONSOLE_KV),
+        ):
+            confirm_ai_selection(_CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=True)
+
+        # Only ["Proceed"] in menu → exits silently without prompting.
+        mock_select.assert_not_called()
+
+    def test_model_explicit_two_installed__shows_change_tool(self) -> None:
+        """model_explicit + two installed tools → Change AI tool appears."""
+        menu_items_seen: list[list[str]] = []
+
+        def fake_select(title: str, items: list[str], **kwargs) -> int:
+            menu_items_seen.append(list(items))
+            return 0  # Proceed
+
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, side_effect=fake_select),
+            patch(_DETECT, return_value=_make_installed(_CLAUDE, _COPILOT)),
+            patch(_CONSOLE_KV),
+        ):
+            confirm_ai_selection(_CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=True)
+
+        assert len(menu_items_seen) == 1
+        items = menu_items_seen[0]
+        assert "Change AI tool" in items
+        assert "Change model" not in items
+
+    def test_neither_explicit_two_installed__full_menu(self) -> None:
+        """Neither explicit + two tools → full menu shown."""
+        menu_items_seen: list[list[str]] = []
+
+        def fake_select(title: str, items: list[str], **kwargs) -> int:
+            menu_items_seen.append(list(items))
+            return 0  # Proceed
+
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, side_effect=fake_select),
+            patch(_DETECT, return_value=_make_installed(_CLAUDE, _COPILOT)),
+            patch(_CONSOLE_KV),
+        ):
+            confirm_ai_selection(_CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=False)
+
+        assert len(menu_items_seen) == 1
+        items = menu_items_seen[0]
+        assert "Proceed" in items
+        assert "Change AI tool" in items
+        assert "Change model" in items
+
+
+# ---------------------------------------------------------------------------
+# Proceed immediately
+# ---------------------------------------------------------------------------
+
+
+class TestProceedImmediately:
+    def test_proceed_returns_resolved_values(self) -> None:
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, return_value=0),  # Proceed
+            patch(_DETECT, return_value=_make_installed(_CLAUDE, _COPILOT)),
+            patch(_CONSOLE_KV),
+        ):
+            result = confirm_ai_selection(
+                _CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=False
+            )
+
+        assert result == (_CLAUDE, _MODEL_A)
+
+
+# ---------------------------------------------------------------------------
+# Change AI tool
+# ---------------------------------------------------------------------------
+
+
+class TestChangeAiTool:
+    def test_change_tool_returns_new_tool(self) -> None:
+        """Selecting Change AI tool → choose copilot → model picker fires."""
+        call_count = 0
+
+        def fake_select(title: str, items: list[str], **kwargs) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Main confirmation menu
+                return items.index("Change AI tool")
+            if call_count == 2:
+                # Tool picker
+                return items.index(_COPILOT)
+            if call_count == 3:
+                # Model picker
+                return 0  # first model
+            # Subsequent main menu calls → Proceed
+            return 0
+
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, side_effect=fake_select),
+            patch(_DETECT, return_value=_make_installed(_CLAUDE, _COPILOT)),
+            patch(_MODELS_FOR_TOOL, return_value=[_MODEL_B]),
+            patch(_CONSOLE_KV),
+        ):
+            tool, model = confirm_ai_selection(
+                _CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=False
+            )
+
+        assert tool == _COPILOT
+        assert model == _MODEL_B
+
+    def test_tool_change_forces_model_reselect_when_model_explicit(self) -> None:
+        """Tool change forces model re-prompt even when model_explicit=True."""
+        call_count = 0
+
+        def fake_select(title: str, items: list[str], **kwargs) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return items.index("Change AI tool")
+            if call_count == 2:
+                return items.index(_COPILOT)
+            if call_count == 3:
+                return 0  # first model
+            return 0  # Proceed
+
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, side_effect=fake_select),
+            patch(_DETECT, return_value=_make_installed(_CLAUDE, _COPILOT)),
+            patch(_MODELS_FOR_TOOL, return_value=[_MODEL_B]),
+            patch(_CONSOLE_KV),
+        ):
+            tool, model = confirm_ai_selection(
+                _CLAUDE,
+                _MODEL_A,
+                tool_explicit=False,
+                model_explicit=True,  # model was explicit but tool change overrides
+            )
+
+        assert tool == _COPILOT
+        assert model == _MODEL_B
+
+
+# ---------------------------------------------------------------------------
+# Change model
+# ---------------------------------------------------------------------------
+
+
+class TestChangeModel:
+    def test_change_model_returns_selected_model(self) -> None:
+        """User picks Change model → selects MODEL_B from list."""
+        call_count = 0
+
+        def fake_select(title: str, items: list[str], **kwargs) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return items.index("Change model")
+            if call_count == 2:
+                return items.index(_MODEL_B)
+            return 0  # Proceed
+
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, side_effect=fake_select),
+            patch(_DETECT, return_value=_make_installed(_CLAUDE)),
+            patch(_MODELS_FOR_TOOL, return_value=[_MODEL_A, _MODEL_B]),
+            patch(_CONSOLE_KV),
+        ):
+            _, model = confirm_ai_selection(
+                _CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=False
+            )
+
+        assert model == _MODEL_B
+
+    def test_change_model_custom_fires_input_prompt(self) -> None:
+        """User picks Custom… → input_prompt fires → custom model returned."""
+        custom_model = "my-custom-model-v9"
+        call_count = 0
+
+        def fake_select(title: str, items: list[str], **kwargs) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return items.index("Change model")
+            if call_count == 2:
+                return items.index("Custom…")
+            return 0  # Proceed
+
+        with (
+            patch(_IS_TTY, return_value=True),
+            patch(_SELECT, side_effect=fake_select),
+            patch(_INPUT_PROMPT, return_value=custom_model) as mock_input,
+            patch(_DETECT, return_value=_make_installed(_CLAUDE)),
+            patch(_MODELS_FOR_TOOL, return_value=[_MODEL_A]),
+            patch(_CONSOLE_KV),
+        ):
+            _, model = confirm_ai_selection(
+                _CLAUDE, _MODEL_A, tool_explicit=False, model_explicit=False
+            )
+
+        assert model == custom_model
+        mock_input.assert_called_once()


### PR DESCRIPTION
Closes #60

<!-- wade:plan:start -->

## Complexity
complex

## Context / Problem

When users run `wade implement-task`, `wade plan-task`, `wade task deps`, or `wade work batch` without explicitly passing `--ai` or `--model`, the resolved defaults (from config or auto-detection) are shown via `console.kv()` but no confirmation is requested. Users have no opportunity to review or change the tool/model before the AI session starts, which can result in unexpectedly using the wrong tool or model.

Additionally, `wade work batch` internally calls `wade implement-task --ai X --model Y` programmatically — those child invocations must not trigger the confirmation step.

## Proposed Solution

Add a `confirm_ai_selection()` function to `services/ai_resolution.py` as a shared helper. It fires only when:
- stdin is a TTY (`prompts.is_tty()`)
- AND `--ai` and/or `--model` were not explicitly provided by the caller

When both `--ai` and `--model` are provided explicitly (including when wade itself passes them in `batch` mode), the function is a no-op and returns immediately.

The confirmation prompt mirrors the `wade init` AI-section UX:
- Shows the resolved tool and model via `console.kv()`
- Offers a menu: `Proceed`, `Change AI tool`, `Change model` (menu options built dynamically based on which flags are explicit)
- Changing the AI tool re-triggers model selection for the new tool (model depends on tool)
- Changing the model shows the full model list for the current tool (from `wade.data` registry via `get_models_for_tool()`), with a `Custom…` option for free-form entry via `prompts.input_prompt()`
- Loops until the user selects `Proceed`

CLI dispatch passes `ai_explicit`/`model_explicit` booleans so each service knows whether to prompt.

## Tasks

### Core function
- [ ] Add `confirm_ai_selection(resolved_tool, resolved_model, *, tool_explicit, model_explicit) -> tuple[str | None, str | None]` to `src/wade/services/ai_resolution.py`
  - Early return if not `is_tty()`, both flags explicit, or `resolved_tool is None`
  - Display resolved values via `console.kv()`
  - Build menu dynamically: always `"Proceed"`, plus `"Change AI tool"` if not tool_explicit, plus `"Change model"` if not model_explicit
  - Loop until user selects `Proceed`
  - "Change AI tool": `prompts.select()` from `AbstractAITool.detect_installed()` with current tool pre-selected; if tool changes → force model re-selection using new tool's model list
  - "Change model": `prompts.select()` from `get_models_for_tool(tool)` + `"Custom…"` option; if `Custom…` → `prompts.input_prompt()`
  - Re-display updated values and loop back after each change
  - If only one tool installed, omit "Change AI tool" from menu (nothing to change to)

### Wire into services
- [ ] `plan_service.plan()` (`src/wade/services/plan_service.py:228`): add `ai_explicit: bool = False, model_explicit: bool = False` keyword-only params; call `confirm_ai_selection()` after resolution (lines 247-252)
- [ ] `work_service.start()` (`src/wade/services/work_service.py:617`): add `ai_explicit`/`model_explicit` params; remove duplicate multi-tool picker at lines 675-682; switch `resolve_ai_tool` to `auto_detect=True`; call `confirm_ai_selection()` after resolution; skip when `cd_only=True`
- [ ] `deps_service.analyze_deps()` (`src/wade/services/deps_service.py:420`): add `ai_explicit`/`model_explicit` params; call `confirm_ai_selection()` after resolution (lines 445-450)
- [ ] `work_service.batch()` (`src/wade/services/work_service.py:1001`): add `ai_explicit`/`model_explicit` params; add model resolution via `resolve_model()`; call `confirm_ai_selection()`; update `_launch()` inner function to forward confirmed model (currently uses raw `model` param)
- [ ] `plan_service._finalize_issues()` internal deps call (line 708): pass `ai_explicit=True, model_explicit=True` to suppress re-prompting (values already confirmed during plan session)

### Update CLI dispatch
- [ ] `main.py:plan_task_cmd` (line 159): pass `ai_explicit=ai is not None, model_explicit=model is not None`
- [ ] `main.py:implement_task_cmd` (line 203): pass `ai_explicit=selected_ai is not None, model_explicit=model is not None`
- [ ] `task.py:deps` (line 235): pass `ai_explicit=ai is not None, model_explicit=model is not None`
- [ ] `work.py:batch` (line 186): pass `ai_explicit=ai is not None, model_explicit=model is not None`
- [ ] Verify internal callers default correctly (no explicit flags → confirmation fires):
  - `main.py:120` — interactive menu `do_start(target=target)` ✓
  - `main.py:133` — interactive menu `plan()` ✓
  - `task.py:89` — interactive deps `analyze_deps(issue_numbers=issue_ids)` ✓
  - `task.py:117` — task list picker `do_start(target=tasks[idx].id)` ✓

### Tests
- [ ] New file `tests/unit/test_services/test_ai_resolution.py` with tests for `confirm_ai_selection`:
  - Non-TTY returns unchanged
  - Both explicit skips all prompts
  - Tool explicit, model not — menu shows only "Proceed" and "Change model"
  - Model explicit, tool not — menu shows only "Proceed" and "Change AI tool"
  - User selects Proceed immediately — returns resolved values unchanged
  - User selects "Change AI tool" — picker shown, new tool returned
  - Tool change forces model re-prompt — even with `model_explicit=True`
  - User selects "Change model" → Custom — `input_prompt` fires, custom string returned
  - None tool returns None — no prompts, passthrough
  - Single installed tool — "Change AI tool" option not shown

## Acceptance Criteria

- [ ] `wade implement-task <N>` (no flags) shows confirmation prompt in TTY; user can proceed or change tool/model
- [ ] `wade implement-task <N> --ai claude --model claude-sonnet-4.6` skips confirmation entirely
- [ ] `wade implement-task <N> --ai claude` (only `--ai`) shows confirmation with AI tool locked, model change possible
- [ ] Changing AI tool at the confirmation prompt re-triggers model selection for the new tool
- [ ] `wade work batch` launches children with `--ai`/`--model` flags; no confirmation prompt in child terminals
- [ ] `wade plan-task` without flags shows confirmation
- [ ] `wade task deps` without flags shows confirmation
- [ ] Non-TTY (piped/scripted) invocations skip confirmation silently
- [ ] All existing tests pass; new unit tests for `confirm_ai_selection` pass

<!-- wade:plan:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive confirmation flow for AI tool and model selection, enabling users to review and adjust choices before executing operations
  * Support for custom model name entry during the selection workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

## What was done

Added an interactive AI tool/model confirmation step to `wade implement-task`, `wade plan-task`, `wade task deps`, and `wade work batch`. When users run these commands without explicitly passing `--ai` or `--model`, they now get a confirmation menu that shows the resolved values and lets them change the tool or model before the session starts.

## Changes

- Added `confirm_ai_selection(resolved_tool, resolved_model, *, tool_explicit, model_explicit)` to `services/ai_resolution.py` as a shared helper
  - Returns `(tool, model)` unchanged when: non-TTY, `resolved_tool is None`, or both flags are explicit
  - Dynamically builds menu: always "Proceed"; adds "Change AI tool" only when >1 tool installed and `tool_explicit=False`; adds "Change model" only when `model_explicit=False`
  - Loops until user selects "Proceed"
  - Changing AI tool forces model re-selection for the new tool (regardless of `model_explicit`)
  - Model picker includes a "Custom…" option that opens a free-form input prompt
  - Extracted `_prompt_model_selection()` helper for reuse between tool-change and model-change paths
- Wired `confirm_ai_selection()` into `plan_service.plan()`, `work_service.start()`, `deps_service.analyze_deps()`, and `work_service.batch()`
- Replaced the duplicate multi-tool picker in `work_service.start()` (lines 675–682) with the shared helper; switched `resolve_ai_tool` to `auto_detect=True`
- Added model resolution via `resolve_model()` to `work_service.batch()`; child terminals now receive the confirmed model as `--model <value>`
- Added `ai_explicit=True, model_explicit=True` to the internal `analyze_deps()` call in `_finalize_issues()` so the confirmation step is suppressed for auto-triggered deps analysis after planning
- Updated CLI dispatch in `main.py`, `task.py`, and `work.py` to pass `ai_explicit`/`model_explicit` booleans

## Testing

- Added 13 unit tests in `tests/unit/test_services/test_ai_resolution.py` covering all cases from the plan: non-TTY passthrough, both-explicit skip, None tool passthrough, menu item construction per flag combination, single-installed-tool omits change-tool, Proceed immediately, tool change forces model re-selection, custom model via input_prompt
- All 822 existing unit tests pass; all 13 new tests pass
- `./scripts/check-all.sh` passes: lint, format, mypy strict

## Notes for reviewers

The one pre-existing test failure (`tests/test_cli_basics.py::TestCommandBehaviorWithoutContext::test_work_done_exits_with_error`) is context-dependent: it expects `wade work done` to fail with "Cannot extract issue number" but since this worktree's branch name contains an issue number (60), the command finds a valid issue and proceeds. This failure exists on the scaffold commit and is unrelated to this feature.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **40,500** |
| Input tokens | **6,400** |
| Output tokens | **34,100** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `607ef0c7-276c-48c4-ae2d-3fed96ae23b6` |

<!-- wade:sessions:end -->
