### PR TITLE
chore: disable all GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,9 +1,8 @@
 name: Auto Version Bump
 
+# Disabled: all GitHub Actions are currently disabled for this repository
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: CI
 
+# Disabled: all GitHub Actions are currently disabled for this repository
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,9 +1,8 @@
 name: PR Title Lint
 
+# Disabled: all GitHub Actions are currently disabled for this repository
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
Changed all workflow triggers to workflow_dispatch only, so they no
longer run automatically on push, pull_request, or PR merge events.

https://claude.ai/code/session_019Jr4RfPjmwdaEJ6epndUdi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD automation workflows to use manual dispatch triggers for version management, continuous integration checks, and pull request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->