### PR TITLE
Prompt for CLI completion install during init

### DIFF
--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -718,7 +718,7 @@ def _prompt_configure_completions(non_interactive: bool) -> None:
 
     from wade.ui import prompts
 
-    if non_interactive:
+    if non_interactive or not prompts.is_tty():
         return
 
     if prompts.confirm("Install CLI autocompletion for wade?", default=True):
@@ -728,10 +728,11 @@ def _prompt_configure_completions(non_interactive: bool) -> None:
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=120,
             )
             console.success("Installed CLI autocompletion")
-        except subprocess.CalledProcessError as exc:
-            logger.warning("init.completion_failed", error=exc.stderr)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            logger.warning("init.completion_failed", error=getattr(exc, "stderr", None))
             console.warn("Could not install CLI autocompletion")
 
 


### PR DESCRIPTION
Closes #115

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
Currently, during `wade init`, the CLI asks about installing shell integration for `wade cd` and tool-specific configurations, but it does not prompt the user to install Typer's shell autocompletions. Offering to install autocompletions during the initialization flow would greatly improve the onboarding experience.

## Proposed Solution
Add a new interactive prompt in `src/wade/services/init_service.py` to ask the user if they want to install CLI autocompletions. If the user accepts, execute Typer's completion installation (e.g. by invoking `wade --install-completion` via `subprocess`).

## Tasks
- [ ] Add a `_prompt_configure_completions(non_interactive: bool)` helper function in `src/wade/services/init_service.py`.
- [ ] Display a prompt (using `prompts.confirm`) asking "Install CLI autocompletion for wade?".
- [ ] If accepted, run `subprocess.run([sys.executable, "-m", "wade", "--install-completion"], capture_output=True)` or equivalent logic to install completions. Catch and handle any errors gracefully.
- [ ] Call `_prompt_configure_completions` within the `init()` function, ideally grouped near the other shell integration prompts.

## Acceptance Criteria
- [ ] Running `wade init` interactively prompts the user to install CLI completions.
- [ ] Accepting the prompt successfully runs the completion installation logic.
- [ ] Rejecting the prompt skips the installation without errors.
- [ ] The prompt is skipped if `--non-interactive` is used.

<!-- wade:plan:end -->

## Summary

# Review Fixes for PR #116 — CLI Completion Install Prompt

## Summary

Addressed two critical robustness improvements to the CLI completion installer invoked during `wade init`:

1. **TTY detection check**: Skip the interactive prompt when stdin is not a TTY (headless/piped environments). Previously, non-TTY runs without `--non-interactive` would use the prompt's default value (`True`) and silently proceed with installation.

2. **Subprocess timeout & exception handling**: Added a 120-second timeout to the completion installer subprocess call and extended exception handling to catch both `CalledProcessError` and `TimeoutExpired`. Uses `getattr()` to safely handle the timeout exception, which doesn't have a `stderr` attribute.

## Changes

- **`src/wade/services/init_service.py`**:
  - Line 721: Added `or not prompts.is_tty()` check to return early in non-TTY environments
  - Line 731: Added `timeout=120` parameter to `subprocess.run()`
  - Line 734: Updated exception handler to catch both `CalledProcessError` and `TimeoutExpired`
  - Line 735: Used `getattr(exc, "stderr", None)` for safe attribute access

## Testing

All 1242 tests pass. No regressions detected.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `gemini` |
| Model | `gemini-3-pro-preview` |
| Total tokens | **691,370** |
| Input tokens | **172,906** |
| Output tokens | **2,663** |
| Cached tokens | **515,801** |

<!-- wade:impl-usage:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI autocompletion prompt during initialization so users can easily install shell completions for an enhanced command-line experience.
  * Prompt runs only in interactive/TTY sessions and safely skips in non-interactive contexts.
  * Installation failures are handled gracefully and do not abort the initialization flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | **5,863** |
| Input tokens | **463** |
| Output tokens | **5,400** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `gemini` | `a87b4b6e-10f0-4ad8-b34a-36f5ab297d1c` |
| Review | `claude` | `072200ad-a2ed-454a-aba6-4e433911af55` |

<!-- wade:sessions:end -->
