### PR TITLE
Fix prompt mode to return raw prompt without user-facing header

### DIFF
--- a/src/wade/services/delegation_service.py
+++ b/src/wade/services/delegation_service.py
@@ -66,11 +66,10 @@ def delegate(request: DelegationRequest) -> DelegationResult:
 
 
 def _delegate_prompt(request: DelegationRequest) -> DelegationResult:
-    """Return the prompt text directly — caller copies into their AI tool."""
-    header = "Copy the prompt below into your AI tool:\n\n---\n"
+    """Return the raw prompt text directly — no user-facing wrapper."""
     return DelegationResult(
         success=True,
-        feedback=header + request.prompt,
+        feedback=request.prompt,
         mode=DelegationMode.PROMPT,
     )
 

--- a/src/wade/services/deps_service.py
+++ b/src/wade/services/deps_service.py
@@ -513,10 +513,6 @@ def analyze_deps(
     # Prompt mode: the output is the raw template text, not AI output.
     # The user must run the prompt manually and re-run with a different mode.
     if delegation_mode == DelegationMode.PROMPT:
-        console.info(
-            "Prompt mode: copy the prompt above and run it manually. "
-            "Then re-run with --mode headless or --mode interactive to parse results."
-        )
         return DependencyGraph()
 
     # Parse edges

--- a/tests/unit/test_services/test_delegation_service.py
+++ b/tests/unit/test_services/test_delegation_service.py
@@ -59,10 +59,10 @@ class TestDelegatePrompt:
         assert result.success is True
         assert "Some prompt text" in result.feedback
 
-    def test_prompt_mode_includes_copy_header(self) -> None:
+    def test_prompt_mode_returns_raw_prompt(self) -> None:
         req = DelegationRequest(mode=DelegationMode.PROMPT, prompt="My prompt")
         result = _delegate_prompt(req)
-        assert result.feedback.startswith("Copy the prompt below")
+        assert result.feedback == "My prompt"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services/test_deps_service.py
+++ b/tests/unit/test_services/test_deps_service.py
@@ -447,7 +447,7 @@ class TestAnalyzeDepsMode:
         mock_confirm.return_value = ("claude", None, None, False)
         mock_delegate.return_value = DelegationResult(
             success=True,
-            feedback="Copy the prompt below...",
+            feedback="raw prompt text",
             mode=DelegationMode.PROMPT,
         )
 


### PR DESCRIPTION
Closes #149

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
When `wade review plan` (and other delegation commands) run in prompt mode, the output includes a user-facing header `"Copy the prompt below into your AI tool:\n\n---\n"` prepended to the actual prompt. But prompt mode is typically invoked from within an AI session (e.g., a Claude Code planning session runs `wade review plan`), where the AI agent IS the tool. The header is noise — the agent just needs the raw prompt to process.

Similarly, `deps_service.py` prints `"Prompt mode: copy the prompt above and run it manually..."` which is also wrong when called by an AI agent.

## Proposed Solution
Remove user-facing instructional text from prompt mode output. Return just the raw prompt.

## Tasks
- [ ] Remove the `"Copy the prompt below..."` header from `_delegate_prompt()` in `src/wade/services/delegation_service.py` — return `request.prompt` directly as `feedback`
- [ ] Remove the `console.info()` instructional message from the prompt-mode branch in `src/wade/services/deps_service.py` (keep the early return)
- [ ] Update test `test_prompt_mode_includes_copy_header` in `tests/unit/test_services/test_delegation_service.py` to assert raw prompt is returned without header
- [ ] Update mock feedback string in `tests/unit/test_services/test_deps_service.py` from `"Copy the prompt below..."` to a plain string

## Acceptance Criteria
- [ ] `_delegate_prompt()` returns raw prompt text without any header or instructional prefix
- [ ] `deps_service.py` prompt-mode branch does not print user-facing copy instructions
- [ ] All existing tests pass after updates
- [ ] `prompt_delivery.py` is NOT changed (different concern — clipboard fallback for GUI tools in interactive mode)

<!-- wade:plan:end -->

## Summary

## What was done
Removed user-facing instructional text from prompt mode output so it returns just the raw prompt. Prompt mode is typically consumed by AI agents (e.g., Claude Code running `wade review plan`), not humans — the wrapper text was noise.

## Changes
- Removed the `"Copy the prompt below into your AI tool:\n\n---\n"` header from `_delegate_prompt()` in `delegation_service.py` — now returns `request.prompt` directly
- Removed the `console.info("Prompt mode: copy the prompt above...")` message from the prompt-mode branch in `deps_service.py` (kept the early return)
- Updated `test_prompt_mode_includes_copy_header` → `test_prompt_mode_returns_raw_prompt` to assert exact raw prompt
- Updated mock feedback string in `test_deps_service.py` from `"Copy the prompt below..."` to `"raw prompt text"`

## Testing
- Ran affected test files: all 57 tests pass
- Lint, format, and type checks pass
- Pre-commit hooks pass

## Notes for reviewers
- `prompt_delivery.py` was intentionally NOT changed (different concern — clipboard fallback for GUI tools in interactive mode)

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.6` |
| Total tokens | **4,195** |
| Input tokens | **95** |
| Output tokens | **4,100** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `ae59f3cc-a7d9-4f7d-967a-b9562e28aabd` |

<!-- wade:sessions:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prompt delegation now returns clean, raw prompt text without wrapper headers, eliminating unnecessary formatting for direct prompt usage.
  * Removed debug console messages from dependency analysis to reduce log clutter.

* **Tests**
  * Updated test cases to verify the improved prompt delegation behavior and console output changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->