### PR TITLE
fix: check all issue states when detecting duplicate tracking issues

### DIFF
--- a/src/wade/services/deps_service.py
+++ b/src/wade/services/deps_service.py
@@ -18,7 +18,6 @@ from wade.config.loader import load_config
 from wade.models.ai import AIToolID
 from wade.models.config import ProjectConfig
 from wade.models.deps import DependencyEdge, DependencyGraph
-from wade.models.task import TaskState
 from wade.providers.base import AbstractTaskProvider
 from wade.providers.registry import get_provider
 from wade.services.ai_resolution import (
@@ -256,13 +255,15 @@ def _find_existing_tracking_issue(
     label: str,
     title: str,
 ) -> str | None:
-    """Check for an existing open tracking issue with the same title.
+    """Check for an existing tracking issue with the same title (any state).
 
     Returns the issue ID if found, None otherwise.
+    Checks all states (open and closed) to prevent duplicate tracking issues
+    from being created after a previous one was closed.
     """
     try:
-        open_issues = provider.list_tasks(label=label, state=TaskState.OPEN)
-        for issue in open_issues:
+        all_issues = provider.list_tasks(label=label, state=None)
+        for issue in all_issues:
             if issue.title == title:
                 return issue.id
     except Exception:

--- a/tests/unit/test_services/test_deps_service.py
+++ b/tests/unit/test_services/test_deps_service.py
@@ -313,6 +313,17 @@ class TestFindExistingTrackingIssue:
         ]
         result = _find_existing_tracking_issue(provider, "feature-plan", "Tracking: #1, #2")
         assert result == "10"
+        provider.list_tasks.assert_called_once_with(label="feature-plan", state=None)
+
+    def test_finds_closed_tracking_issue(self) -> None:
+        """Should find tracking issues even if they are closed."""
+        provider = MagicMock()
+        provider.list_tasks.return_value = [
+            Task(id="42", title="Tracking: #1, #2", state=TaskState.CLOSED),
+        ]
+        result = _find_existing_tracking_issue(provider, "feature-plan", "Tracking: #1, #2")
+        assert result == "42"
+        provider.list_tasks.assert_called_once_with(label="feature-plan", state=None)
 
     def test_returns_none_when_no_match(self) -> None:
         provider = MagicMock()


### PR DESCRIPTION
_find_existing_tracking_issue only checked open issues, so every time
a tracking issue was closed a new duplicate would be created on the
next deps analysis run. Now queries all states (open + closed) to
prevent duplicate "Tracking: #1, #2" issues from being created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dependency tracking lookup to identify existing tracking issues regardless of state (open or closed), preventing duplicate tracking issue creation when topics are revisited or issues are reopened.

* **Tests**
  * Added test coverage verifying that tracking issues are properly detected when closed and that lookups operate regardless of issue state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->