### PR TITLE
Set terminal tab title during plan sessions

### DIFF
--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -40,6 +40,12 @@ from wade.ui import prompts
 from wade.ui.console import console
 from wade.utils.markdown import append_session_to_body
 from wade.utils.process import run_with_transcript
+from wade.utils.terminal import (
+    compose_plan_title,
+    set_terminal_title,
+    start_title_keeper,
+    stop_title_keeper,
+)
 
 logger = structlog.get_logger()
 
@@ -276,6 +282,14 @@ def plan(
             console.error(f"Could not fetch issue #{issue_id}: {e}")
             return False
 
+    # Set terminal title for the plan session
+    plan_title = compose_plan_title(
+        existing_issue.id if existing_issue else None,
+        existing_issue.title if existing_issue else None,
+    )
+    set_terminal_title(plan_title)
+    start_title_keeper(plan_title)
+
     # Resolve repo root for draft PR creation
     from wade.git import repo as git_repo
 
@@ -321,6 +335,7 @@ def plan(
         if not prompts.confirm("Have you finished the session?", default=True):
             console.info("Plan directory preserved — review output manually.")
             console.hint(f"Plan dir: {plan_dir}")
+            stop_title_keeper()
             return False
 
     # Post-session: extract token usage (skip for non-blocking tools)
@@ -352,9 +367,11 @@ def plan(
                 repo_root=repo_root,
             )
             _cleanup_plan_dir(plan_dir)
+            stop_title_keeper()
             return True
         console.warn("No plan files found — the AI session may not have produced output.")
         _cleanup_plan_dir(plan_dir)
+        stop_title_keeper()
         return False
 
     # Read plan files from temp dir and create issues
@@ -379,6 +396,7 @@ def plan(
                 repo_root=repo_root,
             )
             _cleanup_plan_dir(plan_dir)
+            stop_title_keeper()
             return True
         console.warn("No issues were created from plan files.")
     else:
@@ -386,6 +404,7 @@ def plan(
         console.hint("The AI session may not have produced any output.")
 
     _cleanup_plan_dir(plan_dir)
+    stop_title_keeper()
     return False
 
 

--- a/src/wade/utils/terminal.py
+++ b/src/wade/utils/terminal.py
@@ -42,6 +42,19 @@ def compose_work_title(issue_id: str, issue_title: str) -> str:
     return f"wade work #{issue_id} — {title}"
 
 
+def compose_plan_title(issue_id: str | None, issue_title: str | None) -> str:
+    """Compose a terminal title for a plan session.
+
+    Format: "wade plan #42 — Feature Name" with issue, "wade plan" without.
+    """
+    if not issue_id:
+        return "wade plan"
+    max_title = 50
+    title = issue_title or ""
+    title = title[:max_title] + "..." if len(title) > max_title else title
+    return f"wade plan #{issue_id} — {title}" if title else f"wade plan #{issue_id}"
+
+
 def start_title_keeper(title: str, interval: float = 2.0) -> None:
     """Start a background thread that re-asserts the terminal title periodically.
 

--- a/tests/unit/test_utils/test_terminal.py
+++ b/tests/unit/test_utils/test_terminal.py
@@ -1,6 +1,7 @@
 """Tests for terminal utilities."""
 
 from wade.utils.terminal import (
+    compose_plan_title,
     compose_work_title,
     start_title_keeper,
     stop_title_keeper,
@@ -22,6 +23,28 @@ class TestComposeWorkTitle:
 
     def test_short_title_not_truncated(self) -> None:
         result = compose_work_title("1", "Short")
+        assert "..." not in result
+
+
+class TestComposePlanTitle:
+    def test_with_issue(self) -> None:
+        result = compose_plan_title("42", "Add search command")
+        assert "wade plan" in result
+        assert "#42" in result
+        assert "Add search command" in result
+
+    def test_without_issue(self) -> None:
+        result = compose_plan_title(None, None)
+        assert result == "wade plan"
+
+    def test_long_title_truncated(self) -> None:
+        long_title = "A" * 100
+        result = compose_plan_title("1", long_title)
+        assert "..." in result
+        assert len(result) < 120
+
+    def test_short_title_not_truncated(self) -> None:
+        result = compose_plan_title("1", "Short")
         assert "..." not in result
 
 


### PR DESCRIPTION
Closes #69

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
When running `wade` without arguments and going through the interactive menu to plan or implement a task, the terminal tab title stays as the generic `"wade"` throughout the entire planning session. The `work_service.start()` path already sets the title properly (`"wade work #42 — Feature Name"` at `work_service.py:865-868`), but `plan_service.plan()` never sets a terminal title at all. This makes it impossible to identify which tab is running which planning session when multiple tabs are open.

## Proposed Solution
Add a `compose_plan_title()` function to `terminal.py` (mirroring `compose_work_title()`) and call it from `plan_service.plan()` with the title keeper thread, just like work sessions do.

## Tasks
- [ ] Add `compose_plan_title(issue_id: str | None, issue_title: str | None) -> str` to `src/wade/utils/terminal.py` — formats `"wade plan #42 — Title"` with issue, `"wade plan"` without
- [ ] In `src/wade/services/plan_service.py`, after AI selection is confirmed (~line 268): call `set_terminal_title()` + `start_title_keeper()` with the composed plan title
- [ ] Add `stop_title_keeper()` calls before each return after the AI session ends in `plan_service.plan()`
- [ ] Add `TestComposePlanTitle` test class to `tests/unit/test_utils/test_terminal.py` (with issue, without issue, long title truncation)

## Acceptance Criteria
- [ ] Terminal tab title shows `wade plan #<id> — <title>` during plan sessions with an issue
- [ ] Terminal tab title shows `wade plan` during plan sessions without an issue
- [ ] Title keeper reasserts the title periodically (same as work sessions)
- [ ] Title keeper stops when the plan session ends
- [ ] All existing tests still pass

<!-- wade:plan:end -->

## Summary

## What was done

Added terminal tab title support to `wade plan-task` sessions, mirroring the behavior already present in `wade work` sessions. The terminal tab now shows `wade plan #42 — Feature Name` during plan sessions with an issue, or `wade plan` without one.

## Changes

- Added `compose_plan_title(issue_id, issue_title)` to `src/wade/utils/terminal.py` — formats the plan session title following the same pattern as `compose_work_title()`
- Updated `src/wade/services/plan_service.py` to import and call `set_terminal_title()` + `start_title_keeper()` after AI selection is confirmed, and `stop_title_keeper()` before each return after the AI session ends
- Added `TestComposePlanTitle` test class to `tests/unit/test_utils/test_terminal.py` covering: with issue, without issue, long title truncation, short title no truncation

## Testing

- All 939 unit/integration tests pass
- `./scripts/check.sh` passes (ruff + mypy strict)
- New `TestComposePlanTitle` tests pass (4 cases)

## Notes for reviewers

The implementation follows the exact same pattern as `work_service.py` (lines 866–868, 895, 933, 977). The title keeper is started once after the issue context is resolved and stopped at every exit point in `plan_service.plan()` after the AI session ends.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **8,126** |
| Input tokens | **26** |
| Output tokens | **8,100** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `60f611c6-763b-4f33-99df-16fc3f31fcb6` |

<!-- wade:sessions:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal title now displays the current plan context (issue ID and title) during planning sessions.
  * Terminal title automatically reverts to its previous state when the planning session ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->