### PR TITLE
chore: audit and fix gitignore patterns for wade-managed artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,19 +25,12 @@ env/
 htmlcov/
 .mypy_cache/
 
-# wade runtime (per-project, gitignored)
-
-# Claude Code local settings (not covered by managed block)
+# AI tool directories (wade-managed — never committed in this repo)
+.agents/
 .claude/
-
-# AI tool session files written by worktree bootstrap (not covered by managed block)
-# These are per-session artifacts that should never be committed on main.
-.cursor/hooks.json
-.cursor/hooks/worktree_guard.py
-.cursor/cli.json
-.gemini/settings.json
-.gemini/hooks/worktree_guard.py
-.copilot/hooks/worktree_guard.py
+.copilot/
+.cursor/
+.gemini/
 .github/hooks/
 
 # OS
@@ -46,9 +39,6 @@ Thumbs.db
 
 # uv
 uv.lock
-
-# Temporary commit message file (agents use this to avoid rewriting on hook retries)
-.commit-msg
 
 # Local archive (pre-reset export)
 archive/
@@ -59,6 +49,7 @@ archive/
 .wade.yml
 PLAN.md
 PR-SUMMARY.md
+.commit-msg
 .claude/skills/address-reviews-session/
 .claude/skills/deps/
 .claude/skills/implementation-session/
@@ -78,12 +69,13 @@ PR-SUMMARY.md
 .cursor/hooks/worktree_guard.py
 .copilot/hooks/worktree_guard.py
 .gemini/hooks/worktree_guard.py
+.cursor/hooks.json
+.gemini/settings.json
+.github/hooks/hooks.json
+.claude/settings.json
+.cursor/cli.json
 .github/skills
 .agents/skills
 .gemini/skills
 .cursor/skills
 # wade:end
-.copilot/
-.cursor/
-.gemini/
-.github/hooks/

--- a/src/wade/config/cursor_hooks.py
+++ b/src/wade/config/cursor_hooks.py
@@ -30,7 +30,7 @@ def _configure_cursor_hook(worktree_path: Path, guard_script: Path, log_event: s
         entry=CursorHookEntry(
             event="preToolUse",
             command=f"python3 {guard_script.resolve()}",
-            tools=["Write", "Delete"],
+            tools=["Write", "Edit", "Delete"],
         ),
         dedup_key="command",
         ensure_path=["preToolUse"],

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -44,6 +44,7 @@ GITIGNORE_ENTRIES: Final = [
     ".wade.yml",
     "PLAN.md",
     "PR-SUMMARY.md",
+    ".commit-msg",
 ]
 
 # Entries added by older versions without markers — used for backward-compat cleanup

--- a/tests/unit/test_config/test_cursor_hooks.py
+++ b/tests/unit/test_config/test_cursor_hooks.py
@@ -18,7 +18,7 @@ class TestCursorWorktreeHooks:
         assert hooks_file.is_file()
         data = json.loads(hooks_file.read_text(encoding="utf-8"))
         assert len(data["preToolUse"]) == 1
-        assert data["preToolUse"][0]["tools"] == ["Write", "Delete"]
+        assert data["preToolUse"][0]["tools"] == ["Write", "Edit", "Delete"]
 
     def test_idempotent(self, tmp_path: Path) -> None:
         guard = tmp_path / "guard.py"
@@ -54,7 +54,7 @@ class TestCursorPlanHooks:
         assert hooks_file.is_file()
         data = json.loads(hooks_file.read_text(encoding="utf-8"))
         assert len(data["preToolUse"]) == 1
-        assert data["preToolUse"][0]["tools"] == ["Write", "Delete"]
+        assert data["preToolUse"][0]["tools"] == ["Write", "Edit", "Delete"]
 
     def test_idempotent(self, tmp_path: Path) -> None:
         guard = tmp_path / "guard.py"

--- a/tests/unit/test_skills/test_managed_gitignore.py
+++ b/tests/unit/test_skills/test_managed_gitignore.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 from wade.skills.installer import (
     CROSS_TOOL_DIRS,
+    HOOK_CONFIG_FILES,
     MANAGED_SKILL_NAMES,
     PLAN_GUARD_HOOK_FILES,
+    WORKTREE_GUARD_HOOK_FILES,
     get_managed_gitignore_patterns,
 )
 
@@ -22,6 +24,21 @@ class TestGetManagedGitignorePatterns:
         patterns = get_managed_gitignore_patterns(tmp_path)
         for hook_file in PLAN_GUARD_HOOK_FILES:
             assert hook_file in patterns
+
+    def test_includes_worktree_guard_hook_files(self, tmp_path: Path) -> None:
+        patterns = get_managed_gitignore_patterns(tmp_path)
+        for hook_file in WORKTREE_GUARD_HOOK_FILES:
+            assert hook_file in patterns
+
+    def test_includes_hook_config_files(self, tmp_path: Path) -> None:
+        patterns = get_managed_gitignore_patterns(tmp_path)
+        for config_file in HOOK_CONFIG_FILES:
+            assert config_file in patterns
+
+    def test_includes_session_settings_files(self, tmp_path: Path) -> None:
+        patterns = get_managed_gitignore_patterns(tmp_path)
+        assert ".claude/settings.json" in patterns
+        assert ".cursor/cli.json" in patterns
 
     def test_includes_cross_tool_dirs_when_absent(self, tmp_path: Path) -> None:
         """Cross-tool dirs that don't exist yet should be included."""


### PR DESCRIPTION
## Summary

- Add `.commit-msg` to `GITIGNORE_ENTRIES` so all inited projects ignore the temporary commit message file agents create during sessions
- Clean up WADE repo `.gitignore`: remove 14 redundant manual entries, consolidate AI tool directory ignores (`.agents/`, `.claude/`, `.copilot/`, `.cursor/`, `.gemini/`, `.github/hooks/`) into a single block, remove duplicate broad ignores after managed block
- Refresh managed block via `wade update` — adds previously missing entries: `.cursor/hooks.json`, `.gemini/settings.json`, `.github/hooks/hooks.json`, `.claude/settings.json`, `.cursor/cli.json`, `.commit-msg`
- Fix Cursor hook config: add missing `"Edit"` to tools list so the plan write guard actually intercepts edit operations (was only intercepting `Write` and `Delete`)
- Add test coverage for `WORKTREE_GUARD_HOOK_FILES`, `HOOK_CONFIG_FILES`, and session settings files (`.claude/settings.json`, `.cursor/cli.json`) in managed gitignore patterns

## Test plan

- [x] `./scripts/check-all.sh` passes (2154 tests, ruff, mypy)
- [x] Managed block on disk matches `get_gitignore_entries()` output
- [x] No duplicate gitignore entries between manual and managed sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Edit" tool is now available in Cursor's preToolUse hook configuration, alongside existing Write and Delete tools.

* **Chores**
  * Consolidated gitignore patterns with broader directory-level ignores for improved maintainability.
  * Updated unit tests to reflect new configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->