### PR TITLE
Rename "Self-review" to "Review" in implementation-session skill template

### DIFF
--- a/templates/skills/implementation-session/SKILL.md
+++ b/templates/skills/implementation-session/SKILL.md
@@ -139,9 +139,9 @@ directly.
 
 To finalize your work, follow these steps in order:
 
-**Step 1 — Self-review:**
+**Step 1 — Review:**
 
-Run `wade review implementation` to catch issues early and check the exit code:
+Run `wade review implementation` to review your changes and check the exit code:
 - **Exit 0**: Review completed externally or skipped. If there is output, it is
   review feedback — read it and address any actionable findings, then commit
   before proceeding.


### PR DESCRIPTION
Closes #163

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
The implementation-session skill template labels its review step as "**Step 1 — Self-review:**", while the plan-session template uses the neutral "**Review**". When a project configures external review (e.g. `copilot` with `headless` mode in `.wade.yml`), the AI agent reading the implementation-session skill sees "Self-review" and may skip the step entirely — thinking it's unrelated to the configured external implementation review. The `wade review implementation` command already handles both self-review and external delegation automatically based on config, so the skill just needs clearer wording.

## Proposed Solution
Rename the step heading and lightly clarify the description in `templates/skills/implementation-session/SKILL.md` to match the plan-session convention.

Change line 142 area from:
```markdown
**Step 1 — Self-review:**

Run `wade review implementation` to catch issues early and check the exit code:
```

To:
```markdown
**Step 1 — Review:**

Run `wade review implementation` to review your changes and check the exit code:
```

The exit code descriptions below already correctly cover both paths (exit 0 for external/skipped, exit 2 for self-review) and need no changes.

## Tasks
- [ ] Edit `templates/skills/implementation-session/SKILL.md` line ~142: rename "Self-review" to "Review" in the step heading
- [ ] Edit the same line area: change "catch issues early" to "review your changes"
- [ ] Verify the symlink `.claude/skills/implementation-session/` → `templates/skills/implementation-session/` is intact

## Acceptance Criteria
- [ ] Step 1 heading in implementation-session SKILL.md says "Review", not "Self-review"
- [ ] Wording is consistent with plan-session SKILL.md step 5
- [ ] No other changes to the exit code descriptions or behavior

<!-- wade:plan:end -->

## Summary

## What was done

Renamed the "Self-review" step heading to "Review" in the implementation-session skill template, and updated the accompanying description to use neutral wording. This aligns the implementation-session skill with the plan-session convention.

## Changes

- Renamed `**Step 1 — Self-review:**` to `**Step 1 — Review:**` in `templates/skills/implementation-session/SKILL.md`
- Changed description from "catch issues early" to "review your changes" for clarity

## Testing

- Verified the symlink `.claude/skills/implementation-session/` → `../../templates/skills/implementation-session` is intact, so the change is automatically reflected
- Confirmed no other lines were changed (exit code descriptions remain untouched)

## Notes for reviewers

The fix addresses an issue where AI agents reading "Self-review" in the implementation-session skill might skip the step entirely when a project configures external review (e.g. `copilot` with `headless` mode). Using the neutral "Review" label makes clear the step applies regardless of the configured review mode.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **3,015** |
| Input tokens | **15** |
| Output tokens | **3,000** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `f6002285-a3ed-425c-84ac-2383e8efdceb` |

<!-- wade:sessions:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified terminology and labeling in implementation session guidance.
  * Enhanced exit code documentation for improved workflow clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->