### PR TITLE
fix: detect completed bot reviews in PR comment polling

### DIFF
--- a/src/wade/models/review.py
+++ b/src/wade/models/review.py
@@ -48,6 +48,7 @@ class ReviewBotStatus(StrEnum):
 
     PAUSED = "paused"
     IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
 
 
 class PollOutcome(StrEnum):
@@ -55,6 +56,7 @@ class PollOutcome(StrEnum):
 
     COMMENTS_FOUND = "comments_found"
     QUIET_TIMEOUT = "quiet_timeout"
+    REVIEW_COMPLETE = "review_complete"
     PR_CLOSED = "pr_closed"
     INTERRUPTED = "interrupted"
 
@@ -94,7 +96,7 @@ def detect_coderabbit_review_status(
     if "review in progress by coderabbit.ai" in normalized:
         return ReviewBotStatus.IN_PROGRESS
 
-    return None
+    return ReviewBotStatus.COMPLETED
 
 
 # ---------------------------------------------------------------------------

--- a/src/wade/services/implementation_service.py
+++ b/src/wade/services/implementation_service.py
@@ -977,7 +977,7 @@ def _post_implementation_lifecycle_pr(
                 yolo=yolo,
                 yolo_explicit=yolo_explicit,
             )
-        elif outcome == PollOutcome.QUIET_TIMEOUT:
+        elif outcome in (PollOutcome.QUIET_TIMEOUT, PollOutcome.REVIEW_COMPLETE):
             review_service._quiet_next_steps_prompt(
                 repo_root,
                 branch,

--- a/src/wade/services/review_service.py
+++ b/src/wade/services/review_service.py
@@ -334,6 +334,10 @@ def poll_for_reviews(
                 time.sleep(poll_interval)
                 continue
 
+            if status.bot_status == ReviewBotStatus.COMPLETED and not status.actionable_threads:
+                console.info("Review bot completed — no actionable comments found.")
+                return PollOutcome.REVIEW_COMPLETE
+
             if status.actionable_threads:
                 count = len(status.actionable_threads)
                 is_bot = status.bot_status is not None
@@ -853,7 +857,7 @@ def _quiet_next_steps_prompt(
                         yolo_explicit=yolo_explicit,
                     )
                 return
-            elif outcome == PollOutcome.QUIET_TIMEOUT:
+            elif outcome in (PollOutcome.QUIET_TIMEOUT, PollOutcome.REVIEW_COMPLETE):
                 continue  # Show menu again
             else:  # INTERRUPTED or PR_CLOSED
                 return
@@ -907,7 +911,7 @@ def _post_review_lifecycle(
                     yolo=yolo,
                     yolo_explicit=yolo_explicit,
                 )
-        elif outcome == PollOutcome.QUIET_TIMEOUT:
+        elif outcome in (PollOutcome.QUIET_TIMEOUT, PollOutcome.REVIEW_COMPLETE):
             _quiet_next_steps_prompt(
                 repo_root,
                 branch,

--- a/tests/unit/test_models/test_review.py
+++ b/tests/unit/test_models/test_review.py
@@ -101,7 +101,7 @@ class TestDetectCoderabbitReviewStatus:
         ]
         assert detect_coderabbit_review_status(comments) == ReviewBotStatus.IN_PROGRESS
 
-    def test_completed_review_returns_none(self) -> None:
+    def test_completed_review_returns_completed(self) -> None:
         comments = [
             {
                 "login": "coderabbitai[bot]",
@@ -111,7 +111,7 @@ class TestDetectCoderabbitReviewStatus:
                 ),
             }
         ]
-        assert detect_coderabbit_review_status(comments) is None
+        assert detect_coderabbit_review_status(comments) == ReviewBotStatus.COMPLETED
 
     def test_no_coderabbit_comments(self) -> None:
         comments = [
@@ -138,8 +138,8 @@ class TestDetectCoderabbitReviewStatus:
                 ),
             },
         ]
-        # Latest comment has no paused/in-progress marker -> None
-        assert detect_coderabbit_review_status(comments) is None
+        # Latest comment has no paused/in-progress marker -> COMPLETED
+        assert detect_coderabbit_review_status(comments) == ReviewBotStatus.COMPLETED
 
     def test_paused_overrides_earlier_completed(self) -> None:
         """A newer paused comment takes precedence over an older completed one."""
@@ -644,6 +644,7 @@ class TestPollOutcome:
 
         assert PollOutcome.COMMENTS_FOUND == "comments_found"
         assert PollOutcome.QUIET_TIMEOUT == "quiet_timeout"
+        assert PollOutcome.REVIEW_COMPLETE == "review_complete"
         assert PollOutcome.PR_CLOSED == "pr_closed"
         assert PollOutcome.INTERRUPTED == "interrupted"
 

--- a/tests/unit/test_services/test_review_service.py
+++ b/tests/unit/test_services/test_review_service.py
@@ -1569,6 +1569,32 @@ class TestQuietNextStepsPrompt:
         assert first_options == ["Keep polling", "Exit without merging"]
         assert second_options == ["Keep polling", "Merge PR", "Exit without merging"]
 
+    @patch("wade.services.review_service.get_comprehensive_review_status")
+    @patch("wade.services.review_service.poll_for_reviews")
+    @patch("wade.ui.prompts.select")
+    @patch("wade.ui.prompts.is_tty", return_value=True)
+    def test_review_complete_reshows_menu(
+        self,
+        mock_is_tty: MagicMock,
+        mock_select: MagicMock,
+        mock_poll: MagicMock,
+        mock_status: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """REVIEW_COMPLETE from poll should re-show the quiet next-steps menu."""
+        from wade.models.review import PollOutcome, PRReviewStatus
+
+        mock_status.return_value = PRReviewStatus()
+        mock_poll.return_value = PollOutcome.REVIEW_COMPLETE
+        # First iteration: keep polling -> REVIEW_COMPLETE -> second iteration: exit
+        mock_select.side_effect = [0, 2]
+        provider = MagicMock()
+
+        _quiet_next_steps_prompt(tmp_path, "feat/42", "42", tmp_path / "wt", 99, provider)
+
+        assert mock_select.call_count == 2
+        assert mock_poll.call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # _post_review_lifecycle()
@@ -1743,3 +1769,89 @@ class TestPostReviewLifecycle:
             yolo=True,
             yolo_explicit=False,
         )
+
+    @patch("wade.services.review_service._quiet_next_steps_prompt")
+    @patch("wade.services.review_service.poll_for_reviews")
+    @patch("wade.services.review_service._merge_pr")
+    @patch("wade.ui.prompts.select", return_value=1)
+    @patch("wade.ui.prompts.is_tty", return_value=True)
+    def test_wait_review_complete_routes_to_quiet_prompt(
+        self,
+        mock_is_tty: MagicMock,
+        mock_select: MagicMock,
+        mock_merge: MagicMock,
+        mock_poll: MagicMock,
+        mock_quiet: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """When poll returns REVIEW_COMPLETE, the quiet next-steps prompt is shown."""
+        from wade.models.review import PollOutcome
+
+        mock_poll.return_value = PollOutcome.REVIEW_COMPLETE
+        provider = MagicMock()
+        _post_review_lifecycle(tmp_path, "feat/42", "42", tmp_path / "wt", 99, provider)
+        mock_merge.assert_not_called()
+        mock_poll.assert_called_once()
+        mock_quiet.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# poll_for_reviews()
+# ---------------------------------------------------------------------------
+
+
+class TestPollForReviews:
+    """Tests for the poll_for_reviews() function."""
+
+    @patch("wade.services.review_service.time.sleep")
+    @patch("wade.services.review_service.get_comprehensive_review_status")
+    @patch("wade.services.review_service.git_pr.get_pr_for_branch")
+    def test_returns_review_complete_when_bot_finished_no_threads(
+        self,
+        mock_pr: MagicMock,
+        mock_status: MagicMock,
+        mock_sleep: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """poll_for_reviews returns REVIEW_COMPLETE when bot is done and no threads exist."""
+        from wade.models.review import PollOutcome, PRReviewStatus, ReviewBotStatus
+        from wade.services.review_service import poll_for_reviews
+
+        mock_pr.return_value = {"state": "OPEN", "number": 99}
+        mock_status.return_value = PRReviewStatus(
+            bot_status=ReviewBotStatus.COMPLETED,
+            actionable_threads=[],
+        )
+        provider = MagicMock()
+
+        result = poll_for_reviews(provider, tmp_path, 99, "feat/42")
+
+        assert result == PollOutcome.REVIEW_COMPLETE
+        mock_sleep.assert_not_called()
+
+    @patch("wade.services.review_service.time.sleep")
+    @patch("wade.services.review_service.get_comprehensive_review_status")
+    @patch("wade.services.review_service.git_pr.get_pr_for_branch")
+    def test_completed_bot_with_threads_still_returns_comments_found(
+        self,
+        mock_pr: MagicMock,
+        mock_status: MagicMock,
+        mock_sleep: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """When bot is COMPLETED but actionable threads exist, COMMENTS_FOUND is returned."""
+        from wade.models.review import PollOutcome, PRReviewStatus, ReviewBotStatus
+        from wade.services.review_service import poll_for_reviews
+
+        mock_pr.return_value = {"state": "OPEN", "number": 99}
+        mock_status.return_value = PRReviewStatus(
+            bot_status=ReviewBotStatus.COMPLETED,
+            actionable_threads=[
+                ReviewThread(comments=[ReviewComment(author="coderabbitai[bot]", body="Fix this")])
+            ],
+        )
+        provider = MagicMock()
+
+        result = poll_for_reviews(provider, tmp_path, 99, "feat/42", bot_settle=0)
+
+        assert result == PollOutcome.COMMENTS_FOUND


### PR DESCRIPTION
Closes #242

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem

When a user selects "Wait for reviews" after `wade implementation-session done`,
`poll_for_reviews()` keeps polling even when a review bot (e.g., CodeRabbit)
has already completed its review with no actionable comments. The user sees
"No new comments yet — next check in 60s..." repeated for up to 10 minutes
(the quiet timeout), even though the PR's checks tab shows
"CodeRabbit — Review completed."

**Root cause**: `detect_coderabbit_review_status()` in `models/review.py`
returns `None` when a CodeRabbit comment exists but contains no "in progress"
or "paused" markers — i.e., when the review is finished. The polling loop
treats `None` bot status as "no bot information" and falls into the
quiet-timeout path instead of recognizing the review is done.

## Proposed Solution

Add a `COMPLETED` state to `ReviewBotStatus` so the system can distinguish
"no bot involved" (`None`) from "bot finished its review" (`COMPLETED`).
When `poll_for_reviews()` sees `COMPLETED` with no actionable threads, it
should stop immediately and show the next-steps menu.

### Changes by file

**`src/wade/models/review.py`**:
- Add `COMPLETED = "completed"` to `ReviewBotStatus` enum
- Add `REVIEW_COMPLETE = "review_complete"` to `PollOutcome` enum
- In `detect_coderabbit_review_status()`: change the final `return None` (line 97)
  to `return ReviewBotStatus.COMPLETED` — when a CodeRabbit comment is found but
  has neither "paused" nor "in progress" markers, the review is complete

**`src/wade/services/review_service.py`**:
- In `poll_for_reviews()`: after the `IN_PROGRESS` check (~line 331), add:
  ```python
  if status.bot_status == ReviewBotStatus.COMPLETED and not status.actionable_threads:
      console.info("Review bot completed — no actionable comments found.")
      return PollOutcome.REVIEW_COMPLETE
  ```
- In `_post_review_lifecycle()`: handle `PollOutcome.REVIEW_COMPLETE` the same
  as `QUIET_TIMEOUT` (show the `_quiet_next_steps_prompt` menu)
- In `_quiet_next_steps_prompt()`: handle `PollOutcome.REVIEW_COMPLETE` from
  nested `poll_for_reviews()` calls the same as `QUIET_TIMEOUT` (re-show menu)

**`src/wade/services/implementation_service.py`**:
- In the "Wait for reviews" branch (~line 963): handle
  `PollOutcome.REVIEW_COMPLETE` the same as `QUIET_TIMEOUT` (show quiet
  next-steps prompt)

### Compatibility notes

- The `is_all_clear` property on `PRReviewStatus` already handles `COMPLETED`
  correctly: it only blocks on `IN_PROGRESS`, so `COMPLETED` passes through
- The generic bot detection in `github.py` (line 607) only fires when
  `bot_status is None`, so returning `COMPLETED` instead of `None` prevents
  false `IN_PROGRESS` detection from stale PENDING review records
- The `start()` function's quiet-exit path (line 491–541) already handles
  `bot_status == None` and `IN_PROGRESS`/`PAUSED` — `COMPLETED` with no
  threads naturally falls through to the "All review comments resolved" success
  message, which is correct

## Tasks
- [ ] Add `COMPLETED` value to `ReviewBotStatus` enum in `models/review.py`
- [ ] Add `REVIEW_COMPLETE` value to `PollOutcome` enum in `models/review.py`
- [ ] Update `detect_coderabbit_review_status()` to return `COMPLETED` when CodeRabbit comment exists without in-progress/paused markers
- [ ] Add early-exit in `poll_for_reviews()` for `COMPLETED` + no actionable threads
- [ ] Handle `REVIEW_COMPLETE` outcome in `_post_review_lifecycle()` and `_quiet_next_steps_prompt()`
- [ ] Handle `REVIEW_COMPLETE` outcome in `implementation_service.py` "Wait for reviews" branch
- [ ] Add unit tests for `detect_coderabbit_review_status()` returning `COMPLETED`
- [ ] Add unit test for `poll_for_reviews()` returning `REVIEW_COMPLETE` when bot is completed

## Acceptance Criteria
- [ ] When CodeRabbit review is completed with no actionable comments, polling stops immediately instead of waiting for the 10-minute quiet timeout
- [ ] When CodeRabbit review is completed WITH actionable comments, existing `COMMENTS_FOUND` behavior is preserved
- [ ] When no CodeRabbit bot is involved (no comment at all), `detect_coderabbit_review_status()` still returns `None`
- [ ] `./scripts/test.sh` passes
- [ ] `./scripts/check.sh` passes

<!-- wade:plan:end -->

## Summary

## What was done

When a user selected "Wait for reviews" after `wade implementation-session done`, the polling loop kept running for the full 10-minute quiet timeout even when CodeRabbit had already completed its review with no actionable comments. This fix adds a `COMPLETED` bot status so the system can distinguish "no bot involved" from "bot finished reviewing" and stop polling immediately.

## Changes

- Added `ReviewBotStatus.COMPLETED` enum value to `models/review.py`
- Added `PollOutcome.REVIEW_COMPLETE` enum value to `models/review.py`
- Updated `detect_coderabbit_review_status()` to return `COMPLETED` (instead of `None`) when a CodeRabbit comment exists but has no in-progress/paused markers
- Added early-exit in `poll_for_reviews()`: when `bot_status == COMPLETED` and no actionable threads, returns `REVIEW_COMPLETE` immediately
- Handled `REVIEW_COMPLETE` in `_post_review_lifecycle()` and `_quiet_next_steps_prompt()` (treated same as `QUIET_TIMEOUT`: show the next-steps menu)
- Handled `REVIEW_COMPLETE` in `implementation_service.py` "Wait for reviews" branch (same treatment)

## Testing

- Updated `test_completed_review_returns_none` → now asserts `COMPLETED` is returned
- Updated `test_uses_latest_comment` → now asserts `COMPLETED` for latest completed comment
- Added `REVIEW_COMPLETE` to `TestPollOutcome.test_all_values_exist`
- Added `TestPollForReviews::test_returns_review_complete_when_bot_finished_no_threads`
- Added `TestPollForReviews::test_completed_bot_with_threads_still_returns_comments_found`
- Added `TestPostReviewLifecycle::test_wait_review_complete_routes_to_quiet_prompt`
- Added `TestQuietNextStepsPrompt::test_review_complete_reshows_menu`
- All 2161 tests pass; lint and mypy clean

## Notes for reviewers

The `is_all_clear` property on `PRReviewStatus` already handles `COMPLETED` correctly — it only blocks on `IN_PROGRESS`, so `COMPLETED` passes through without change. The generic bot detection in `github.py` only fires when `bot_status is None`, so returning `COMPLETED` instead of `None` also prevents false `IN_PROGRESS` detection from stale PENDING review records.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced detection of when code reviews are completed, allowing the system to recognize review finalization with greater accuracy
  * Automatic workflow progression to subsequent steps upon completion detection, eliminating extended polling waits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **14,200** |
| Input tokens | **1,300** |
| Output tokens | **12,900** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `f1a9a3e7-d825-42f9-93e6-c6ba05ac2523` |

<!-- wade:sessions:end -->
