### PR TITLE
fix: prevent shell injection in auto-version workflow

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -15,8 +15,10 @@ jobs:
     steps:
       - name: Detect bump type
         id: detect
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          MSG="${{ github.event.head_commit.message }}"
+          MSG="$COMMIT_MSG"
           FIRST_LINE=$(echo "$MSG" | head -n 1)
 
           if echo "$MSG" | grep -q 'BREAKING CHANGE'; then


### PR DESCRIPTION
Pass commit message via environment variable instead of direct interpolation in the Detect bump type step. Direct interpolation of ${{ github.event.head_commit.message }} breaks when the commit message contains shell metacharacters (quotes, backticks, $, etc.), causing exit code 127.

https://claude.ai/code/session_01HfVit14qTjbCs8futEfe4X