### PR TITLE
Effort configuration overhaul: Claude --effort flag + WADE_EFFORT env var

### DIFF
--- a/src/wade/ai_tools/claude.py
+++ b/src/wade/ai_tools/claude.py
@@ -161,8 +161,8 @@ class ClaudeAdapter(AbstractAITool):
         return ["--output-format", "json", "--json-schema", json.dumps(json_schema)]
 
     def effort_args(self, effort: EffortLevel) -> list[str]:
-        """Claude uses ``--settings '{"effortLevel": "<level>"}'``."""
-        return ["--settings", json.dumps({"effortLevel": effort.value})]
+        """Claude uses the native ``--effort <level>`` flag."""
+        return ["--effort", effort.value]
 
     def yolo_args(self) -> list[str]:
         """Claude uses ``--dangerously-skip-permissions``."""

--- a/src/wade/services/ai_resolution.py
+++ b/src/wade/services/ai_resolution.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import structlog
 
 from wade.ai_tools.base import AbstractAITool
@@ -102,17 +104,21 @@ def resolve_effort(
     *,
     tool: str | None = None,
 ) -> EffortLevel | None:
-    """Resolve effort level from args -> config -> None.
+    """Resolve effort level from args -> env var -> config -> None.
 
     Fallback chain:
       1. Explicit *effort* arg (e.g. ``--effort`` CLI flag)
-      2. Command-specific config (``ai.<command>.effort``)
-      3. Global config (``ai.effort``)
+      2. ``WADE_EFFORT`` environment variable
+      3. Command-specific config (``ai.<command>.effort``)
+      4. Global config (``ai.effort``)
 
     When *tool* is provided and the tool does not support effort, a warning
     is logged and ``None`` is returned.
     """
     resolved: str | None = effort
+
+    if not resolved:
+        resolved = os.environ.get("WADE_EFFORT")
 
     if not resolved:
         resolved = config.get_effort(command)

--- a/tests/unit/test_effort.py
+++ b/tests/unit/test_effort.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import patch
 
 import pytest
@@ -146,11 +145,11 @@ class TestClaudeEffortArgs:
 
     def test_effort_low(self) -> None:
         result = self._get_adapter().effort_args(EffortLevel.LOW)
-        assert result == ["--settings", json.dumps({"effortLevel": "low"})]
+        assert result == ["--effort", "low"]
 
     def test_effort_max(self) -> None:
         result = self._get_adapter().effort_args(EffortLevel.MAX)
-        assert result == ["--settings", json.dumps({"effortLevel": "max"})]
+        assert result == ["--effort", "max"]
 
     def test_resolve_effort_model_unchanged(self) -> None:
         adapter = self._get_adapter()
@@ -270,17 +269,16 @@ class TestBuildLaunchCommandEffort:
 
         adapter = ClaudeAdapter()
         cmd = adapter.build_launch_command(model="claude-sonnet-4-6", effort=EffortLevel.HIGH)
-        settings_str = json.dumps({"effortLevel": "high"})
-        assert "--settings" in cmd
-        idx = cmd.index("--settings")
-        assert cmd[idx + 1] == settings_str
+        assert "--effort" in cmd
+        idx = cmd.index("--effort")
+        assert cmd[idx + 1] == "high"
 
     def test_effort_none_no_extra_args(self) -> None:
         from wade.ai_tools.claude import ClaudeAdapter
 
         adapter = ClaudeAdapter()
         cmd = adapter.build_launch_command(model="claude-sonnet-4-6", effort=None)
-        assert "--settings" not in cmd
+        assert "--effort" not in cmd
 
     def test_cursor_effort_changes_model(self) -> None:
         from wade.ai_tools.cursor import CursorAdapter
@@ -369,6 +367,42 @@ class TestResolveEffort:
         config = ProjectConfig()
         result = resolve_effort("high", config, tool="claude")
         assert result is EffortLevel.HIGH
+
+    def test_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from wade.models.config import ProjectConfig
+        from wade.services.ai_resolution import resolve_effort
+
+        monkeypatch.setenv("WADE_EFFORT", "high")
+        config = ProjectConfig()
+        result = resolve_effort(None, config)
+        assert result is EffortLevel.HIGH
+
+    def test_explicit_arg_beats_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from wade.models.config import ProjectConfig
+        from wade.services.ai_resolution import resolve_effort
+
+        monkeypatch.setenv("WADE_EFFORT", "low")
+        config = ProjectConfig()
+        result = resolve_effort("max", config)
+        assert result is EffortLevel.MAX
+
+    def test_env_var_beats_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from wade.models.config import AIConfig, ProjectConfig
+        from wade.services.ai_resolution import resolve_effort
+
+        monkeypatch.setenv("WADE_EFFORT", "high")
+        config = ProjectConfig(ai=AIConfig(effort="low"))
+        result = resolve_effort(None, config)
+        assert result is EffortLevel.HIGH
+
+    def test_invalid_env_var_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from wade.models.config import ProjectConfig
+        from wade.services.ai_resolution import resolve_effort
+
+        monkeypatch.setenv("WADE_EFFORT", "turbo")
+        config = ProjectConfig()
+        result = resolve_effort(None, config)
+        assert result is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #189

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem

Claude Code now has a native `--effort` CLI flag (`--effort low|medium|high|max`) for setting reasoning effort. WADE's Claude adapter currently uses a workaround — injecting `--settings '{"effortLevel": "..."}'` — instead of the official flag. This is fragile and may break as Claude Code evolves its settings API.

Additionally, Claude Code supports `CLAUDE_CODE_EFFORT_LEVEL` as an environment variable for persistent effort configuration, but WADE has no equivalent. Users who want to set a default effort level across all WADE commands currently must edit `.wade.yml` — there's no quick env var override.

## Proposed Solution

Two focused improvements to the effort configuration system:

1. **Switch Claude adapter to native `--effort` flag** — Replace `--settings '{"effortLevel": "..."}'` with `["--effort", effort.value]` in `ClaudeAdapter.effort_args()`. This uses Claude Code's official programmatic interface.

2. **Add `WADE_EFFORT` environment variable** — Insert a new step in `resolve_effort()` between the explicit CLI arg and config fallback. The env var name follows the existing `WADE_` prefix convention (`WADE_AI_TOOL`, `WADE_NO_UPDATE_CHECK`). It's tool-agnostic since WADE supports multiple AI backends.

No changes needed to the `EffortLevel` enum (low/medium/high/max are correct), other adapters (Codex, Cursor, OpenCode), config models, or CLI flags.

## Tasks

- [ ] Update `ClaudeAdapter.effort_args()` in `src/wade/ai_tools/claude.py` (line 163-165) to return `["--effort", effort.value]` instead of `["--settings", json.dumps({"effortLevel": effort.value})]`
- [ ] Add `import os` and `WADE_EFFORT` env var lookup to `resolve_effort()` in `src/wade/services/ai_resolution.py` (between explicit arg check and config fallback)
- [ ] Update docstring in `resolve_effort()` to document the new 4-step resolution chain
- [ ] Update Claude adapter effort tests in `tests/unit/test_effort.py` (lines 147-153) to expect `["--effort", "<level>"]`
- [ ] Update `build_launch_command` integration tests (lines 268-283) to assert `"--effort"` instead of `"--settings"`
- [ ] Add env var resolution tests: `test_env_var_fallback`, `test_explicit_arg_beats_env_var`, `test_env_var_beats_config`, `test_invalid_env_var_returns_none`
- [ ] Run `./scripts/check-all.sh` to verify lint, types, and all tests pass

## Acceptance Criteria

- [ ] `wade plan --effort high` produces a `claude --effort high ...` command (not `--settings`)
- [ ] `WADE_EFFORT=high wade plan` resolves effort to HIGH without needing `--effort` flag or config
- [ ] Explicit `--effort` CLI arg takes precedence over `WADE_EFFORT` env var
- [ ] `WADE_EFFORT` env var takes precedence over `.wade.yml` config
- [ ] Invalid `WADE_EFFORT` values are handled gracefully (warning logged, returns None)
- [ ] All existing effort tests pass with updated assertions
- [ ] Other adapters (Codex, Cursor, OpenCode) are unaffected

<!-- wade:plan:end -->

## Summary

## What was done

Replaced the fragile `--settings '{"effortLevel": "..."}'` workaround in the Claude adapter with Claude Code's native `--effort <level>` flag, and added a `WADE_EFFORT` environment variable as a new step in the effort resolution chain.

## Changes

- Updated `ClaudeAdapter.effort_args()` in `src/wade/ai_tools/claude.py` to return `["--effort", effort.value]` instead of `["--settings", json.dumps({...})]`
- Added `import os` and `WADE_EFFORT` env var lookup to `resolve_effort()` in `src/wade/services/ai_resolution.py` as step 2 in the 4-step chain (explicit arg > env var > command config > global config)
- Updated docstring in `resolve_effort()` to document the new resolution chain
- Updated Claude adapter effort tests to assert `--effort` instead of `--settings`
- Added four new env var resolution tests: fallback, explicit arg beats env var, env var beats config, invalid env var returns None

## Testing

- All 1714 tests pass (`./scripts/check-all.sh`)
- Lint (ruff) and type check (mypy --strict) pass clean
- New tests verify all four env var resolution scenarios

## Notes for reviewers

Other adapters (Codex, Cursor, OpenCode) are unaffected. The `WADE_EFFORT` name follows the existing `WADE_` prefix convention and is tool-agnostic. Invalid values are handled gracefully via the existing `EffortLevel` validation with a warning log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `WADE_EFFORT` environment variable support for configuring effort levels across commands.

* **Changes**
  * Updated effort resolution priority: explicit arguments now take precedence over the new environment variable, which takes precedence over configuration settings.
  * Simplified Claude effort flag implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **7,333** |
| Input tokens | **33** |
| Output tokens | **7,300** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `9f4a347d-c830-43c1-b605-ba92fd71cb2f` |

<!-- wade:sessions:end -->
