### PR TITLE
Fix medium complexity tier defaulting to fast-tier model in init

### DIFF
--- a/src/wade/ai_tools/base.py
+++ b/src/wade/ai_tools/base.py
@@ -117,7 +117,7 @@ class AbstractAITool(ABC):
 
         return ComplexityModelMapping(
             easy=fast.id if fast else None,
-            medium=fast.id if fast else None,
+            medium=balanced.id if balanced else None,
             complex=balanced.id if balanced else None,
             very_complex=powerful.id if powerful else None,
         )

--- a/src/wade/ai_tools/model_utils.py
+++ b/src/wade/ai_tools/model_utils.py
@@ -30,7 +30,7 @@ def classify_tier_universal(model_id: str) -> ModelTier:
     Used when processing raw model IDs from scraping/probing.
 
     Tier mapping (matches Bash _init_probe_models_for_tool):
-        easy/medium  — haiku, flash, spark, mini
+        easy         — haiku, flash, spark, mini
         complex      — sonnet, or unrecognized mid-tier models
         very_complex — opus, pro, ultra, max
 

--- a/src/wade/config/defaults.py
+++ b/src/wade/config/defaults.py
@@ -9,25 +9,25 @@ from wade.models.config import ComplexityModelMapping
 TOOL_DEFAULTS: dict[str, ComplexityModelMapping] = {
     AIToolID.CLAUDE: ComplexityModelMapping(
         easy="claude-haiku-4.5",
-        medium="claude-haiku-4.5",
+        medium="claude-sonnet-4.6",
         complex="claude-sonnet-4.6",
         very_complex="claude-opus-4.6",
     ),
     AIToolID.COPILOT: ComplexityModelMapping(
         easy="claude-haiku-4.5",
-        medium="claude-haiku-4.5",
+        medium="claude-sonnet-4.6",
         complex="claude-sonnet-4.6",
         very_complex="claude-opus-4.6",
     ),
     AIToolID.GEMINI: ComplexityModelMapping(
         easy="gemini-3-flash-preview",
-        medium="gemini-3-flash-preview",
+        medium="gemini-3-pro-preview",
         complex="gemini-3-pro-preview",
         very_complex="gemini-3-pro-preview",
     ),
     AIToolID.CODEX: ComplexityModelMapping(
         easy="gpt-5.1-codex-mini",
-        medium="gpt-5.1-codex-mini",
+        medium="gpt-5.3-codex",
         complex="gpt-5.3-codex",
         very_complex="gpt-5.3-codex",
     ),
@@ -39,7 +39,7 @@ TOOL_DEFAULTS: dict[str, ComplexityModelMapping] = {
     ),
     AIToolID.OPENCODE: ComplexityModelMapping(
         easy="anthropic/claude-haiku-4.5",
-        medium="anthropic/claude-haiku-4.5",
+        medium="anthropic/claude-sonnet-4.6",
         complex="anthropic/claude-sonnet-4.6",
         very_complex="anthropic/claude-opus-4.6",
     ),

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -1636,7 +1636,10 @@ def _write_config(
 
     # models section keyed by implement_tool (or default tool)
     models_key = implement_tool or ai_tool
-    if models_key and (model_mapping.easy or model_mapping.complex):
+    has_any_model = any(
+        getattr(model_mapping, k, None) for k in ("easy", "medium", "complex", "very_complex")
+    )
+    if models_key and has_any_model:
         config_dict["models"] = {
             str(models_key): {
                 k: v

--- a/tests/unit/test_config/test_defaults.py
+++ b/tests/unit/test_config/test_defaults.py
@@ -1,0 +1,55 @@
+"""Tests for config defaults — tier mapping correctness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from wade.config.defaults import TOOL_DEFAULTS, get_defaults
+from wade.models.ai import AIToolID
+from wade.services.init_service import _write_config
+
+
+class TestMediumTierDefaults:
+    """Medium tier must map to balanced-tier (not fast-tier) for all tools."""
+
+    def test_medium_differs_from_easy_for_all_tools(self) -> None:
+        for tool_id, mapping in TOOL_DEFAULTS.items():
+            assert mapping.medium != mapping.easy, (
+                f"{tool_id}: medium ({mapping.medium}) should differ from easy ({mapping.easy})"
+            )
+
+    def test_medium_equals_complex_for_all_tools(self) -> None:
+        for tool_id, mapping in TOOL_DEFAULTS.items():
+            assert mapping.medium == mapping.complex, (
+                f"{tool_id}: medium ({mapping.medium}) should equal "
+                f"complex ({mapping.complex}) — both balanced-tier"
+            )
+
+    def test_claude_medium_is_sonnet(self) -> None:
+        mapping = get_defaults(AIToolID.CLAUDE)
+        assert mapping.medium == "claude-sonnet-4.6"
+
+    def test_cursor_medium_is_balanced(self) -> None:
+        mapping = get_defaults(AIToolID.CURSOR)
+        assert mapping.medium == "sonnet-4.6"
+
+
+class TestWriteLoadRoundtrip:
+    """Write config → load → verify models resolve correctly per tier."""
+
+    def test_roundtrip_all_tiers(self, tmp_path: Path) -> None:
+        defaults = get_defaults(AIToolID.CLAUDE)
+        config_path = tmp_path / ".wade.yml"
+        _write_config(config_path, "claude", defaults)
+
+        config = yaml.safe_load(config_path.read_text())
+        models = config["models"]["claude"]
+
+        assert models["easy"] == defaults.easy
+        assert models["medium"] == defaults.medium
+        assert models["complex"] == defaults.complex
+        assert models["very_complex"] == defaults.very_complex
+        # medium must not equal easy
+        assert models["medium"] != models["easy"]

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -637,12 +637,22 @@ class TestWriteConfig:
     def test_with_model_mapping(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
         mapping = ComplexityModelMapping(
-            easy="haiku", medium="haiku", complex="sonnet", very_complex="opus"
+            easy="haiku", medium="sonnet", complex="sonnet", very_complex="opus"
         )
         _write_config(config_path, "claude", mapping)
         config = yaml.safe_load(config_path.read_text())
         assert config["models"]["claude"]["easy"] == "haiku"
+        assert config["models"]["claude"]["medium"] == "sonnet"
         assert config["models"]["claude"]["complex"] == "sonnet"
+        assert config["models"]["claude"]["very_complex"] == "opus"
+
+    def test_write_config_with_only_medium_and_very_complex(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        mapping = ComplexityModelMapping(medium="sonnet", very_complex="opus")
+        _write_config(config_path, "claude", mapping)
+        config = yaml.safe_load(config_path.read_text())
+        assert "models" in config
+        assert config["models"]["claude"]["medium"] == "sonnet"
         assert config["models"]["claude"]["very_complex"] == "opus"
 
     def test_no_tool_omits_ai_and_models(self, tmp_path: Path) -> None:
@@ -787,6 +797,19 @@ class TestPatchConfig:
         config = yaml.safe_load(config_path.read_text())
         assert config["models"]["claude"]["easy"] == "new-haiku"
         assert config["models"]["claude"]["complex"] == "sonnet"
+
+    def test_patch_config_writes_all_four_tiers(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\nai:\n  default_tool: claude\n")
+        mapping = ComplexityModelMapping(
+            easy="haiku", medium="sonnet", complex="sonnet", very_complex="opus"
+        )
+        _patch_config(config_path, "claude", mapping, force=True)
+        config = yaml.safe_load(config_path.read_text())
+        assert config["models"]["claude"]["easy"] == "haiku"
+        assert config["models"]["claude"]["medium"] == "sonnet"
+        assert config["models"]["claude"]["complex"] == "sonnet"
+        assert config["models"]["claude"]["very_complex"] == "opus"
 
     def test_no_force_preserves_existing_models(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"


### PR DESCRIPTION
Closes #151

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem

The `medium` complexity tier defaults to fast-tier models (haiku/flash/mini) instead of balanced-tier (sonnet/pro/codex) across all AI tools except Cursor. Users who accept defaults during `wade init` get the wrong model for medium-complexity tasks — the same model as `easy` tasks.

The documented mapping is:
- `easy` → fast-tier
- `medium` → balanced-tier (BROKEN: currently defaults to fast-tier)
- `complex` → balanced-tier
- `very_complex` → powerful-tier

Additionally, `_write_config()` has a gate condition that only checks `easy` and `complex` tiers, silently dropping the models section if only `medium` and/or `very_complex` are set.

## Proposed Solution

Fix three code paths that share the same root cause:

1. **`src/wade/config/defaults.py`** — Change `medium` from fast-tier to balanced-tier for 5 affected tools (claude, copilot, gemini, codex, opencode). Cursor is already correct.

2. **`src/wade/services/init_service.py`** (line 1639) — Replace the `_write_config()` gate condition `model_mapping.easy or model_mapping.complex` with an `any()` check across all 4 tiers, matching the pattern already used by `_patch_config()`.

3. **`src/wade/ai_tools/base.py`** (line 120) — Change `medium=fast.id` → `medium=balanced.id` in `get_recommended_mapping()`. No current callers but should be consistent.

4. **`src/wade/ai_tools/model_utils.py`** (line 33) — Update comment from `easy/medium` to `easy` for fast-tier keywords.

5. Add comprehensive tests covering the medium tier.

## Tasks
- [ ] Update `medium` value in `defaults.py` for claude, copilot, gemini, codex, opencode
- [ ] Fix `_write_config()` gate condition in `init_service.py` to use `any()` check
- [ ] Fix `medium=fast.id` → `medium=balanced.id` in `base.py` `get_recommended_mapping()`
- [ ] Update tier mapping comment in `model_utils.py`
- [ ] Add `medium` assertion to existing `test_with_model_mapping` test
- [ ] Add test: `_write_config` with only `medium`/`very_complex` set
- [ ] Add test: `_patch_config` writes all 4 tiers
- [ ] Add test: defaults have `medium != easy` for all tools
- [ ] Add end-to-end roundtrip test (write → load → resolve per complexity)
- [ ] Run `./scripts/check-all.sh`

## Acceptance Criteria
- [ ] `medium` tier defaults to balanced-tier model (e.g., sonnet, not haiku) for all tools
- [ ] `_write_config()` persists models section when only `medium`/`very_complex` are set
- [ ] All new tests pass
- [ ] `./scripts/check-all.sh` passes

<!-- wade:plan:end -->

## Summary

## What was done
Fixed the medium complexity tier defaulting to fast-tier models (haiku/flash/mini) instead of balanced-tier (sonnet/pro/codex) across all AI tools except Cursor. Also fixed the `_write_config()` gate condition that silently dropped the models section when only `medium` and/or `very_complex` tiers were set.

## Changes
- **`src/wade/config/defaults.py`** — Changed `medium` from fast-tier to balanced-tier for claude, copilot, gemini, codex, and opencode
- **`src/wade/services/init_service.py`** — Replaced `_write_config()` gate `model_mapping.easy or model_mapping.complex` with `any()` check across all 4 tiers (matching `_patch_config` pattern)
- **`src/wade/ai_tools/base.py`** — Fixed `get_recommended_mapping()` to use `medium=balanced.id` instead of `medium=fast.id`
- **`src/wade/ai_tools/model_utils.py`** — Updated comment from `easy/medium` to `easy` for fast-tier keywords
- **`tests/unit/test_config/test_defaults.py`** — New test file: medium != easy for all tools, medium == complex for all tools, roundtrip write/load test
- **`tests/unit/test_services/test_init.py`** — Added medium assertion to `test_with_model_mapping`, new `_write_config` test with only medium/very_complex set, new `_patch_config` test for all 4 tiers

## Testing
- All 1557 tests pass
- Lint (ruff) clean
- Type check (mypy --strict) clean
- Full `./scripts/check-all.sh` passes

## Notes for reviewers
Cursor was already correctly mapping medium to balanced-tier (`sonnet-4.6`), so it was not changed.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.6` |
| Total tokens | **20,600** |
| Input tokens | **3,900** |
| Output tokens | **16,700** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `087fe822-8ecc-459e-8aa3-3212fb49b2ff` |

<!-- wade:sessions:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated default medium-tier models across multiple tools (Claude, Copilot, Gemini, Codex, and OpenCode) to use higher-capacity models, improving the performance-cost balance.
  * Enhanced configuration system to fully support medium and very_complex model tiers during configuration writes and loads.

* **Tests**
  * Added comprehensive test coverage for configuration defaults and tier-based model mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->