### PR TITLE
fix: prevent auto-version workflow race condition on concurrent PR merges

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: auto-version-bump
+  cancel-in-progress: false
+
 jobs:
   version-bump:
     # Only run when the PR was actually merged
@@ -69,5 +73,12 @@ jobs:
       - name: Push commit and tag
         if: steps.detect.outputs.bump != ''
         run: |
-          git push
-          git push --tags
+          # Pull any commits that landed since checkout (e.g. from a
+          # concurrent version-bump that finished first), then retry push.
+          for attempt in 1 2 3; do
+            git pull --rebase origin main && git push && git push --tags && exit 0
+            echo "Push attempt $attempt failed, retrying in $((attempt * 2))s..."
+            sleep $((attempt * 2))
+          done
+          echo "All push attempts failed"
+          exit 1

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -77,8 +77,10 @@ jobs:
           # concurrent version-bump that finished first), then retry push.
           for attempt in 1 2 3; do
             git pull --rebase origin main && git push && git push --tags && exit 0
-            echo "Push attempt $attempt failed, retrying in $((attempt * 2))s..."
-            sleep $((attempt * 2))
+            if [ "$attempt" -lt 3 ]; then
+              echo "Push attempt $attempt failed, retrying in $((attempt * 2))s..."
+              sleep $((attempt * 2))
+            fi
           done
           echo "All push attempts failed"
           exit 1


### PR DESCRIPTION
Add concurrency group (cancel-in-progress: false) to serialize workflow
runs, and add pull --rebase with retry loop before pushing so a second
bump can land even if main moved since checkout.

https://claude.ai/code/session_01BU9BRTVoEPoLBSj4w6R6f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version bumping workflow to prevent concurrent execution conflicts.
  * Improved version update push reliability with automatic retry logic and exponential backoff to handle transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->