### PR TITLE
Fix review_batch default delegation mode from prompt to interactive

### DIFF
--- a/src/wade/services/delegation_service.py
+++ b/src/wade/services/delegation_service.py
@@ -28,14 +28,17 @@ from wade.utils.process import CommandError, run
 logger = structlog.get_logger()
 
 
-def resolve_mode(cmd_config: AICommandConfig) -> DelegationMode:
-    """Resolve the delegation mode from config, defaulting to prompt."""
+def resolve_mode(
+    cmd_config: AICommandConfig,
+    default: DelegationMode = DelegationMode.PROMPT,
+) -> DelegationMode:
+    """Resolve the delegation mode from config, falling back to ``default``."""
     if cmd_config.mode:
         try:
             return DelegationMode(cmd_config.mode)
         except ValueError:
-            logger.warning("delegation.invalid_mode", mode=cmd_config.mode, fallback="prompt")
-    return DelegationMode.PROMPT
+            logger.warning("delegation.invalid_mode", mode=cmd_config.mode, fallback=default.value)
+    return default
 
 
 def _parse_effort(raw: str | None) -> EffortLevel | None:

--- a/src/wade/services/review_delegation_service.py
+++ b/src/wade/services/review_delegation_service.py
@@ -59,7 +59,12 @@ def _run_review_delegation(
     cmd_config: AICommandConfig = getattr(config.ai, command)
 
     try:
-        delegation_mode = DelegationMode(mode) if mode else resolve_mode(cmd_config)
+        default_mode = (
+            DelegationMode.INTERACTIVE if command == "review_batch" else DelegationMode.PROMPT
+        )
+        delegation_mode = (
+            DelegationMode(mode) if mode else resolve_mode(cmd_config, default=default_mode)
+        )
     except ValueError:
         console.error(f"Invalid delegation mode: {mode}")
         return DelegationResult(

--- a/tests/unit/test_services/test_delegation_service.py
+++ b/tests/unit/test_services/test_delegation_service.py
@@ -39,6 +39,18 @@ class TestResolveMode:
         cfg = AICommandConfig(mode="bad_value")
         assert resolve_mode(cfg) == DelegationMode.PROMPT
 
+    def test_custom_default_no_config(self) -> None:
+        cfg = AICommandConfig()
+        assert resolve_mode(cfg, default=DelegationMode.INTERACTIVE) == DelegationMode.INTERACTIVE
+
+    def test_config_mode_overrides_custom_default(self) -> None:
+        cfg = AICommandConfig(mode="headless")
+        assert resolve_mode(cfg, default=DelegationMode.INTERACTIVE) == DelegationMode.HEADLESS
+
+    def test_invalid_mode_falls_back_to_custom_default(self) -> None:
+        cfg = AICommandConfig(mode="bad_value")
+        assert resolve_mode(cfg, default=DelegationMode.INTERACTIVE) == DelegationMode.INTERACTIVE
+
 
 # ---------------------------------------------------------------------------
 # Prompt mode

--- a/tests/unit/test_services/test_review_delegation_service.py
+++ b/tests/unit/test_services/test_review_delegation_service.py
@@ -249,6 +249,74 @@ class TestReviewCode:
 
 
 # ---------------------------------------------------------------------------
+# Default mode per command
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultModePerCommand:
+    @patch("wade.services.review_delegation_service.delegate")
+    @patch("wade.services.review_delegation_service.confirm_ai_selection")
+    @patch("wade.services.review_delegation_service.resolve_effort")
+    @patch("wade.services.review_delegation_service.resolve_model")
+    @patch("wade.services.review_delegation_service.resolve_ai_tool")
+    @patch("wade.services.review_delegation_service.load_config")
+    def test_review_batch_defaults_to_interactive(
+        self,
+        mock_config: MagicMock,
+        mock_tool: MagicMock,
+        mock_model: MagicMock,
+        mock_effort: MagicMock,
+        mock_confirm: MagicMock,
+        mock_delegate: MagicMock,
+    ) -> None:
+        """review_batch with no mode configured resolves to interactive."""
+        mock_config.return_value = ProjectConfig(
+            ai=AIConfig(review_batch=AICommandConfig(enabled=True))
+        )
+        mock_tool.return_value = "claude"
+        mock_model.return_value = None
+        mock_effort.return_value = None
+        mock_confirm.return_value = ("claude", None, None, False)
+        mock_delegate.return_value = DelegationResult(
+            success=True, feedback="ok", mode=DelegationMode.INTERACTIVE
+        )
+
+        _run_review_delegation("prompt text", "review_batch")
+
+        call_args = mock_delegate.call_args[0][0]
+        assert call_args.mode == DelegationMode.INTERACTIVE
+
+    @patch("wade.services.review_delegation_service.delegate")
+    @patch("wade.services.review_delegation_service.resolve_effort")
+    @patch("wade.services.review_delegation_service.resolve_model")
+    @patch("wade.services.review_delegation_service.resolve_ai_tool")
+    @patch("wade.services.review_delegation_service.load_config")
+    def test_review_plan_defaults_to_prompt(
+        self,
+        mock_config: MagicMock,
+        mock_tool: MagicMock,
+        mock_model: MagicMock,
+        mock_effort: MagicMock,
+        mock_delegate: MagicMock,
+    ) -> None:
+        """review_plan with no mode configured still resolves to prompt."""
+        mock_config.return_value = ProjectConfig(
+            ai=AIConfig(review_plan=AICommandConfig(enabled=True))
+        )
+        mock_tool.return_value = None
+        mock_model.return_value = None
+        mock_effort.return_value = None
+        mock_delegate.return_value = DelegationResult(
+            success=True, feedback="ok", mode=DelegationMode.PROMPT
+        )
+
+        _run_review_delegation("prompt text", "review_plan")
+
+        call_args = mock_delegate.call_args[0][0]
+        assert call_args.mode == DelegationMode.PROMPT
+
+
+# ---------------------------------------------------------------------------
 # _run_review_delegation effort + confirm tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #186

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem

`wade review batch <N>` defaults to `DelegationMode.PROMPT`, which means it
just prints the review prompt to the terminal for the user to read manually —
it never actually launches an AI tool. This makes the coherence review
workflow confusing: `wade implement-batch` already shows a post-batch hint
with the exact command to run, but following that hint produces no AI action.

The root cause is `resolve_mode()` in `delegation_service.py:31-38`, which
falls back to `DelegationMode.PROMPT` for any command with no `mode`
configured in `.wade.yml`. For most review commands `prompt` is a valid
self-review fallback, but for `review_batch` it is actively misleading — the
command exists specifically to run an AI coherence analysis, and `prompt` mode
makes it a no-op without any warning.

## Proposed Solution

Add an optional `default` parameter to `resolve_mode()` so callers can
specify a different fallback mode. Then pass `DelegationMode.INTERACTIVE` as
the default when resolving mode for the `review_batch` command.

### 1. Add `default` parameter to `resolve_mode()`

In `src/wade/services/delegation_service.py` (line 31), add a `default`
parameter that defaults to `DelegationMode.PROMPT` to preserve existing
behavior for all other callers:

```python
def resolve_mode(
    cmd_config: AICommandConfig,
    default: DelegationMode = DelegationMode.PROMPT,
) -> DelegationMode:
    if cmd_config.mode:
        try:
            return DelegationMode(cmd_config.mode)
        except ValueError:
            logger.warning("delegation.invalid_mode", mode=cmd_config.mode, fallback=default.value)
    return default
```

### 2. Pass `DelegationMode.INTERACTIVE` for `review_batch`

In `src/wade/services/review_delegation_service.py` (line 62), compute
`default_mode` based on command name:

```python
default_mode = DelegationMode.INTERACTIVE if command == "review_batch" else DelegationMode.PROMPT
delegation_mode = DelegationMode(mode) if mode else resolve_mode(cmd_config, default=default_mode)
```

### 3. No changes needed in `batch()` hint

The post-batch hint already prints the correct command. Once `review_batch`
defaults to `interactive`, the command works end-to-end with no flag changes.

## Tasks

- [ ] Add `default: DelegationMode = DelegationMode.PROMPT` parameter to `resolve_mode()` in `src/wade/services/delegation_service.py`
- [ ] Update warning log to use `default.value` instead of hardcoded `"prompt"`
- [ ] In `src/wade/services/review_delegation_service.py` `_run_review_delegation`, pass `default=DelegationMode.INTERACTIVE` when `command == "review_batch"`
- [ ] Add unit test: `resolve_mode` with custom default and no config returns the custom default
- [ ] Add unit test: `resolve_mode` with config mode set ignores custom default
- [ ] Add unit test: `resolve_mode` with invalid config mode falls back to custom default
- [ ] Add unit test: `review_batch` with no mode configured resolves to `interactive`
- [ ] Add unit test: other commands (e.g. `review_plan`) still resolve to `prompt` by default
- [ ] Run `./scripts/check-all.sh` to verify all tests, lint, and types pass

## Acceptance Criteria

- [ ] `wade review batch <N>` with no `.wade.yml` mode configured launches AI interactively
- [ ] `ai.review_batch.mode: headless` in `.wade.yml` runs headlessly
- [ ] `ai.review_batch.mode: prompt` in `.wade.yml` still enables self-review mode
- [ ] All other review commands (`review_plan`, `review_implementation`) continue to default to `prompt`
- [ ] Post-batch "Run later" hint command works end-to-end with no extra flags
- [ ] `./scripts/check-all.sh` passes

<!-- wade:plan:end -->

## Summary

## What was done

`wade review batch <N>` previously defaulted to `DelegationMode.PROMPT`, which just printed the review prompt to the terminal without launching any AI tool — making the command a confusing no-op. This fix changes the default delegation mode for `review_batch` to `DelegationMode.INTERACTIVE`, so running `wade review batch <N>` with no mode configured in `.wade.yml` now launches an interactive AI session.

## Changes

- Added `default: DelegationMode = DelegationMode.PROMPT` parameter to `resolve_mode()` in `delegation_service.py`, preserving backward compatibility for all existing callers
- Updated the invalid-mode warning log to use `default.value` instead of hardcoded `"prompt"`
- In `_run_review_delegation()`, compute `default_mode` based on command name: `INTERACTIVE` for `review_batch`, `PROMPT` for everything else

## Testing

- Added 3 unit tests to `TestResolveMode`: custom default with no config, config mode overrides custom default, invalid config mode falls back to custom default
- Added 2 integration-style tests to `TestDefaultModePerCommand`: `review_batch` resolves to `interactive`, `review_plan` still resolves to `prompt`
- Ran `./scripts/check-all.sh`: 1710 tests passed, ruff clean, mypy strict clean

## Notes for reviewers

All other review commands (`review_plan`, `review_implementation`) are unaffected — the `default` parameter defaults to `PROMPT`, so their behavior is unchanged. The `.wade.yml` overrides (`mode: headless`, `mode: prompt`, `mode: interactive`) continue to work for all commands including `review_batch`.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **20,300** |
| Input tokens | **13,300** |
| Output tokens | **7,000** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `d13198b1-b02d-4258-9010-68ee02d35e25` |

<!-- wade:sessions:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Delegation mode resolution now includes command-specific defaults: review_batch commands default to interactive mode, while other operations default to prompt mode when no explicit preference is configured.
  * Enhanced handling of invalid delegation mode configurations with improved fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->