### PR TITLE
feat: overhaul knowledge system with tagging, search, and contextual retrieval

### DIFF
--- a/src/wade/cli/knowledge.py
+++ b/src/wade/cli/knowledge.py
@@ -1,14 +1,17 @@
-"""Knowledge subcommands — add, get, and rate project learnings."""
+"""Knowledge subcommands — add, get, rate, and tag project learnings."""
 
 from __future__ import annotations
 
 import sys
+from typing import Annotated
 
 import typer
 
 knowledge_app = typer.Typer(
     help="Project knowledge management.",
 )
+tag_app = typer.Typer(help="Manage tags on knowledge entries.")
+knowledge_app.add_typer(tag_app, name="tag")
 
 VALID_SESSION_TYPES = ("plan", "implementation")
 
@@ -20,6 +23,9 @@ def add(
     supersedes: str | None = typer.Option(
         None, "--supersedes", help="Entry ID that this new entry supersedes."
     ),
+    tag: Annotated[
+        list[str] | None, typer.Option("--tag", help="Tag for the entry (repeatable).")
+    ] = None,
 ) -> None:
     """Add a knowledge entry (reads content from stdin)."""
     from pathlib import Path
@@ -68,6 +74,7 @@ def add(
             content=content,
             session_type=session,
             issue_ref=issue,
+            tags=tag,
         )
 
         if supersedes:
@@ -95,7 +102,17 @@ def add(
 @knowledge_app.command()
 def get(
     min_score: int | None = typer.Option(
-        None, "--min-score", help="Minimum net score (up - down) to include."
+        None, "--min-score", help="Minimum net score (up - down) to include. Bypasses auto-filter."
+    ),
+    search: str | None = typer.Option(
+        None, "--search", help="Boolean search query (AND, OR, NOT, quotes, parens)."
+    ),
+    tag: Annotated[
+        list[str] | None,
+        typer.Option("--tag", help="Filter by tag (repeatable, OR semantics)."),
+    ] = None,
+    no_filter: bool = typer.Option(
+        False, "--no-filter", help="Disable all score filtering (auto-filter and min-score)."
     ),
 ) -> None:
     """Print the project knowledge file to stdout."""
@@ -112,7 +129,14 @@ def get(
 
     project_root = Path(config.project_root) if config.project_root else Path.cwd()
     try:
-        content = get_annotated_knowledge(project_root, config.knowledge, min_score=min_score)
+        content = get_annotated_knowledge(
+            project_root,
+            config.knowledge,
+            min_score=min_score,
+            search_query=search,
+            filter_tags=tag,
+            no_filter=no_filter,
+        )
     except (ValueError, OSError) as exc:
         console.error(str(exc))
         raise typer.Exit(1) from exc
@@ -224,4 +248,107 @@ def disable() -> None:
         raise typer.Exit(1) from exc
     except OSError as exc:
         console.error(f"Failed to disable knowledge: {exc}")
+        raise typer.Exit(1) from exc
+
+
+@tag_app.command("add")
+def tag_add(
+    entry_id: str = typer.Argument(help="Entry ID to tag."),
+    tag: str = typer.Argument(help="Tag to add."),
+) -> None:
+    """Add a tag to an existing knowledge entry."""
+    from pathlib import Path
+
+    from wade.config.loader import load_config
+    from wade.services.knowledge_service import add_tag_to_entry, resolve_knowledge_path
+    from wade.ui.console import console
+
+    config = load_config()
+    if not config.knowledge.enabled:
+        console.error("Knowledge capture is not enabled. Run `wade init` to enable it.")
+        raise typer.Exit(1)
+
+    project_root = Path(config.project_root) if config.project_root else Path.cwd()
+    try:
+        knowledge_path = resolve_knowledge_path(project_root, config.knowledge)
+        add_tag_to_entry(knowledge_path, entry_id, tag)
+        console.success(f"Tag '{tag}' added to entry {entry_id}")
+    except typer.Exit:
+        raise
+    except ValueError as exc:
+        console.error(str(exc))
+        raise typer.Exit(1) from exc
+    except OSError as exc:
+        console.error(str(exc))
+        raise typer.Exit(1) from exc
+
+
+@tag_app.command("remove")
+def tag_remove(
+    entry_id: str = typer.Argument(help="Entry ID to remove tag from."),
+    tag: str = typer.Argument(help="Tag to remove."),
+) -> None:
+    """Remove a tag from an existing knowledge entry."""
+    from pathlib import Path
+
+    from wade.config.loader import load_config
+    from wade.services.knowledge_service import remove_tag_from_entry, resolve_knowledge_path
+    from wade.ui.console import console
+
+    config = load_config()
+    if not config.knowledge.enabled:
+        console.error("Knowledge capture is not enabled. Run `wade init` to enable it.")
+        raise typer.Exit(1)
+
+    project_root = Path(config.project_root) if config.project_root else Path.cwd()
+    try:
+        knowledge_path = resolve_knowledge_path(project_root, config.knowledge)
+        remove_tag_from_entry(knowledge_path, entry_id, tag)
+        console.success(f"Tag '{tag}' removed from entry {entry_id}")
+    except typer.Exit:
+        raise
+    except ValueError as exc:
+        console.error(str(exc))
+        raise typer.Exit(1) from exc
+    except OSError as exc:
+        console.error(str(exc))
+        raise typer.Exit(1) from exc
+
+
+@tag_app.command("list")
+def tag_list(
+    entry_id: str | None = typer.Argument(None, help="Entry ID (omit to list all tags)."),
+) -> None:
+    """List tags — all unique tags or tags for a specific entry."""
+    from pathlib import Path
+
+    from wade.config.loader import load_config
+    from wade.services.knowledge_service import list_tags, resolve_knowledge_path
+    from wade.ui.console import console
+
+    config = load_config()
+    if not config.knowledge.enabled:
+        console.error("Knowledge capture is not enabled. Run `wade init` to enable it.")
+        raise typer.Exit(1)
+
+    project_root = Path(config.project_root) if config.project_root else Path.cwd()
+    try:
+        knowledge_path = resolve_knowledge_path(project_root, config.knowledge)
+        result = list_tags(knowledge_path, entry_id=entry_id)
+        if isinstance(result, list):
+            if not result:
+                print("No tags found.", file=sys.stderr)
+            else:
+                for t in result:
+                    print(t)
+        else:
+            for t in result:
+                print(t)
+    except typer.Exit:
+        raise
+    except ValueError as exc:
+        console.error(str(exc))
+        raise typer.Exit(1) from exc
+    except OSError as exc:
+        console.error(str(exc))
         raise typer.Exit(1) from exc

--- a/src/wade/cli/knowledge.py
+++ b/src/wade/cli/knowledge.py
@@ -335,12 +335,8 @@ def tag_list(
     try:
         knowledge_path = resolve_knowledge_path(project_root, config.knowledge)
         result = list_tags(knowledge_path, entry_id=entry_id)
-        if isinstance(result, list):
-            if not result:
-                print("No tags found.", file=sys.stderr)
-            else:
-                for t in result:
-                    print(t)
+        if not result:
+            print("No tags found.", file=sys.stderr)
         else:
             for t in result:
                 print(t)

--- a/src/wade/services/knowledge_search.py
+++ b/src/wade/services/knowledge_search.py
@@ -1,0 +1,236 @@
+"""Boolean search parser and evaluator for knowledge entries.
+
+Supports: AND, OR, NOT, "quoted phrases", parentheses.
+Default operator for bare spaces is AND.
+All matching is case-insensitive.
+
+Grammar (recursive descent):
+    expression = or_expr
+    or_expr    = and_expr ("OR" and_expr)*
+    and_expr   = not_expr (("AND" | implicit) not_expr)*
+    not_expr   = "NOT" primary | primary
+    primary    = "(" expression ")" | PHRASE | TERM
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import TypeAlias
+
+from pydantic import BaseModel
+
+
+class TokenKind(StrEnum):
+    AND = "AND"
+    OR = "OR"
+    NOT = "NOT"
+    LPAREN = "("
+    RPAREN = ")"
+    PHRASE = "PHRASE"
+    TERM = "TERM"
+    EOF = "EOF"
+
+
+class Token(BaseModel, frozen=True):
+    kind: TokenKind
+    value: str = ""
+
+
+# AST nodes
+
+
+class TermNode(BaseModel, frozen=True):
+    """Matches a single term (case-insensitive word boundary)."""
+
+    term: str
+
+
+class PhraseNode(BaseModel, frozen=True):
+    """Matches an exact phrase (case-insensitive)."""
+
+    phrase: str
+
+
+class AndNode(BaseModel, frozen=True):
+    """Both children must match."""
+
+    left: QueryNode
+    right: QueryNode
+
+
+class OrNode(BaseModel, frozen=True):
+    """Either child must match."""
+
+    left: QueryNode
+    right: QueryNode
+
+
+class NotNode(BaseModel, frozen=True):
+    """Child must NOT match."""
+
+    child: QueryNode
+
+
+QueryNode: TypeAlias = TermNode | PhraseNode | AndNode | OrNode | NotNode
+
+# Update forward references for recursive models
+AndNode.model_rebuild()
+OrNode.model_rebuild()
+NotNode.model_rebuild()
+
+
+_KEYWORD_RE = re.compile(r"^(AND|OR|NOT)$", re.IGNORECASE)
+
+
+def _tokenize(query: str) -> list[Token]:
+    """Tokenize a boolean search query string."""
+    tokens: list[Token] = []
+    i = 0
+    while i < len(query):
+        ch = query[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch == "(":
+            tokens.append(Token(kind=TokenKind.LPAREN, value="("))
+            i += 1
+        elif ch == ")":
+            tokens.append(Token(kind=TokenKind.RPAREN, value=")"))
+            i += 1
+        elif ch == '"':
+            # Quoted phrase
+            end = query.find('"', i + 1)
+            if end == -1:
+                # Unterminated quote — treat rest as phrase
+                phrase = query[i + 1 :]
+                tokens.append(Token(kind=TokenKind.PHRASE, value=phrase))
+                i = len(query)
+            else:
+                phrase = query[i + 1 : end]
+                tokens.append(Token(kind=TokenKind.PHRASE, value=phrase))
+                i = end + 1
+        else:
+            # Word token
+            end = i
+            while end < len(query) and not query[end].isspace() and query[end] not in '()"':
+                end += 1
+            word = query[i:end]
+            if word.upper() == "AND":
+                tokens.append(Token(kind=TokenKind.AND, value="AND"))
+            elif word.upper() == "OR":
+                tokens.append(Token(kind=TokenKind.OR, value="OR"))
+            elif word.upper() == "NOT":
+                tokens.append(Token(kind=TokenKind.NOT, value="NOT"))
+            else:
+                tokens.append(Token(kind=TokenKind.TERM, value=word))
+            i = end
+    tokens.append(Token(kind=TokenKind.EOF))
+    return tokens
+
+
+class _Parser:
+    """Recursive descent parser for boolean search queries."""
+
+    def __init__(self, tokens: list[Token]) -> None:
+        self._tokens = tokens
+        self._pos = 0
+
+    def _peek(self) -> Token:
+        return self._tokens[self._pos]
+
+    def _advance(self) -> Token:
+        tok = self._tokens[self._pos]
+        self._pos += 1
+        return tok
+
+    def _expect(self, kind: TokenKind) -> Token:
+        tok = self._advance()
+        if tok.kind != kind:
+            raise ValueError(f"Expected {kind}, got {tok.kind} ({tok.value!r})")
+        return tok
+
+    def parse(self) -> QueryNode:
+        node = self._or_expr()
+        if self._peek().kind != TokenKind.EOF:
+            raise ValueError(f"Unexpected token: {self._peek().value!r}")
+        return node
+
+    def _or_expr(self) -> QueryNode:
+        left = self._and_expr()
+        while self._peek().kind == TokenKind.OR:
+            self._advance()
+            right = self._and_expr()
+            left = OrNode(left=left, right=right)
+        return left
+
+    def _and_expr(self) -> QueryNode:
+        left = self._not_expr()
+        while True:
+            peek = self._peek()
+            if peek.kind == TokenKind.AND:
+                self._advance()
+                right = self._not_expr()
+                left = AndNode(left=left, right=right)
+            elif peek.kind in (TokenKind.TERM, TokenKind.PHRASE, TokenKind.NOT, TokenKind.LPAREN):
+                # Implicit AND
+                right = self._not_expr()
+                left = AndNode(left=left, right=right)
+            else:
+                break
+        return left
+
+    def _not_expr(self) -> QueryNode:
+        if self._peek().kind == TokenKind.NOT:
+            self._advance()
+            child = self._primary()
+            return NotNode(child=child)
+        return self._primary()
+
+    def _primary(self) -> QueryNode:
+        tok = self._peek()
+        if tok.kind == TokenKind.LPAREN:
+            self._advance()
+            node = self._or_expr()
+            self._expect(TokenKind.RPAREN)
+            return node
+        if tok.kind == TokenKind.PHRASE:
+            self._advance()
+            return PhraseNode(phrase=tok.value)
+        if tok.kind == TokenKind.TERM:
+            self._advance()
+            return TermNode(term=tok.value)
+        raise ValueError(f"Unexpected token: {tok.kind} ({tok.value!r})")
+
+
+def parse_query(query: str) -> QueryNode:
+    """Parse a boolean search query string into an AST."""
+    tokens = _tokenize(query)
+    # Handle empty query
+    if len(tokens) == 1 and tokens[0].kind == TokenKind.EOF:
+        return TermNode(term="")
+    return _Parser(tokens).parse()
+
+
+def evaluate_query(node: QueryNode, text: str) -> bool:
+    """Evaluate a parsed query against text (case-insensitive)."""
+    text_lower = text.lower()
+    return _eval(node, text_lower)
+
+
+def _eval(node: QueryNode, text_lower: str) -> bool:
+    if isinstance(node, TermNode):
+        if not node.term:
+            return True  # empty query matches everything
+        return node.term.lower() in text_lower
+    if isinstance(node, PhraseNode):
+        if not node.phrase:
+            return True
+        return node.phrase.lower() in text_lower
+    if isinstance(node, AndNode):
+        return _eval(node.left, text_lower) and _eval(node.right, text_lower)
+    if isinstance(node, OrNode):
+        return _eval(node.left, text_lower) or _eval(node.right, text_lower)
+    if isinstance(node, NotNode):
+        return not _eval(node.child, text_lower)
+    return False  # pragma: no cover

--- a/src/wade/services/knowledge_search.py
+++ b/src/wade/services/knowledge_search.py
@@ -14,7 +14,6 @@ Grammar (recursive descent):
 
 from __future__ import annotations
 
-import re
 from enum import StrEnum
 from typing import TypeAlias
 
@@ -78,9 +77,6 @@ QueryNode: TypeAlias = TermNode | PhraseNode | AndNode | OrNode | NotNode
 AndNode.model_rebuild()
 OrNode.model_rebuild()
 NotNode.model_rebuild()
-
-
-_KEYWORD_RE = re.compile(r"^(AND|OR|NOT)$", re.IGNORECASE)
 
 
 def _tokenize(query: str) -> list[Token]:

--- a/src/wade/services/knowledge_service.py
+++ b/src/wade/services/knowledge_service.py
@@ -590,7 +590,7 @@ def remove_tag_from_entry(
 def list_tags(
     knowledge_path: Path,
     entry_id: str | None = None,
-) -> list[str] | dict[str, list[str]]:
+) -> list[str]:
     """List tags for a specific entry, or all unique tags across the knowledge file."""
     if not knowledge_path.is_file():
         if entry_id:

--- a/src/wade/services/knowledge_service.py
+++ b/src/wade/services/knowledge_service.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import fcntl
+import math
 import re
+import statistics
 import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -24,12 +26,16 @@ Read this at the start of every session. Add new entries via `wade knowledge add
 ---
 """
 
-# Regex to match entry headings: ## <id> | <date> | <session_type> [+N/-M]
-# Also matches old-style headings without IDs: ## <date> | <session_type>
+# Regex to match entry headings: ## <id> | <date> | <rest> [+N/-M]
+# Also matches old-style headings without IDs: ## <date> | <rest>
 # ID can be 8-char hex (legacy), alphanumeric with hyphens and underscores, or absent.
 _ENTRY_HEADING_RE = re.compile(
     r"^## (?:([a-zA-Z0-9_-]+) \| )?(\d{4}-\d{2}-\d{2}) \| (.+?)(?:\s+\[.*\])?\s*$"
 )
+
+# Tag validation: lowercase kebab-case, max 30 chars
+_TAG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_TAG_MAX_LEN = 30
 
 
 class KnowledgeEntry(BaseModel, frozen=True):
@@ -45,6 +51,7 @@ class ParsedEntry(BaseModel, frozen=True):
     entry_id: str | None
     date: str
     heading_rest: str
+    tags: list[str] = []
     content: str
     raw: str
 
@@ -60,6 +67,35 @@ class EntryRating(BaseModel):
 def _generate_entry_id() -> str:
     """Generate a short entry ID (first 8 hex chars of uuid4)."""
     return uuid.uuid4().hex[:8]
+
+
+def validate_tag(tag: str) -> str | None:
+    """Validate a tag string. Returns error message or None if valid."""
+    if not tag:
+        return "Tag cannot be empty"
+    if len(tag) > _TAG_MAX_LEN:
+        return f"Tag '{tag}' exceeds {_TAG_MAX_LEN} characters"
+    if not _TAG_RE.match(tag):
+        return f"Tag '{tag}' must be lowercase kebab-case (alphanumeric and hyphens)"
+    return None
+
+
+def _parse_tags_from_heading_rest(heading_rest: str) -> list[str]:
+    """Extract tags from the heading_rest field.
+
+    heading_rest examples:
+      "plan" → []
+      "plan | tags: git, worktree" → ["git", "worktree"]
+      "plan | tags: git, worktree | Issue #7" → ["git", "worktree"]
+    """
+    parts = [p.strip() for p in heading_rest.split("|")]
+    for part in parts:
+        if part.startswith("tags:"):
+            raw_tags = part[5:].strip()
+            if not raw_tags:
+                return []
+            return [t.strip() for t in raw_tags.split(",") if t.strip()]
+    return []
 
 
 def resolve_knowledge_path(project_root: Path, config: KnowledgeConfig) -> Path:
@@ -145,11 +181,13 @@ def parse_entries(text: str) -> list[ParsedEntry]:
             if content_text.endswith("---"):
                 content_text = content_text[:-3].strip()
 
+            tags = _parse_tags_from_heading_rest(heading_rest)
             entries.append(
                 ParsedEntry(
                     entry_id=entry_id,
                     date=date,
                     heading_rest=heading_rest,
+                    tags=tags,
                     content=content_text,
                     raw=raw_block,
                 )
@@ -266,15 +304,65 @@ def record_supersede(
     _read_modify_write_ratings(ratings_path, _modify)
 
 
+def compute_auto_filter_threshold(
+    entries: list[ParsedEntry],
+    ratings: dict[str, EntryRating],
+) -> float | None:
+    """Compute statistical auto-filter threshold.
+
+    Returns None if there isn't enough data (fewer than 3 entries with >= 5 votes).
+    """
+    # Collect net scores for entries with >= 5 total votes
+    qualifying_scores: list[float] = []
+    for entry in entries:
+        if not entry.entry_id:
+            continue
+        r = ratings.get(entry.entry_id)
+        if not r:
+            continue
+        total_votes = r.up + r.down
+        if total_votes >= 5:
+            qualifying_scores.append(float(r.up - r.down))
+
+    if len(qualifying_scores) < 3:
+        return None
+
+    mean = statistics.mean(qualifying_scores)
+    if len(qualifying_scores) < 2:
+        return mean  # pragma: no cover — already checked >= 3
+    stdev = statistics.stdev(qualifying_scores)
+
+    # p10: 10th percentile
+    sorted_scores = sorted(qualifying_scores)
+    p10_idx = math.ceil(len(sorted_scores) * 0.1) - 1
+    p10_idx = max(0, p10_idx)
+    p10 = sorted_scores[p10_idx]
+
+    return max(p10, mean - 2 * stdev)
+
+
 def get_annotated_knowledge(
     project_root: Path,
     config: KnowledgeConfig,
     min_score: int | None = None,
+    search_query: str | None = None,
+    filter_tags: list[str] | None = None,
+    no_filter: bool = False,
 ) -> str | None:
     """Read knowledge file, annotate headings with scores, and optionally filter.
 
+    Filtering modes (mutually exclusive, checked in order):
+    - ``no_filter=True``: no score filtering at all
+    - ``min_score`` set: hard cutoff on net score
+    - default: statistical auto-filter (prunes low-rated entries with sufficient votes)
+
+    ``search_query`` and ``filter_tags`` combine with OR: an entry passes if it
+    matches the search OR has any of the requested tags.
+
     Returns None if the knowledge file does not exist.
     """
+    from wade.services.knowledge_search import evaluate_query, parse_query
+
     path = resolve_knowledge_path(project_root, config)
     if not path.exists():
         return None
@@ -290,6 +378,14 @@ def get_annotated_knowledge(
     ratings_path = resolve_ratings_path(path)
     ratings = read_ratings(ratings_path)
 
+    # Pre-parse search query
+    parsed_query = parse_query(search_query) if search_query else None
+
+    # Compute auto-filter threshold if using default filtering
+    auto_threshold: float | None = None
+    if min_score is None and not no_filter:
+        auto_threshold = compute_auto_filter_threshold(entries, ratings)
+
     # Build the header (everything before the first entry)
     first_entry_pos = text.find(entries[0].raw)
     header = text[:first_entry_pos] if first_entry_pos > 0 else ""
@@ -300,11 +396,34 @@ def get_annotated_knowledge(
         up = entry_rating.up if entry_rating else 0
         down = entry_rating.down if entry_rating else 0
         net_score = up - down
+        total_votes = up + down
         should_annotate = entry.entry_id is not None
 
-        # Apply min_score filter
-        if min_score is not None and net_score < min_score:
-            continue
+        # Score filtering
+        if not no_filter:
+            if min_score is not None:
+                # Hard cutoff mode
+                if net_score < min_score:
+                    continue
+            elif (
+                auto_threshold is not None
+                and entry.entry_id is not None
+                and total_votes >= 5
+                and net_score < auto_threshold
+            ):
+                continue
+
+        # Search/tag filtering (OR semantics)
+        if parsed_query is not None or filter_tags:
+            matches_search = False
+            matches_tag = False
+            if parsed_query is not None:
+                searchable = entry.raw.split("\n")[0] + "\n" + entry.content
+                matches_search = evaluate_query(parsed_query, searchable)
+            if filter_tags:
+                matches_tag = bool(set(entry.tags) & set(filter_tags))
+            if not matches_search and not matches_tag:
+                continue
 
         # Re-build the heading with score annotation
         heading_match = _ENTRY_HEADING_RE.match(entry.raw.split("\n")[0])
@@ -329,11 +448,18 @@ def append_knowledge(
     content: str,
     session_type: str,
     issue_ref: str | None = None,
+    tags: list[str] | None = None,
 ) -> KnowledgeEntry:
     """Format and append a knowledge entry to the knowledge file.
 
     Returns a KnowledgeEntry with the path and generated entry ID.
     """
+    if tags:
+        for tag in tags:
+            err = validate_tag(tag)
+            if err:
+                raise ValueError(err)
+
     path = ensure_knowledge_file(project_root, config)
 
     existing_ids = {
@@ -345,14 +471,145 @@ def append_knowledge(
     while entry_id in existing_ids:
         entry_id = _generate_entry_id()
     timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    tags_part = f" | tags: {', '.join(tags)}" if tags else ""
     issue_part = f" | Issue #{issue_ref}" if issue_ref else ""
-    header = f"## {entry_id} | {timestamp} | {session_type}{issue_part}"
+    header = f"## {entry_id} | {timestamp} | {session_type}{tags_part}{issue_part}"
 
     entry = f"\n{header}\n\n{content.strip()}\n\n---\n"
     with path.open("a", encoding="utf-8") as f:
         f.write(entry)
 
     return KnowledgeEntry(path=path, entry_id=entry_id)
+
+
+def _rebuild_heading_line(
+    entry_id: str | None,
+    date: str,
+    session_type: str,
+    tags: list[str],
+    issue_part: str,
+) -> str:
+    """Reconstruct a heading line from its components."""
+    id_part = f"{entry_id} | " if entry_id else ""
+    tags_part = f" | tags: {', '.join(tags)}" if tags else ""
+    issue_str = f" | {issue_part}" if issue_part else ""
+    return f"## {id_part}{date} | {session_type}{tags_part}{issue_str}"
+
+
+def _decompose_heading_rest(heading_rest: str) -> tuple[str, list[str], str]:
+    """Split heading_rest into (session_type, tags, issue_part).
+
+    Returns the session type, list of tags, and the issue part (e.g. "Issue #7")
+    or empty string if no issue.
+    """
+    parts = [p.strip() for p in heading_rest.split("|")]
+    session_type = parts[0]
+    tags: list[str] = []
+    issue_part = ""
+    for part in parts[1:]:
+        if part.startswith("tags:"):
+            raw_tags = part[5:].strip()
+            tags = [t.strip() for t in raw_tags.split(",") if t.strip()]
+        elif part.startswith("Issue"):
+            issue_part = part
+    return session_type, tags, issue_part
+
+
+def add_tag_to_entry(
+    knowledge_path: Path,
+    entry_id: str,
+    tag: str,
+) -> None:
+    """Add a tag to an existing entry's heading (in-place file edit with locking)."""
+    err = validate_tag(tag)
+    if err:
+        raise ValueError(err)
+
+    with knowledge_path.open("r+", encoding="utf-8") as fd:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            content = fd.read()
+            entries = parse_entries(content)
+            target = next((e for e in entries if e.entry_id == entry_id), None)
+            if target is None:
+                raise ValueError(f"Entry ID '{entry_id}' not found")
+
+            if tag in target.tags:
+                return  # Already has the tag
+
+            session_type, tags, issue_part = _decompose_heading_rest(target.heading_rest)
+            tags.append(tag)
+            new_heading = _rebuild_heading_line(
+                entry_id, target.date, session_type, tags, issue_part
+            )
+
+            old_heading_line = target.raw.split("\n")[0]
+            content = content.replace(old_heading_line, new_heading, 1)
+
+            fd.seek(0)
+            fd.truncate()
+            fd.write(content)
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def remove_tag_from_entry(
+    knowledge_path: Path,
+    entry_id: str,
+    tag: str,
+) -> None:
+    """Remove a tag from an existing entry's heading (in-place file edit with locking)."""
+    with knowledge_path.open("r+", encoding="utf-8") as fd:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            content = fd.read()
+            entries = parse_entries(content)
+            target = next((e for e in entries if e.entry_id == entry_id), None)
+            if target is None:
+                raise ValueError(f"Entry ID '{entry_id}' not found")
+
+            if tag not in target.tags:
+                raise ValueError(f"Tag '{tag}' not found on entry {entry_id}")
+
+            session_type, tags, issue_part = _decompose_heading_rest(target.heading_rest)
+            tags.remove(tag)
+            new_heading = _rebuild_heading_line(
+                entry_id, target.date, session_type, tags, issue_part
+            )
+
+            old_heading_line = target.raw.split("\n")[0]
+            content = content.replace(old_heading_line, new_heading, 1)
+
+            fd.seek(0)
+            fd.truncate()
+            fd.write(content)
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def list_tags(
+    knowledge_path: Path,
+    entry_id: str | None = None,
+) -> list[str] | dict[str, list[str]]:
+    """List tags for a specific entry, or all unique tags across the knowledge file."""
+    if not knowledge_path.is_file():
+        if entry_id:
+            raise ValueError(f"Knowledge file not found: {knowledge_path}")
+        return []
+
+    text = knowledge_path.read_text(encoding="utf-8")
+    entries = parse_entries(text)
+
+    if entry_id:
+        target = next((e for e in entries if e.entry_id == entry_id), None)
+        if target is None:
+            raise ValueError(f"Entry ID '{entry_id}' not found")
+        return target.tags
+
+    all_tags: set[str] = set()
+    for entry in entries:
+        all_tags.update(entry.tags)
+    return sorted(all_tags)
 
 
 def enable_knowledge(project_root: Path, path: str | None = None) -> None:

--- a/src/wade/services/knowledge_service.py
+++ b/src/wade/services/knowledge_service.py
@@ -332,7 +332,11 @@ def compute_auto_filter_threshold(
         return mean  # pragma: no cover — already checked >= 3
     stdev = statistics.stdev(qualifying_scores)
 
-    # p10: 10th percentile
+    # p10: 10th percentile.  math.ceil ensures we round up to the nearest
+    # integer index, then -1 converts to 0-based.  For small samples (<=10
+    # entries) this yields index 0 (the minimum) — intentionally conservative
+    # so we don't over-filter when data is scarce.  max(0, ...) guards against
+    # negative indices that could arise from floating-point edge cases.
     sorted_scores = sorted(qualifying_scores)
     p10_idx = math.ceil(len(sorted_scores) * 0.1) - 1
     p10_idx = max(0, p10_idx)
@@ -544,7 +548,15 @@ def add_tag_to_entry(
             )
 
             old_heading_line = target.raw.split("\n")[0]
-            content = content.replace(old_heading_line, new_heading, 1)
+            entry_start = content.find(target.raw)
+            if entry_start != -1:
+                content = (
+                    content[:entry_start]
+                    + new_heading
+                    + content[entry_start + len(old_heading_line) :]
+                )
+            else:
+                content = content.replace(old_heading_line, new_heading, 1)
 
             fd.seek(0)
             fd.truncate()
@@ -578,7 +590,15 @@ def remove_tag_from_entry(
             )
 
             old_heading_line = target.raw.split("\n")[0]
-            content = content.replace(old_heading_line, new_heading, 1)
+            entry_start = content.find(target.raw)
+            if entry_start != -1:
+                content = (
+                    content[:entry_start]
+                    + new_heading
+                    + content[entry_start + len(old_heading_line) :]
+                )
+            else:
+                content = content.replace(old_heading_line, new_heading, 1)
 
             fd.seek(0)
             fd.truncate()

--- a/src/wade/skills/installer.py
+++ b/src/wade/skills/installer.py
@@ -85,7 +85,12 @@ SKILL_FILES: dict[str, list[str]] = {
 }
 
 # Skills that should always be overwritten on update
-ALWAYS_OVERWRITE = {"plan-session", "implementation-session", "review-pr-comments-session"}
+ALWAYS_OVERWRITE = {
+    "plan-session",
+    "implementation-session",
+    "review-pr-comments-session",
+    "knowledge",
+}
 
 # Skills whose SKILL.md files contain placeholder strings (see _SKILL_PARTIALS) that
 # must be expanded at install time.  These cannot be installed as plain directory
@@ -135,10 +140,10 @@ HOOK_CONFIG_FILES = [
 
 # --- Command-to-skill mapping: which skills each session type needs ---
 
-PLAN_SKILLS: list[str] = ["plan-session", "task", "deps"]
+PLAN_SKILLS: list[str] = ["plan-session", "task", "deps", "knowledge"]
 DEPS_SKILLS: list[str] = ["deps"]
-IMPLEMENT_SKILLS: list[str] = ["implementation-session", "task"]
-REVIEW_SKILLS: list[str] = ["review-pr-comments-session", "task"]
+IMPLEMENT_SKILLS: list[str] = ["implementation-session", "task", "knowledge"]
+REVIEW_SKILLS: list[str] = ["review-pr-comments-session", "task", "knowledge"]
 
 
 def get_worktree_gitignore_entries() -> list[str]:

--- a/src/wade/skills/installer.py
+++ b/src/wade/skills/installer.py
@@ -79,6 +79,7 @@ SKILL_FILES: dict[str, list[str]] = {
     "implementation-session": ["SKILL.md"],
     "review-pr-comments-session": ["SKILL.md"],
     "deps": ["SKILL.md"],
+    "knowledge": ["SKILL.md"],
 }
 
 # Skills that should always be overwritten on update

--- a/templates/skills/implementation-session/SKILL.md
+++ b/templates/skills/implementation-session/SKILL.md
@@ -45,30 +45,12 @@ dependency analysis hooks.
 
 ## Project Knowledge
 
-Run `wade knowledge get` at the start of this session to read project context
-from previous planning and implementation sessions.
-- If knowledge is disabled, it exits with code 1.
-- If the file doesn't exist, it exits with code 0 and prints an informational message to stderr.
+Read @.claude/skills/knowledge/SKILL.md for knowledge operations (search,
+tagging, rating, adding entries).
 
-After reading knowledge entries, rate entries that were useful or unhelpful:
-```bash
-wade knowledge rate <entry-id> up    # entry was useful
-wade knowledge rate <entry-id> down  # entry was outdated or misleading
-```
-
-Before writing `PR-SUMMARY.md`, if knowledge capture is enabled
-(check `.wade.yml` → `knowledge.enabled`) and you discovered important project
-patterns, conventions, or gotchas during this session, capture them:
-
-```bash
-echo "Your learnings here" | wade knowledge add --session implementation --issue <number>
-```
-
-If a new entry corrects or replaces an existing one, use `--supersedes`:
-```bash
-echo "Corrected info" | wade knowledge add --session implementation --issue <number> --supersedes <old-entry-id>
-```
-
+At the start of this session, search for knowledge relevant to your task
+(do not dump all entries). Before writing `PR-SUMMARY.md`, capture important
+learnings if knowledge is enabled (`.wade.yml` → `knowledge.enabled`).
 Then commit the updated knowledge file alongside your other changes.
 
 ## First action: check your context
@@ -307,7 +289,7 @@ create a GitHub Issue from it:
 
 The following skill directories under `.claude/skills/` are **managed by wade**
 and must not be modified, committed, or deleted:
-`plan-session`, `implementation-session`, `review-pr-comments-session`, `task`, `deps`.
+`plan-session`, `implementation-session`, `review-pr-comments-session`, `task`, `deps`, `knowledge`.
 
 Wade also installs cross-tool alias symlinks per-session in worktrees:
 `.github/skills`, `.agents/skills`, `.gemini/skills`, `.cursor/skills`.

--- a/templates/skills/implementation-session/SKILL.md
+++ b/templates/skills/implementation-session/SKILL.md
@@ -292,7 +292,7 @@ mechanism to populate a checklist with the workflow steps below. This ensures
 you complete every mandatory step and the user can track progress.
 
 - [ ] Run `wade implementation-session check`
-- [ ] Read project knowledge (`wade knowledge get`)
+- [ ] Search relevant knowledge (`wade knowledge get --search <topic>` or `wade knowledge get --tag <tag>`)
 - [ ] Implementation tasks from PLAN.md (add each task as a separate item)
 - [ ] Run `wade review implementation` (if `review_implementation.enabled` is not `false`)
 - [ ] Capture knowledge (`wade knowledge add`) (if knowledge capture is enabled)

--- a/templates/skills/knowledge/SKILL.md
+++ b/templates/skills/knowledge/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: knowledge
+description: >
+  Instructions for contextual knowledge retrieval, tagging, search, and rating.
+  Referenced by plan-session and implementation-session skills.
+---
+
+# Knowledge Operations
+
+## Contextual retrieval
+
+Do **not** dump all knowledge at session start. Instead, search for entries
+relevant to your current task:
+
+```bash
+wade knowledge get --search "worktree safety"
+wade knowledge get --tag git
+wade knowledge get --search "error handling" --tag testing
+```
+
+When both `--search` and `--tag` are provided, entries matching **either**
+criterion are returned (OR semantics).
+
+Only fall back to `wade knowledge get` (no filters) if you need a broad overview
+or the knowledge base is small.
+
+## Search syntax
+
+The `--search` flag accepts boolean queries:
+
+| Syntax | Meaning |
+|--------|---------|
+| `term` | Entries containing the term (case-insensitive) |
+| `"exact phrase"` | Entries containing the exact phrase |
+| `term1 AND term2` | Both terms must appear |
+| `term1 OR term2` | Either term may appear |
+| `NOT term` | Exclude entries containing the term |
+| `(a OR b) AND c` | Parentheses for grouping |
+| `worktree safety` | Bare space = implicit AND |
+
+## Tagging
+
+### When to tag
+
+Tag entries when they relate to specific topics that future sessions might
+search for. Good tags describe the **domain** (e.g. `git`, `testing`,
+`ci`, `error-handling`), not the action (avoid `fix`, `add`, `update`).
+
+### Tag format
+
+- Lowercase kebab-case: `git`, `worktree-safety`, `error-handling`
+- Alphanumeric + hyphens only, no spaces
+- Max 30 characters per tag
+
+### Adding tags
+
+When creating an entry:
+```bash
+echo "Learning" | wade knowledge add --session plan --tag git --tag worktree
+```
+
+Managing tags on existing entries:
+```bash
+wade knowledge tag add <entry-id> <tag>
+wade knowledge tag remove <entry-id> <tag>
+wade knowledge tag list              # all unique tags
+wade knowledge tag list <entry-id>   # tags for one entry
+```
+
+## Rating
+
+Rate entries you read — this feeds the auto-filter that prunes low-quality
+entries over time:
+
+```bash
+wade knowledge rate <entry-id> up    # entry was useful
+wade knowledge rate <entry-id> down  # entry was outdated or misleading
+```
+
+## Adding entries
+
+Capture important patterns, conventions, or gotchas discovered during a session:
+
+```bash
+echo "Your learnings here" | wade knowledge add --session <type> --issue <number> --tag <topic>
+```
+
+If a new entry corrects or replaces an existing one:
+```bash
+echo "Corrected info" | wade knowledge add --session <type> --supersedes <old-entry-id>
+```
+
+## Filtering
+
+By default, entries with enough negative votes are automatically pruned
+(statistical auto-filter). Override with:
+
+- `--min-score N` — hard cutoff on net score (bypasses auto-filter)
+- `--no-filter` — show everything, no score filtering

--- a/templates/skills/plan-session/SKILL.md
+++ b/templates/skills/plan-session/SKILL.md
@@ -153,7 +153,7 @@ At the start of this session, use your tool's native task/todo tracking
 mechanism to populate a checklist with the workflow steps below. This ensures
 you complete every mandatory step and the user can track progress.
 
-- [ ] Read project knowledge (`wade knowledge get`)
+- [ ] Search relevant knowledge (`wade knowledge get --search <topic>` or `wade knowledge get --tag <tag>`)
 - [ ] Plan the feature with the user
 - [ ] Write plan file(s) to the temp directory
 - [ ] Run `wade review plan` for each plan file (if review is enabled)

--- a/templates/skills/plan-session/SKILL.md
+++ b/templates/skills/plan-session/SKILL.md
@@ -46,31 +46,14 @@ dependency analysis hooks.
 
 ## Project Knowledge
 
-Run `wade knowledge get` at the start of this session to read project context
-from previous planning and implementation sessions.
-- If knowledge is disabled, it exits with code 1.
-- If the file doesn't exist, it exits with code 0 and prints an informational message to stderr.
+Read @.claude/skills/knowledge/SKILL.md for knowledge operations (search,
+tagging, rating, adding entries).
 
-After reading knowledge entries, rate entries that were useful or unhelpful:
-```bash
-wade knowledge rate <entry-id> up    # entry was useful
-wade knowledge rate <entry-id> down  # entry was outdated or misleading
-```
+At the start of this session, search for knowledge relevant to your task
+(do not dump all entries). Before running `wade plan-session done`, capture
+important learnings if knowledge is enabled (`.wade.yml` → `knowledge.enabled`).
 
-Before running `wade plan-session done`, if knowledge capture is enabled
-(check `.wade.yml` → `knowledge.enabled`) and you discovered important project
-patterns, conventions, or gotchas during this session, capture them:
-
-```bash
-echo "Your learnings here" | wade knowledge add --session plan
-```
-
-If a new entry corrects or replaces an existing one, use `--supersedes`:
-```bash
-echo "Corrected info" | wade knowledge add --session plan --supersedes <old-entry-id>
-```
-
-The `--issue` flag is optional (issue numbers may not exist yet during planning).
+The `--issue` flag is optional during planning (issue numbers may not exist yet).
 Running `wade knowledge add` is allowed even though this is a planning session.
 
 ## Your role

--- a/tests/integration/test_knowledge.py
+++ b/tests/integration/test_knowledge.py
@@ -234,21 +234,24 @@ class TestKnowledgeSearchWorkflow:
         monkeypatch.chdir(tmp_wade_project)
 
         # Add entries with different tags and content
-        runner.invoke(
+        result = runner.invoke(
             app,
             ["knowledge", "add", "--session", "plan", "--tag", "git"],
             input="Git worktree is useful for isolation.\n",
         )
-        runner.invoke(
+        assert result.exit_code == 0
+        result = runner.invoke(
             app,
             ["knowledge", "add", "--session", "plan", "--tag", "testing"],
             input="Always write tests for new features.\n",
         )
-        runner.invoke(
+        assert result.exit_code == 0
+        result = runner.invoke(
             app,
             ["knowledge", "add", "--session", "plan"],
             input="Docker is unrelated.\n",
         )
+        assert result.exit_code == 0
 
         # Search by text
         result = runner.invoke(app, ["knowledge", "get", "--search", "worktree", "--no-filter"])

--- a/tests/integration/test_knowledge.py
+++ b/tests/integration/test_knowledge.py
@@ -171,3 +171,103 @@ class TestKnowledgeRate:
 
         assert result.exit_code == 1
         assert "must be inside project root" in result.output
+
+
+class TestKnowledgeTagWorkflow:
+    """Integration test for the full tag workflow."""
+
+    def test_add_with_tags_then_tag_crud(
+        self, tmp_wade_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_knowledge_config(tmp_wade_project)
+        monkeypatch.chdir(tmp_wade_project)
+
+        # Add entry with tags
+        result = runner.invoke(
+            app,
+            ["knowledge", "add", "--session", "plan", "--tag", "git", "--tag", "worktree"],
+            input="Worktree safety matters.\n",
+        )
+        assert result.exit_code == 0
+        # Extract entry ID from output (format: "Knowledge entry XXXXXXXX added to ...")
+        entry_id = result.output.split("entry ")[1].split(" ")[0]
+
+        # Verify tags in file
+        text = (tmp_wade_project / "KNOWLEDGE.md").read_text(encoding="utf-8")
+        assert "tags: git, worktree" in text
+
+        # Add another tag
+        result = runner.invoke(app, ["knowledge", "tag", "add", entry_id, "safety"])
+        assert result.exit_code == 0
+
+        # List tags for entry
+        result = runner.invoke(app, ["knowledge", "tag", "list", entry_id])
+        assert result.exit_code == 0
+        assert "git" in result.output
+        assert "worktree" in result.output
+        assert "safety" in result.output
+
+        # Remove a tag
+        result = runner.invoke(app, ["knowledge", "tag", "remove", entry_id, "git"])
+        assert result.exit_code == 0
+
+        # Verify removal
+        result = runner.invoke(app, ["knowledge", "tag", "list", entry_id])
+        assert "git" not in result.output
+        assert "worktree" in result.output
+        assert "safety" in result.output
+
+        # List all tags
+        result = runner.invoke(app, ["knowledge", "tag", "list"])
+        assert result.exit_code == 0
+        assert "safety" in result.output
+        assert "worktree" in result.output
+
+
+class TestKnowledgeSearchWorkflow:
+    """Integration test for search + tag filtering."""
+
+    def test_search_and_tag_filter(
+        self, tmp_wade_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_knowledge_config(tmp_wade_project)
+        monkeypatch.chdir(tmp_wade_project)
+
+        # Add entries with different tags and content
+        runner.invoke(
+            app,
+            ["knowledge", "add", "--session", "plan", "--tag", "git"],
+            input="Git worktree is useful for isolation.\n",
+        )
+        runner.invoke(
+            app,
+            ["knowledge", "add", "--session", "plan", "--tag", "testing"],
+            input="Always write tests for new features.\n",
+        )
+        runner.invoke(
+            app,
+            ["knowledge", "add", "--session", "plan"],
+            input="Docker is unrelated.\n",
+        )
+
+        # Search by text
+        result = runner.invoke(app, ["knowledge", "get", "--search", "worktree", "--no-filter"])
+        assert result.exit_code == 0
+        assert "worktree" in result.output
+        assert "Docker" not in result.output
+
+        # Filter by tag
+        result = runner.invoke(app, ["knowledge", "get", "--tag", "testing", "--no-filter"])
+        assert result.exit_code == 0
+        assert "tests" in result.output
+        assert "Docker" not in result.output
+
+        # Combined search + tag (OR semantics)
+        result = runner.invoke(
+            app,
+            ["knowledge", "get", "--search", "worktree", "--tag", "testing", "--no-filter"],
+        )
+        assert result.exit_code == 0
+        assert "worktree" in result.output
+        assert "tests" in result.output
+        assert "Docker" not in result.output

--- a/tests/integration/test_skill_install.py
+++ b/tests/integration/test_skill_install.py
@@ -241,7 +241,7 @@ class TestSelectiveSkillInstallation:
             assert "task" in entry or "deps" in entry
 
     def test_selective_install_implement_skills(self, tmp_git_repo: Path) -> None:
-        """IMPLEMENT_SKILLS installs only implementation-session and task."""
+        """IMPLEMENT_SKILLS installs implementation-session, task, and knowledge."""
         from wade.skills.installer import IMPLEMENT_SKILLS, install_skills
 
         install_skills(tmp_git_repo, skills=IMPLEMENT_SKILLS)
@@ -249,12 +249,13 @@ class TestSelectiveSkillInstallation:
         skills_dir = tmp_git_repo / ".claude" / "skills"
         assert (skills_dir / "implementation-session").is_dir()
         assert (skills_dir / "task").is_dir()
+        assert (skills_dir / "knowledge").is_dir()
         assert not (skills_dir / "plan-session").exists()
         assert not (skills_dir / "deps").exists()
         assert not (skills_dir / "review-pr-comments-session").exists()
 
     def test_selective_install_review_skills(self, tmp_git_repo: Path) -> None:
-        """REVIEW_SKILLS installs only review-pr-comments-session and task."""
+        """REVIEW_SKILLS installs review-pr-comments-session, task, and knowledge."""
         from wade.skills.installer import REVIEW_SKILLS, install_skills
 
         install_skills(tmp_git_repo, skills=REVIEW_SKILLS)
@@ -262,12 +263,13 @@ class TestSelectiveSkillInstallation:
         skills_dir = tmp_git_repo / ".claude" / "skills"
         assert (skills_dir / "review-pr-comments-session").is_dir()
         assert (skills_dir / "task").is_dir()
+        assert (skills_dir / "knowledge").is_dir()
         assert not (skills_dir / "plan-session").exists()
         assert not (skills_dir / "deps").exists()
         assert not (skills_dir / "implementation-session").exists()
 
     def test_selective_install_plan_skills(self, tmp_git_repo: Path) -> None:
-        """PLAN_SKILLS installs plan-session, task, and deps."""
+        """PLAN_SKILLS installs plan-session, task, deps, and knowledge."""
         from wade.skills.installer import PLAN_SKILLS, install_skills
 
         install_skills(tmp_git_repo, skills=PLAN_SKILLS)
@@ -276,6 +278,7 @@ class TestSelectiveSkillInstallation:
         assert (skills_dir / "plan-session").is_dir()
         assert (skills_dir / "task").is_dir()
         assert (skills_dir / "deps").is_dir()
+        assert (skills_dir / "knowledge").is_dir()
         assert not (skills_dir / "implementation-session").exists()
         assert not (skills_dir / "review-pr-comments-session").exists()
 

--- a/tests/unit/test_services/test_implementation_service.py
+++ b/tests/unit/test_services/test_implementation_service.py
@@ -290,9 +290,10 @@ class TestBootstrapWorktree:
             bootstrap_worktree(worktree, config, repo_root, skills=IMPLEMENT_SKILLS)
 
         skills_dir = worktree / ".claude" / "skills"
-        # IMPLEMENT_SKILLS = ["implementation-session", "task"]
+        # IMPLEMENT_SKILLS = ["implementation-session", "task", "knowledge"]
         assert (skills_dir / "implementation-session").is_dir()
         assert (skills_dir / "task").is_dir()
+        assert (skills_dir / "knowledge").is_dir()
         # Other skills should NOT be installed
         assert not (skills_dir / "plan-session").exists()
         assert not (skills_dir / "deps").exists()

--- a/tests/unit/test_services/test_knowledge_search.py
+++ b/tests/unit/test_services/test_knowledge_search.py
@@ -1,0 +1,153 @@
+"""Unit tests for knowledge_search boolean query parser and evaluator."""
+
+from __future__ import annotations
+
+import pytest
+
+from wade.services.knowledge_search import (
+    AndNode,
+    NotNode,
+    OrNode,
+    PhraseNode,
+    TermNode,
+    evaluate_query,
+    parse_query,
+)
+
+
+class TestParseQuery:
+    def test_single_term(self) -> None:
+        node = parse_query("worktree")
+        assert isinstance(node, TermNode)
+        assert node.term == "worktree"
+
+    def test_quoted_phrase(self) -> None:
+        node = parse_query('"exact phrase"')
+        assert isinstance(node, PhraseNode)
+        assert node.phrase == "exact phrase"
+
+    def test_and_explicit(self) -> None:
+        node = parse_query("worktree AND safety")
+        assert isinstance(node, AndNode)
+        assert isinstance(node.left, TermNode)
+        assert node.left.term == "worktree"
+        assert isinstance(node.right, TermNode)
+        assert node.right.term == "safety"
+
+    def test_and_implicit(self) -> None:
+        node = parse_query("worktree safety")
+        assert isinstance(node, AndNode)
+        assert isinstance(node.left, TermNode)
+        assert node.left.term == "worktree"
+        assert isinstance(node.right, TermNode)
+        assert node.right.term == "safety"
+
+    def test_or(self) -> None:
+        node = parse_query("worktree OR branch")
+        assert isinstance(node, OrNode)
+        assert isinstance(node.left, TermNode)
+        assert isinstance(node.right, TermNode)
+
+    def test_not(self) -> None:
+        node = parse_query("NOT deprecated")
+        assert isinstance(node, NotNode)
+        assert isinstance(node.child, TermNode)
+        assert node.child.term == "deprecated"
+
+    def test_parentheses(self) -> None:
+        node = parse_query("(worktree OR branch) AND safety")
+        assert isinstance(node, AndNode)
+        assert isinstance(node.left, OrNode)
+        assert isinstance(node.right, TermNode)
+
+    def test_complex_expression(self) -> None:
+        node = parse_query('(git OR worktree) AND "error handling" AND NOT deprecated')
+        assert isinstance(node, AndNode)
+
+    def test_empty_query(self) -> None:
+        node = parse_query("")
+        assert isinstance(node, TermNode)
+        assert node.term == ""
+
+    def test_unterminated_quote(self) -> None:
+        node = parse_query('"unclosed phrase')
+        assert isinstance(node, PhraseNode)
+        assert node.phrase == "unclosed phrase"
+
+    def test_case_insensitive_operators(self) -> None:
+        node = parse_query("a and b or c")
+        assert isinstance(node, OrNode)
+
+    def test_malformed_missing_rparen(self) -> None:
+        with pytest.raises(ValueError, match="Expected"):
+            parse_query("(a AND b")
+
+    def test_unexpected_rparen(self) -> None:
+        with pytest.raises(ValueError, match="Unexpected"):
+            parse_query(")")
+
+    def test_trailing_operator(self) -> None:
+        with pytest.raises(ValueError, match="Unexpected"):
+            parse_query("a AND")
+
+
+class TestEvaluateQuery:
+    def test_term_match(self) -> None:
+        node = parse_query("worktree")
+        assert evaluate_query(node, "Use git worktree for isolation")
+
+    def test_term_no_match(self) -> None:
+        node = parse_query("docker")
+        assert not evaluate_query(node, "Use git worktree for isolation")
+
+    def test_case_insensitive(self) -> None:
+        node = parse_query("Worktree")
+        assert evaluate_query(node, "use git worktree for isolation")
+
+    def test_phrase_match(self) -> None:
+        node = parse_query('"error handling"')
+        assert evaluate_query(node, "Always add error handling in services")
+
+    def test_phrase_no_match(self) -> None:
+        node = parse_query('"error handling"')
+        assert not evaluate_query(node, "Handle the error carefully")
+
+    def test_and_both_match(self) -> None:
+        node = parse_query("git AND worktree")
+        assert evaluate_query(node, "Use git worktree for safe development")
+
+    def test_and_one_missing(self) -> None:
+        node = parse_query("git AND docker")
+        assert not evaluate_query(node, "Use git worktree for safe development")
+
+    def test_or_one_matches(self) -> None:
+        node = parse_query("docker OR worktree")
+        assert evaluate_query(node, "Use git worktree for safe development")
+
+    def test_or_neither_matches(self) -> None:
+        node = parse_query("docker OR kubernetes")
+        assert not evaluate_query(node, "Use git worktree for safe development")
+
+    def test_not_excludes(self) -> None:
+        node = parse_query("NOT deprecated")
+        assert evaluate_query(node, "This is the current approach")
+        assert not evaluate_query(node, "This is deprecated")
+
+    def test_complex_query(self) -> None:
+        node = parse_query("(git OR testing) AND NOT deprecated")
+        text = "Use git worktree for safe development"
+        assert evaluate_query(node, text)
+
+    def test_complex_query_excluded(self) -> None:
+        node = parse_query("(git OR testing) AND NOT deprecated")
+        text = "This git approach is deprecated"
+        assert not evaluate_query(node, text)
+
+    def test_empty_query_matches_everything(self) -> None:
+        node = parse_query("")
+        assert evaluate_query(node, "anything")
+
+    def test_implicit_and(self) -> None:
+        node = parse_query("worktree safety")
+        assert evaluate_query(node, "worktree safety is important")
+        assert not evaluate_query(node, "only worktree here")

--- a/tests/unit/test_services/test_knowledge_service.py
+++ b/tests/unit/test_services/test_knowledge_service.py
@@ -1099,11 +1099,15 @@ class TestGetAnnotatedKnowledgeAutoFilter:
 
 def _make_parsed_entry(entry_id: str | None, tags: list[str] | None = None) -> ParsedEntry:
     """Helper to create a ParsedEntry for testing."""
+    if entry_id:
+        raw = f"## {entry_id} | 2026-01-01 | plan\n\ncontent\n\n---\n"
+    else:
+        raw = "## 2026-01-01 | plan\n\ncontent\n\n---\n"
     return ParsedEntry(
         entry_id=entry_id,
         date="2026-01-01",
         heading_rest="plan",
         tags=tags or [],
         content="content",
-        raw=f"## {entry_id or ''} | 2026-01-01 | plan\n\ncontent\n\n---\n",
+        raw=raw,
     )

--- a/tests/unit/test_services/test_knowledge_service.py
+++ b/tests/unit/test_services/test_knowledge_service.py
@@ -11,20 +11,27 @@ import yaml
 from wade.models.config import KnowledgeConfig
 from wade.services.knowledge_service import (
     KNOWLEDGE_TEMPLATE,
+    EntryRating,
     KnowledgeEntry,
+    ParsedEntry,
+    add_tag_to_entry,
     append_knowledge,
+    compute_auto_filter_threshold,
     disable_knowledge,
     enable_knowledge,
     ensure_knowledge_file,
     find_entry_id,
     get_annotated_knowledge,
+    list_tags,
     parse_entries,
     read_knowledge,
     read_ratings,
     record_rating,
     record_supersede,
+    remove_tag_from_entry,
     resolve_knowledge_path,
     resolve_ratings_path,
+    validate_tag,
 )
 
 
@@ -678,3 +685,425 @@ knowledge:
 
         config_content = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         assert config_content["knowledge"]["enabled"] is False
+
+
+# --- Tag validation ---
+
+
+class TestValidateTag:
+    def test_valid_simple(self) -> None:
+        assert validate_tag("git") is None
+
+    def test_valid_kebab(self) -> None:
+        assert validate_tag("worktree-safety") is None
+
+    def test_valid_with_numbers(self) -> None:
+        assert validate_tag("python3") is None
+
+    def test_empty(self) -> None:
+        assert validate_tag("") is not None
+
+    def test_too_long(self) -> None:
+        assert validate_tag("a" * 31) is not None
+
+    def test_max_length_ok(self) -> None:
+        assert validate_tag("a" * 30) is None
+
+    def test_uppercase_rejected(self) -> None:
+        assert validate_tag("Git") is not None
+
+    def test_spaces_rejected(self) -> None:
+        assert validate_tag("my tag") is not None
+
+    def test_underscores_rejected(self) -> None:
+        assert validate_tag("my_tag") is not None
+
+    def test_leading_hyphen_rejected(self) -> None:
+        assert validate_tag("-leading") is not None
+
+    def test_trailing_hyphen_rejected(self) -> None:
+        assert validate_tag("trailing-") is not None
+
+    def test_double_hyphen_rejected(self) -> None:
+        assert validate_tag("double--hyphen") is not None
+
+
+# --- Tag parsing from headings ---
+
+
+class TestTagParsing:
+    def test_no_tags(self) -> None:
+        text = "## abc12345 | 2026-03-24 | plan\n\nSome content\n\n---\n"
+        entries = parse_entries(text)
+        assert len(entries) == 1
+        assert entries[0].tags == []
+
+    def test_tags_no_issue(self) -> None:
+        text = "## abc12345 | 2026-03-24 | plan | tags: git, worktree\n\nContent\n\n---\n"
+        entries = parse_entries(text)
+        assert entries[0].tags == ["git", "worktree"]
+
+    def test_tags_and_issue(self) -> None:
+        text = (
+            "## abc12345 | 2026-03-24 | plan | tags: git, worktree | Issue #7\n\nContent\n\n---\n"
+        )
+        entries = parse_entries(text)
+        assert entries[0].tags == ["git", "worktree"]
+
+    def test_issue_no_tags(self) -> None:
+        text = "## abc12345 | 2026-03-24 | plan | Issue #7\n\nContent\n\n---\n"
+        entries = parse_entries(text)
+        assert entries[0].tags == []
+
+    def test_single_tag(self) -> None:
+        text = "## abc12345 | 2026-03-24 | plan | tags: git\n\nContent\n\n---\n"
+        entries = parse_entries(text)
+        assert entries[0].tags == ["git"]
+
+    def test_old_entries_no_tags(self) -> None:
+        text = "## 2026-03-24 | plan\n\nOld content\n\n---\n"
+        entries = parse_entries(text)
+        assert entries[0].tags == []
+
+
+# --- Append with tags ---
+
+
+class TestAppendWithTags:
+    def test_append_with_tags(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "content", "plan", tags=["git", "worktree"])
+        text = (project_root / "KNOWLEDGE.md").read_text(encoding="utf-8")
+        entries = parse_entries(text)
+        assert len(entries) == 1
+        assert entries[0].tags == ["git", "worktree"]
+        assert "tags: git, worktree" in entries[0].raw
+
+    def test_append_with_tags_and_issue(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "content", "plan", issue_ref="42", tags=["git"])
+        text = (project_root / "KNOWLEDGE.md").read_text(encoding="utf-8")
+        entries = parse_entries(text)
+        assert entries[0].tags == ["git"]
+        assert "tags: git" in entries[0].raw
+        assert "Issue #42" in entries[0].raw
+
+    def test_append_without_tags(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "content", "plan")
+        text = (project_root / "KNOWLEDGE.md").read_text(encoding="utf-8")
+        entries = parse_entries(text)
+        assert entries[0].tags == []
+        assert "tags:" not in entries[0].raw
+
+    def test_append_rejects_invalid_tags(self, project_root: Path, config: KnowledgeConfig) -> None:
+        with pytest.raises(ValueError, match="kebab-case"):
+            append_knowledge(project_root, config, "content", "plan", tags=["Invalid"])
+
+
+# --- Tag CRUD operations ---
+
+
+class TestAddTagToEntry:
+    def test_add_tag(self, project_root: Path, config: KnowledgeConfig) -> None:
+        result = append_knowledge(project_root, config, "content", "plan")
+        kpath = project_root / "KNOWLEDGE.md"
+        add_tag_to_entry(kpath, result.entry_id, "git")
+        entries = parse_entries(kpath.read_text(encoding="utf-8"))
+        assert "git" in entries[0].tags
+
+    def test_add_second_tag(self, project_root: Path, config: KnowledgeConfig) -> None:
+        result = append_knowledge(project_root, config, "content", "plan", tags=["git"])
+        kpath = project_root / "KNOWLEDGE.md"
+        add_tag_to_entry(kpath, result.entry_id, "worktree")
+        entries = parse_entries(kpath.read_text(encoding="utf-8"))
+        assert set(entries[0].tags) == {"git", "worktree"}
+
+    def test_add_duplicate_tag_is_noop(self, project_root: Path, config: KnowledgeConfig) -> None:
+        result = append_knowledge(project_root, config, "content", "plan", tags=["git"])
+        kpath = project_root / "KNOWLEDGE.md"
+        add_tag_to_entry(kpath, result.entry_id, "git")
+        entries = parse_entries(kpath.read_text(encoding="utf-8"))
+        assert entries[0].tags == ["git"]
+
+    def test_add_tag_invalid_entry(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "content", "plan")
+        kpath = project_root / "KNOWLEDGE.md"
+        with pytest.raises(ValueError, match="not found"):
+            add_tag_to_entry(kpath, "nonexist", "git")
+
+    def test_add_invalid_tag(self, project_root: Path, config: KnowledgeConfig) -> None:
+        result = append_knowledge(project_root, config, "content", "plan")
+        kpath = project_root / "KNOWLEDGE.md"
+        with pytest.raises(ValueError, match="kebab-case"):
+            add_tag_to_entry(kpath, result.entry_id, "Invalid")
+
+    def test_add_tag_preserves_issue(self, project_root: Path, config: KnowledgeConfig) -> None:
+        result = append_knowledge(project_root, config, "content", "plan", issue_ref="42")
+        kpath = project_root / "KNOWLEDGE.md"
+        add_tag_to_entry(kpath, result.entry_id, "git")
+        entries = parse_entries(kpath.read_text(encoding="utf-8"))
+        assert "git" in entries[0].tags
+        assert "Issue #42" in entries[0].heading_rest
+
+
+class TestRemoveTagFromEntry:
+    def test_remove_tag(self, project_root: Path, config: KnowledgeConfig) -> None:
+        result = append_knowledge(project_root, config, "content", "plan", tags=["git", "worktree"])
+        kpath = project_root / "KNOWLEDGE.md"
+        remove_tag_from_entry(kpath, result.entry_id, "git")
+        entries = parse_entries(kpath.read_text(encoding="utf-8"))
+        assert entries[0].tags == ["worktree"]
+
+    def test_remove_last_tag(self, project_root: Path, config: KnowledgeConfig) -> None:
+        result = append_knowledge(project_root, config, "content", "plan", tags=["git"])
+        kpath = project_root / "KNOWLEDGE.md"
+        remove_tag_from_entry(kpath, result.entry_id, "git")
+        entries = parse_entries(kpath.read_text(encoding="utf-8"))
+        assert entries[0].tags == []
+        assert "tags:" not in entries[0].raw
+
+    def test_remove_nonexistent_tag(self, project_root: Path, config: KnowledgeConfig) -> None:
+        result = append_knowledge(project_root, config, "content", "plan", tags=["git"])
+        kpath = project_root / "KNOWLEDGE.md"
+        with pytest.raises(ValueError, match="not found"):
+            remove_tag_from_entry(kpath, result.entry_id, "worktree")
+
+    def test_remove_from_nonexistent_entry(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        append_knowledge(project_root, config, "content", "plan")
+        kpath = project_root / "KNOWLEDGE.md"
+        with pytest.raises(ValueError, match="not found"):
+            remove_tag_from_entry(kpath, "nonexist", "git")
+
+
+class TestListTags:
+    def test_list_all_tags(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "c1", "plan", tags=["git", "worktree"])
+        append_knowledge(project_root, config, "c2", "plan", tags=["testing", "git"])
+        kpath = project_root / "KNOWLEDGE.md"
+        result = list_tags(kpath)
+        assert result == ["git", "testing", "worktree"]
+
+    def test_list_entry_tags(self, project_root: Path, config: KnowledgeConfig) -> None:
+        r1 = append_knowledge(project_root, config, "c1", "plan", tags=["git", "worktree"])
+        kpath = project_root / "KNOWLEDGE.md"
+        result = list_tags(kpath, entry_id=r1.entry_id)
+        assert result == ["git", "worktree"]
+
+    def test_list_no_tags(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "c1", "plan")
+        kpath = project_root / "KNOWLEDGE.md"
+        result = list_tags(kpath)
+        assert result == []
+
+    def test_list_nonexistent_entry(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "c1", "plan")
+        kpath = project_root / "KNOWLEDGE.md"
+        with pytest.raises(ValueError, match="not found"):
+            list_tags(kpath, entry_id="nonexist")
+
+    def test_list_missing_file(self, project_root: Path) -> None:
+        result = list_tags(project_root / "KNOWLEDGE.md")
+        assert result == []
+
+
+# --- Statistical auto-filter ---
+
+
+class TestComputeAutoFilterThreshold:
+    def test_no_qualifying_entries(self) -> None:
+        entries = [
+            _make_parsed_entry("e1"),
+            _make_parsed_entry("e2"),
+        ]
+        ratings = {
+            "e1": EntryRating(up=1, down=0),  # 1 vote < 5
+            "e2": EntryRating(up=2, down=1),  # 3 votes < 5
+        }
+        assert compute_auto_filter_threshold(entries, ratings) is None
+
+    def test_fewer_than_3_qualifying(self) -> None:
+        entries = [_make_parsed_entry("e1"), _make_parsed_entry("e2")]
+        ratings = {
+            "e1": EntryRating(up=5, down=0),  # 5 votes, qualifies
+            "e2": EntryRating(up=3, down=3),  # 6 votes, qualifies
+        }
+        # Only 2 qualifying entries — not enough
+        assert compute_auto_filter_threshold(entries, ratings) is None
+
+    def test_exactly_3_qualifying(self) -> None:
+        entries = [_make_parsed_entry(f"e{i}") for i in range(3)]
+        ratings = {
+            "e0": EntryRating(up=10, down=0),  # net=10
+            "e1": EntryRating(up=8, down=2),  # net=6
+            "e2": EntryRating(up=2, down=5),  # net=-3
+        }
+        threshold = compute_auto_filter_threshold(entries, ratings)
+        assert threshold is not None
+        # Threshold should allow filtering of very negative entries
+        assert threshold <= 10  # sanity check
+
+    def test_all_same_score(self) -> None:
+        entries = [_make_parsed_entry(f"e{i}") for i in range(5)]
+        ratings = {f"e{i}": EntryRating(up=5, down=0) for i in range(5)}
+        threshold = compute_auto_filter_threshold(entries, ratings)
+        assert threshold is not None
+        # All scores are 5, stdev=0, so threshold = max(p10=5, 5 - 0) = 5
+        assert threshold == 5.0
+
+    def test_entries_without_ids_skipped(self) -> None:
+        entries = [
+            _make_parsed_entry(None),
+            _make_parsed_entry("e1"),
+            _make_parsed_entry("e2"),
+        ]
+        ratings = {
+            "e1": EntryRating(up=5, down=0),
+            "e2": EntryRating(up=3, down=3),
+        }
+        # Only 2 qualifying entries (ID-less one skipped)
+        assert compute_auto_filter_threshold(entries, ratings) is None
+
+    def test_entries_with_few_votes_not_counted(self) -> None:
+        entries = [_make_parsed_entry(f"e{i}") for i in range(5)]
+        ratings = {
+            "e0": EntryRating(up=10, down=0),  # 10 votes
+            "e1": EntryRating(up=8, down=2),  # 10 votes
+            "e2": EntryRating(up=3, down=5),  # 8 votes
+            "e3": EntryRating(up=1, down=0),  # 1 vote — not counted
+            "e4": EntryRating(up=2, down=1),  # 3 votes — not counted
+        }
+        threshold = compute_auto_filter_threshold(entries, ratings)
+        assert threshold is not None
+
+
+# --- Search + tag filtering in get_annotated_knowledge ---
+
+
+class TestGetAnnotatedKnowledgeSearch:
+    def test_search_filters_entries(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "Git worktree is useful", "plan")
+        append_knowledge(project_root, config, "Docker is also useful", "plan")
+        result = get_annotated_knowledge(
+            project_root, config, search_query="worktree", no_filter=True
+        )
+        assert result is not None
+        assert "worktree" in result
+        assert "Docker" not in result
+
+    def test_tag_filters_entries(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "Git stuff", "plan", tags=["git"])
+        append_knowledge(project_root, config, "Docker stuff", "plan", tags=["docker"])
+        result = get_annotated_knowledge(project_root, config, filter_tags=["git"], no_filter=True)
+        assert result is not None
+        assert "Git stuff" in result
+        assert "Docker stuff" not in result
+
+    def test_search_and_tag_or_semantics(self, project_root: Path, config: KnowledgeConfig) -> None:
+        append_knowledge(project_root, config, "Git worktree tips", "plan", tags=["git"])
+        append_knowledge(project_root, config, "Testing patterns", "plan", tags=["testing"])
+        append_knowledge(project_root, config, "Unrelated stuff", "plan")
+        result = get_annotated_knowledge(
+            project_root, config, search_query="worktree", filter_tags=["testing"], no_filter=True
+        )
+        assert result is not None
+        assert "worktree tips" in result  # matches search
+        assert "Testing patterns" in result  # matches tag
+        assert "Unrelated stuff" not in result  # matches neither
+
+    def test_no_filter_shows_everything(self, project_root: Path, config: KnowledgeConfig) -> None:
+        r = append_knowledge(project_root, config, "content", "plan")
+        kpath = resolve_knowledge_path(project_root, config)
+        ratings_path = resolve_ratings_path(kpath)
+        # Give it lots of downvotes
+        for _ in range(10):
+            record_rating(ratings_path, r.entry_id, "down")
+        result = get_annotated_knowledge(project_root, config, no_filter=True)
+        assert result is not None
+        assert "content" in result
+
+
+class TestGetAnnotatedKnowledgeAutoFilter:
+    def test_auto_filter_prunes_low_rated(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        # Need >= 11 qualifying entries so p10_idx > 0 (p10 is 2nd smallest, not min)
+        kpath = resolve_knowledge_path(project_root, config)
+        ensure_knowledge_file(project_root, config)
+        ratings_path = resolve_ratings_path(kpath)
+
+        # 10 good entries with 5 upvotes each (net=5, total=5, qualifies)
+        good_ids = []
+        for i in range(10):
+            r = append_knowledge(project_root, config, f"Good entry {i}", "plan")
+            good_ids.append(r.entry_id)
+        # 1 bad entry with 5 downvotes (net=-5, total=5, qualifies)
+        bad = append_knowledge(project_root, config, "Bad entry", "plan")
+
+        for eid in good_ids:
+            for _ in range(5):
+                record_rating(ratings_path, eid, "up")
+        for _ in range(5):
+            record_rating(ratings_path, bad.entry_id, "down")
+
+        # With 11 qualifying entries, p10 = sorted[1] = 5
+        # Bad entry (net=-5) < 5 → filtered out
+        result = get_annotated_knowledge(project_root, config)
+        assert result is not None
+        assert "Good entry 0" in result
+        assert "Bad entry" not in result
+
+    def test_auto_filter_passes_low_vote_entries(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        kpath = resolve_knowledge_path(project_root, config)
+        ensure_knowledge_file(project_root, config)
+        ratings_path = resolve_ratings_path(kpath)
+
+        r1 = append_knowledge(project_root, config, "Rated entry", "plan")
+        r2 = append_knowledge(project_root, config, "Rated entry 2", "plan")
+        r3 = append_knowledge(project_root, config, "Rated entry 3", "plan")
+        append_knowledge(project_root, config, "New unrated entry", "plan")
+
+        for _ in range(10):
+            record_rating(ratings_path, r1.entry_id, "up")
+        for _ in range(8):
+            record_rating(ratings_path, r2.entry_id, "up")
+        for _ in range(6):
+            record_rating(ratings_path, r3.entry_id, "up")
+        # r4 has no votes — should always pass through
+
+        result = get_annotated_knowledge(project_root, config)
+        assert result is not None
+        assert "New unrated entry" in result
+
+    def test_min_score_overrides_auto_filter(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        kpath = resolve_knowledge_path(project_root, config)
+        ensure_knowledge_file(project_root, config)
+        ratings_path = resolve_ratings_path(kpath)
+
+        r1 = append_knowledge(project_root, config, "High entry", "plan")
+        r2 = append_knowledge(project_root, config, "Low entry", "plan")
+
+        for _ in range(10):
+            record_rating(ratings_path, r1.entry_id, "up")
+        record_rating(ratings_path, r2.entry_id, "up")
+
+        # min_score=5 is a hard cutoff
+        result = get_annotated_knowledge(project_root, config, min_score=5)
+        assert result is not None
+        assert "High entry" in result
+        assert "Low entry" not in result
+
+
+def _make_parsed_entry(entry_id: str | None, tags: list[str] | None = None) -> ParsedEntry:
+    """Helper to create a ParsedEntry for testing."""
+    return ParsedEntry(
+        entry_id=entry_id,
+        date="2026-01-01",
+        heading_rest="plan",
+        tags=tags or [],
+        content="content",
+        raw=f"## {entry_id or ''} | 2026-01-01 | plan\n\ncontent\n\n---\n",
+    )


### PR DESCRIPTION
Closes #260

<!-- wade:plan:start -->

## Complexity
very_complex

## Context / Problem

The current knowledge system has several limitations:

1. **Dump-all retrieval**: `wade knowledge get` dumps the entire knowledge file at session start, polluting AI context with irrelevant entries. Both `plan-session` and `implementation-session` skills instruct the AI to read all knowledge upfront regardless of the task at hand.

2. **No tagging**: Entries have no categorization beyond session type (`plan`/`implementation`). There's no way to organize or filter entries by topic.

3. **No search**: The only filtering is `--min-score` (a fixed cutoff). There's no text search or boolean query support.

4. **Duplicated instructions**: Knowledge usage instructions are duplicated across `plan-session/SKILL.md` and `implementation-session/SKILL.md` with no single source of truth.

5. **Static score filtering**: `--min-score` is a fixed threshold. It doesn't adapt as the knowledge base grows and gets rated.

## Proposed Solution

Overhaul the knowledge system in four areas: tagging, search, auto-filtering, and skill consolidation.

### 1. Tagging

Extend entry heading format to include optional tags:

```
## a1b2c3d4 | 2026-03-24 | plan | tags: git, worktree-safety | Issue #7
```

Tag naming rules:
- Lowercase kebab-case (`git`, `worktree-safety`, `error-handling`)
- Alphanumeric + hyphens only, no spaces
- Max 30 characters per tag
- Validated at add/tag time

CLI additions:
- `wade knowledge add --tag <tag>` (repeatable, e.g. `--tag git --tag worktree`)
- `wade knowledge tag add <entry-id> <tag>` — add tag to existing entry
- `wade knowledge tag remove <entry-id> <tag>` — remove tag from existing entry
- `wade knowledge tag list [entry-id]` — list all tags (or tags for a specific entry)

Tags are stored inline in the entry heading (not in the sidecar). This keeps them visible when reading the knowledge file directly. Existing tagless entries remain valid — tags are optional.

Heading format variants (tags and issue are both optional, tags always precede issue when both present):
- `## id | date | session` — no tags, no issue
- `## id | date | session | tags: a, b` — tags, no issue
- `## id | date | session | Issue #7` — no tags, with issue
- `## id | date | session | tags: a, b | Issue #7` — tags and issue

### 2. Search and filtering

Add search capabilities to `wade knowledge get`:

- `--search "query"` — boolean text search against entry content and heading
- `--tag <tag>` — filter by tag (repeatable for multiple tags)
- When both `--search` and `--tag` are provided, they combine with OR (wider net for discovery)

Boolean search syntax (Lucene-inspired):
- `term` — matches entries containing the term (case-insensitive)
- `"exact phrase"` — matches the exact phrase
- `term1 AND term2` — both must match
- `term1 OR term2` — either must match
- `NOT term` — excludes entries containing term
- `(term1 OR term2) AND term3` — parentheses for grouping
- Default operator (bare space) is AND: `worktree safety` = `worktree AND safety`

Implementation: in-memory recursive descent parser. Knowledge files are small (dozens to low hundreds of entries), so no indexing or external search library is needed. Parse the markdown, evaluate the boolean expression against each entry's text.

### 3. Statistical auto-filtering

Replace the static `--min-score` default with adaptive statistical filtering:

1. Only entries with >= 5 total votes (up + down summed) are considered as data points with sufficient signal
2. Require at least 3 such entries to engage statistical filtering — with fewer, skip auto-filtering entirely (not enough data for meaningful statistics)
3. Compute net score (up - down) for qualifying entries
4. Calculate mean and standard deviation of the net score distribution
5. Threshold = max(p10 of the distribution, mean - 2 * std)
6. Auto-exclude entries below the threshold
7. Entries with < 5 total votes always pass through (not enough signal to judge)

This means poorly-rated entries get naturally pruned once enough signal accumulates, while new entries aren't penalized.

CLI flags:
- Default (no flag): auto-filter is active
- `--min-score N`: hard cutoff, bypasses statistical filter
- `--no-filter`: disable all filtering, show everything

### 4. Knowledge skill and session skill updates

Create a dedicated `templates/skills/knowledge/SKILL.md` skill containing:
- Contextual retrieval instructions (search when relevant, never dump all at start)
- Tag naming conventions, examples, and when to tag
- Search syntax reference
- Rating and entry addition instructions

Update `templates/skills/plan-session/SKILL.md` and `templates/skills/implementation-session/SKILL.md`:
- Remove the duplicated `## Project Knowledge` sections
- Replace with a short reference: read `@.claude/skills/knowledge/SKILL.md` for knowledge operations
- Remove the instruction to run `wade knowledge get` at session start

Update `wade init` / skill installation to include the new `knowledge` skill in the installed set.

## Tasks

### Tagging
- [ ] Extend `_ENTRY_HEADING_RE` regex in `knowledge_service.py` to parse optional `tags: tag1, tag2` field
- [ ] Update `ParsedEntry` model to include `tags: list[str]`
- [ ] Add tag validation function (lowercase kebab-case, max 30 chars, alphanumeric + hyphens)
- [ ] Extend `append_knowledge()` to accept and format tags in the heading
- [ ] Add `--tag` repeatable option to `wade knowledge add` CLI
- [ ] Implement `wade knowledge tag add <entry-id> <tag>` — in-place edit of the knowledge file heading (use `fcntl.LOCK_EX` file locking, same pattern as ratings)
- [ ] Implement `wade knowledge tag remove <entry-id> <tag>` — in-place edit of the knowledge file heading (use `fcntl.LOCK_EX` file locking)
- [ ] Implement `wade knowledge tag list [entry-id]` — parse and display tags
- [ ] Add unit tests for tag parsing, validation, CRUD operations
- [ ] Add integration test for full tag workflow (add with tags, tag add/remove, tag list)

### Search
- [ ] Implement boolean query parser (recursive descent): supports AND, OR, NOT, quoted phrases, parentheses, default AND for spaces
- [ ] Implement query evaluator that matches a parsed query against entry text (case-insensitive)
- [ ] Add `--search` option to `wade knowledge get` CLI
- [ ] Add `--tag` filter option to `wade knowledge get` CLI (repeatable, OR semantics)
- [ ] Combine `--search` and `--tag` with OR logic
- [ ] Add unit tests for query parser (all operators, edge cases, malformed input)
- [ ] Add unit tests for query evaluator against sample entries
- [ ] Add integration test for search + tag filter workflow

### Auto-filtering
- [ ] Implement statistical filtering function: compute mean/std of net scores for entries with >= 5 votes, threshold = max(p10, mean - 2*std)
- [ ] Apply auto-filter by default in `get_annotated_knowledge()`
- [ ] Add `--no-filter` flag to bypass auto-filtering
- [ ] Keep `--min-score` as a hard-cutoff override (bypasses statistical filter)
- [ ] Add unit tests for statistical filtering (normal distribution, edge cases like all same score, fewer than 3 qualifying entries, exactly 3 qualifying entries)

### Skill consolidation
- [ ] Create `templates/skills/knowledge/SKILL.md` with contextual retrieval, tagging, search syntax, rating instructions
- [ ] Update `templates/skills/plan-session/SKILL.md` — remove `## Project Knowledge` section, add reference to knowledge skill
- [ ] Update `templates/skills/implementation-session/SKILL.md` — remove `## Project Knowledge` section, add reference to knowledge skill
- [ ] Update `wade init` skill installation to include the `knowledge` skill
- [ ] Verify backward compatibility: projects without tags, old entry formats, disabled knowledge

## Acceptance Criteria

- [ ] `wade knowledge add --tag git --tag worktree --session plan` creates an entry with tags visible in the heading
- [ ] `wade knowledge tag add <id> new-tag` adds a tag to an existing entry; `tag remove` removes it; `tag list` shows all tags
- [ ] `wade knowledge get --search "worktree AND safety"` returns only entries matching both terms
- [ ] `wade knowledge get --tag git` returns entries tagged with `git`
- [ ] `wade knowledge get --search "worktree" --tag git` returns entries matching the search OR tagged with `git` (OR semantics)
- [ ] Boolean search supports: AND, OR, NOT, `"quoted phrases"`, parentheses, default AND for bare spaces
- [ ] Auto-filtering prunes low-rated entries (>= 5 votes, below p10 / mean-2*std) by default
- [ ] `--no-filter` disables auto-filtering; `--min-score` overrides with a hard cutoff
- [ ] Existing tagless entries parse and display correctly (backward compatible)
- [ ] `knowledge/SKILL.md` exists and is installed by `wade init`
- [ ] Plan-session and implementation-session skills no longer instruct to dump all knowledge at session start
- [ ] All new code has unit tests; integration tests cover the end-to-end workflow

<!-- wade:plan:end -->

## Summary

## What was addressed
All 5 unresolved CodeRabbit review comments on PR #261.

## Changes
- Added inline comment explaining p10 percentile calculation rationale in `compute_auto_filter_threshold`
- Fixed brittle `str.replace` in `add_tag_to_entry` — now uses positional replacement via `target.raw` to prevent data corruption when heading text appears elsewhere in the file
- Applied same positional replacement fix to `remove_tag_from_entry`
- Added exit code assertions on setup `runner.invoke` calls in integration test `test_search_and_tag_filter`
- Fixed `_make_parsed_entry` test helper to produce correct `raw` format when `entry_id` is None

## Remaining
None — all 5 review threads resolved.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.6` |
| Total tokens | **89,300** |
| Input tokens | **29,600** |
| Output tokens | **59,700** |

### Session 2

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.6` |
| Total tokens | **113,000** |
| Input tokens | **36,000** |
| Output tokens | **77,000** |

<!-- wade:impl-usage:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Tagging for knowledge entries with tag CRUD commands (add, remove, list)
  - Advanced boolean search for knowledge (AND/OR/NOT, phrases, parentheses)
  - Added --search, repeatable --tag, and --no-filter options for retrieval
  - Auto-filtering by entry popularity with a --min-score override

* **Documentation**
  - New knowledge skill guide and updated session skill docs showing search/tag workflows

* **Tests**
  - New unit and integration tests covering search, tagging, filtering, and install behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.6` |
| Total tokens | **8,809** |
| Input tokens | **809** |
| Output tokens | **8,000** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Review | `claude` | `7e212bbf-ad7f-4cb3-bf2e-298cedcd42db` |

<!-- wade:sessions:end -->
