### PR TITLE
Fix plan-phase AI config leaking into implementation handoff

### DIFF
--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -858,9 +858,7 @@ def _finalize_issues(
     # Hint for next steps
     console.empty()
     if len(issue_numbers) == 1:
-        result = _offer_to_implement(
-            issue_numbers[0], ai_tool=ai_tool, model=model, effort=effort, yolo=yolo
-        )
+        result = _offer_to_implement(issue_numbers[0])
         if result is not None:
             return result
     elif len(issue_numbers) >= 2:
@@ -876,13 +874,7 @@ def _print_implement_hint(issue_number: str) -> None:
     console.detail(f"wade implement {issue_number}")
 
 
-def _offer_to_implement(
-    issue_number: str,
-    ai_tool: str | None = None,
-    model: str | None = None,
-    effort: EffortLevel | None = None,
-    yolo: bool = False,
-) -> bool | None:
+def _offer_to_implement(issue_number: str) -> bool | None:
     """Prompt the user to start an implementation session on the newly planned issue.
 
     Returns True/False if the user accepted/implementation session succeeded or failed,
@@ -901,16 +893,7 @@ def _offer_to_implement(
         return None
 
     try:
-        return start_implementation_session(
-            target=issue_number,
-            ai_tool=ai_tool,
-            model=model,
-            effort=effort.value if effort is not None else None,
-            ai_explicit=ai_tool is not None,
-            model_explicit=model is not None,
-            effort_explicit=effort is not None,
-            yolo=yolo or None,
-        )
+        return start_implementation_session(target=issue_number)
     except Exception:
         logger.exception("plan.work_session_start_failed", issue=issue_number)
         return False

--- a/tests/unit/test_services/test_plan_service.py
+++ b/tests/unit/test_services/test_plan_service.py
@@ -638,48 +638,7 @@ class TestOfferToImplement:
             result = _offer_to_implement("42")
 
             assert result is True
-            mock_start.assert_called_once_with(
-                target="42",
-                ai_tool=None,
-                model=None,
-                effort=None,
-                ai_explicit=False,
-                model_explicit=False,
-                effort_explicit=False,
-                yolo=None,
-            )
-
-    def test_ai_params_passed_to_implementation_session(self) -> None:
-        """AI params from plan session are threaded through to start_implementation_session."""
-        from wade.models.ai import EffortLevel
-
-        with (
-            patch("wade.services.plan_service.prompts") as mock_prompts,
-            patch("wade.services.plan_service.start_implementation_session") as mock_start,
-            patch("wade.services.plan_service.console"),
-        ):
-            mock_prompts.is_tty.return_value = True
-            mock_prompts.confirm.return_value = True
-            mock_start.return_value = True
-
-            result = _offer_to_implement(
-                "42",
-                ai_tool="claude",
-                model="claude-opus-4-5",
-                effort=EffortLevel.HIGH,
-            )
-
-            assert result is True
-            mock_start.assert_called_once_with(
-                target="42",
-                ai_tool="claude",
-                model="claude-opus-4-5",
-                effort="high",
-                ai_explicit=True,
-                model_explicit=True,
-                effort_explicit=True,
-                yolo=None,
-            )
+            mock_start.assert_called_once_with(target="42")
 
     def test_user_declines_returns_none(self) -> None:
         """Declining the prompt returns None without calling start."""
@@ -780,9 +739,7 @@ class TestFinalizeIssuesHints:
                 issue_numbers=["1"],
             )
 
-            mock_offer.assert_called_once_with(
-                "1", ai_tool=None, model=None, effort=None, yolo=False
-            )
+            mock_offer.assert_called_once_with("1")
             assert result is True
 
     def test_multiple_issues_shows_batch_hint(self) -> None:


### PR DESCRIPTION
Closes #157

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

When `wade plan` completes and offers "Start implementing #N now?", the plan-phase
resolved `ai_tool`, `model`, `effort`, and `yolo` are forwarded to
`start_implementation_session()` as explicit arguments. Because `resolve_ai_tool()`
short-circuits when an explicit tool is provided (`if ai_tool: return ai_tool`),
the implement-phase config (`ai.implement.tool`) is never consulted.

Users who configure different AI tools per phase (e.g. `ai.plan.tool: claude`,
`ai.implement.tool: copilot`) get the plan tool used for implementation instead
of the configured implementation tool.

## Proposed Solution

Stop passing plan-phase AI parameters through the plan→implement handoff.
Let `implementation_service.start()` resolve its own tool/model/effort/yolo
independently from config for the "implement" phase.

### File changes

**`src/wade/services/plan_service.py`**

1. In `_finalize_issues()` (~line 861): call `_offer_to_implement(issue_numbers[0])`
   without AI params.
2. In `_offer_to_implement()` (~line 879): remove `ai_tool`, `model`, `effort`,
   `yolo` parameters from the signature.
3. In `_offer_to_implement()` (~line 904): call
   `start_implementation_session(target=issue_number)` without AI params.

**`tests/unit/test_services/test_plan_service.py`**

4. Remove or rewrite the test that verifies `_offer_to_implement` forwards
   `ai_tool`/`model`/`effort` (those params no longer exist).
5. Update `TestFinalizeIssuesHints.test_single_issue_calls_offer` assertion from
   `mock_offer.assert_called_once_with("1", ai_tool=None, model=None, effort=None, yolo=False)`
   to `mock_offer.assert_called_once_with("1")`.

## Tasks
- [ ] Remove AI params from `_offer_to_implement` signature and body
- [ ] Update `_finalize_issues` call to `_offer_to_implement(issue_numbers[0])`
- [ ] Update/remove affected tests in `test_plan_service.py`
- [ ] Run `./scripts/check-all.sh` to verify

## Acceptance Criteria
- [ ] `_offer_to_implement` no longer accepts or forwards AI tool/model/effort/yolo
- [ ] `_finalize_issues` calls `_offer_to_implement` with only the issue number
- [ ] Implementation phase resolves tool/model from `ai.implement` config independently
- [ ] All existing tests pass (updated as needed)
- [ ] `./scripts/check-all.sh` passes

<!-- wade:plan:end -->

## Summary

## What was done

Stopped the plan-phase AI config (`ai_tool`, `model`, `effort`, `yolo`) from leaking into the implementation handoff. When `wade plan` finishes and offers "Start implementing #N now?", `start_implementation_session` is now called with only the target issue number, allowing the implementation service to resolve its own tool/model from the `ai.implement` config section independently.

## Changes

- Removed `ai_tool`, `model`, `effort`, `yolo` parameters from `_offer_to_implement` signature and body in `plan_service.py`
- Updated `_finalize_issues` call site to pass only `issue_numbers[0]` to `_offer_to_implement`
- Removed `test_ai_params_passed_to_implementation_session` test (behaviour no longer exists)
- Updated `test_user_accepts_starts_implementation_session` assertion to match simplified `start_implementation_session(target="42")` call
- Updated `TestFinalizeIssuesHints.test_single_issue_calls_offer` assertion to match `mock_offer.assert_called_once_with("1")`

## Testing

- Ran `./scripts/check-all.sh`: 1550 passed, 7 skipped, lint clean, mypy strict clean

## Notes for reviewers

The fix is minimal and surgical — no behaviour change for users who use the same AI tool for both phases. Users who configure different tools per phase (`ai.plan.tool` vs `ai.implement.tool`) now correctly get the implementation tool during implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined the implementation session initialization process by simplifying the internal logic for offering to implement issues. The flow now directly targets specific issues with reduced parameter handling, improving code maintainability while preserving existing functionality and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **80** |
| Input tokens | **9** |
| Output tokens | **21** |
| Cached tokens | **50** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `fde5ca04-eed2-4205-bc1a-3c9ecbab9a3f` |

<!-- wade:sessions:end -->
