### PR TITLE
Add option to open PR and/or issue

### DIFF
--- a/src/wade/services/work_service.py
+++ b/src/wade/services/work_service.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+import webbrowser
 from pathlib import Path
 from typing import Any
 
@@ -522,6 +523,10 @@ def _post_work_lifecycle_pr(
     if not pr_number:
         console.warn(f"Could not determine PR number for branch '{branch}'.")
         return
+
+    pr_url = str(pr_info.get("url", ""))
+    if pr_url and prompts.confirm("Open PR in browser?", default=True):
+        webbrowser.open(pr_url)
 
     if not prompts.confirm(f"Do you want to merge PR #{pr_number}?", default=True):
         return
@@ -1967,6 +1972,9 @@ def _done_via_pr(
     lines.append(f"  PR      [url]{pr_url}[/]")
     lines.append(f"  Issue   {console.issue_ref(issue_number, task.title)}")
     console.panel("\n".join(lines), title="Work done")
+
+    if pr_url and prompts.confirm("Open PR in browser?", default=True):
+        webbrowser.open(pr_url)
 
     return True
 

--- a/tests/unit/test_services/test_post_work_lifecycle.py
+++ b/tests/unit/test_services/test_post_work_lifecycle.py
@@ -31,12 +31,14 @@ def _config(strategy: MergeStrategy) -> ProjectConfig:
 @patch("wade.services.work_service.git_pr.merge_pr")
 @patch("wade.services.work_service.git_repo.is_clean", return_value=True)
 @patch("wade.services.work_service.prompts.confirm", return_value=True)
+@patch("wade.services.work_service.webbrowser.open")
 @patch(
     "wade.services.work_service.git_pr.get_pr_for_branch",
     return_value={"number": 99, "url": "https://example/pr/99"},
 )
 def test_pr_strategy_prompts_merge_on_existing_pr(
     _mock_get_pr: MagicMock,
+    _mock_webbrowser_open: MagicMock,
     mock_confirm: MagicMock,
     _mock_is_clean: MagicMock,
     mock_merge_pr: MagicMock,
@@ -110,19 +112,22 @@ def test_pr_strategy_user_declines_merge(
         provider,
     )
 
-    mock_confirm.assert_called_once()
+    # confirm is called twice: once for "Open PR in browser?" and once for merge
+    assert mock_confirm.call_count == 2
     mock_merge_pr.assert_not_called()
 
 
 @patch(_CHECKOUT)
 @patch("wade.services.work_service.git_pr.merge_pr")
 @patch("wade.services.work_service.prompts.confirm", return_value=True)
+@patch("wade.services.work_service.webbrowser.open")
 @patch(
     "wade.services.work_service.git_pr.get_pr_for_branch",
     return_value={"number": 99, "url": "https://example/pr/99"},
 )
 def test_pr_strategy_merge_failure_preserves_branch(
     _mock_get_pr: MagicMock,
+    _mock_webbrowser_open: MagicMock,
     _mock_confirm: MagicMock,
     mock_merge_pr: MagicMock,
     _mock_checkout: MagicMock,
@@ -149,12 +154,14 @@ def test_pr_strategy_merge_failure_preserves_branch(
 @patch("wade.services.work_service.git_pr.merge_pr")
 @patch("wade.services.work_service.git_repo.is_clean", return_value=True)
 @patch("wade.services.work_service.prompts.confirm", return_value=True)
+@patch("wade.services.work_service.webbrowser.open")
 @patch(
     "wade.services.work_service.git_pr.get_pr_for_branch",
     return_value={"number": 99, "url": "https://example/pr/99"},
 )
 def test_pr_strategy_merge_failure_restores_branch(
     _mock_get_pr: MagicMock,
+    _mock_webbrowser_open: MagicMock,
     _mock_confirm: MagicMock,
     _mock_is_clean: MagicMock,
     mock_merge_pr: MagicMock,
@@ -188,12 +195,14 @@ def test_pr_strategy_merge_failure_restores_branch(
 @patch("wade.services.work_service.git_pr.merge_pr")
 @patch("wade.services.work_service.git_repo.is_clean", return_value=True)
 @patch("wade.services.work_service.prompts.confirm", return_value=True)
+@patch("wade.services.work_service.webbrowser.open")
 @patch(
     "wade.services.work_service.git_pr.get_pr_for_branch",
     return_value={"number": 99, "url": "https://example/pr/99"},
 )
 def test_pr_strategy_cleanup_and_pull_after_merge(
     _mock_get_pr: MagicMock,
+    _mock_webbrowser_open: MagicMock,
     _mock_confirm: MagicMock,
     _mock_is_clean: MagicMock,
     _mock_merge_pr: MagicMock,


### PR DESCRIPTION
Closes #62

<!-- wade:plan:start -->

When the PR is ready after a work-session or plan-session, ask if the user wants to open the PR on the browser. Default is yes. This should come before the ask if the user wants to merge the PR.

<!-- wade:plan:end -->

## Summary

## What was done

After a work session completes (via `wade work done`) and after the AI session ends before the merge prompt, the user is now asked whether they want to open the PR in their browser. The default is yes. This makes it easy to review the PR immediately after it's ready, and it appears before the merge confirmation so the user can inspect the PR before deciding to merge.

## Changes

- Added `import webbrowser` to `work_service.py`
- Added "Open PR in browser?" prompt (default: yes) in `_done_via_pr()` after the "Work done" panel — triggered when `wade work done` finalizes the PR
- Added the same prompt in `_post_work_lifecycle_pr()` before the merge confirmation — triggered when the interactive work session ends
- Updated `test_post_work_lifecycle.py`: mocked `webbrowser.open` in tests where `confirm` returns `True` to avoid actually opening a browser, and updated the call count assertion in `test_pr_strategy_user_declines_merge` to reflect the two confirm calls

## Testing

- All 822 unit tests pass
- Lint and type checks pass
- Manually verified the prompt appears in the correct sequence

## Notes for reviewers

The feature uses Python's standard `webbrowser` module (no new dependency). The prompt is guarded by `if pr_url and ...` so it's a no-op if no URL is available.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **18,800** |
| Input tokens | **1,500** |
| Output tokens | **17,300** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `ebf2915e-db2d-4213-a056-feae65a23cc5` |

<!-- wade:sessions:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now optionally open pull requests in their browser immediately after creation.

* **Tests**
  * Updated test coverage to reflect the new browser functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->