### PR TITLE
fix: continue polling when pending reviewers exist after review bot completes

### DIFF
--- a/src/wade/services/review_service.py
+++ b/src/wade/services/review_service.py
@@ -399,7 +399,9 @@ def poll_for_reviews(
 
             # No review signals, no bot blocking — apply quiet-timeout logic.
             if status.pending_reviewers:
-                names = ", ".join(f"@{r.name}" for r in status.pending_reviewers)
+                names = ", ".join(
+                    f"@{r.name}{' (team)' if r.is_team else ''}" for r in status.pending_reviewers
+                )
                 console.detail(f"Awaiting review from {names} — next check in {poll_interval}s...")
 
             if status.is_commit_fresh():

--- a/src/wade/services/review_service.py
+++ b/src/wade/services/review_service.py
@@ -373,6 +373,7 @@ def poll_for_reviews(
                 status.bot_status == ReviewBotStatus.COMPLETED
                 and not eff_threads
                 and not status.has_changes_requested
+                and not status.pending_reviewers
             ):
                 console.info("Review bot completed — no actionable comments found.")
                 return PollOutcome.REVIEW_COMPLETE
@@ -397,6 +398,10 @@ def poll_for_reviews(
                 return PollOutcome.COMMENTS_FOUND
 
             # No review signals, no bot blocking — apply quiet-timeout logic.
+            if status.pending_reviewers:
+                names = ", ".join(f"@{r.name}" for r in status.pending_reviewers)
+                console.detail(f"Awaiting review from {names} — next check in {poll_interval}s...")
+
             if status.is_commit_fresh():
                 # Commit too recent; reset quiet timer and keep polling.
                 quiet_start = None

--- a/tests/unit/test_services/test_poll_for_reviews.py
+++ b/tests/unit/test_services/test_poll_for_reviews.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from wade.models.review import (
+    PendingReviewer,
     PollOutcome,
     PRReviewStatus,
     ReviewBotStatus,
@@ -457,12 +458,57 @@ def test_bot_completed_no_signals_returns_review_complete(
         actionable_threads=[],
         all_unresolved_threads=[],
         bot_status=ReviewBotStatus.COMPLETED,
+        pending_reviewers=[],
     )
 
     result = poll_for_reviews(_provider(), tmp_path, 42, "feat/42-test")
 
     assert result == PollOutcome.REVIEW_COMPLETE
     mock_sleep.assert_not_called()
+
+
+@patch(_SLEEP)
+@patch(_TIME)
+@patch(_STATUS)
+@patch(_GET_PR)
+def test_bot_completed_with_pending_reviewers_keeps_polling(
+    mock_get_pr: MagicMock,
+    mock_status: MagicMock,
+    mock_time: MagicMock,
+    _mock_sleep: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Bot completed but pending reviewers exist — loop continues, not REVIEW_COMPLETE.
+
+    Regression test for issue #268: polling should continue when CodeRabbit
+    completes with no actionable comments but other reviewers are still pending
+    (e.g. @copilot-pull-request-reviewer).
+    """
+    from datetime import datetime, timedelta
+
+    old_commit_time = datetime.now(UTC) - timedelta(minutes=30)
+    mock_get_pr.return_value = {"number": 42, "state": "OPEN"}
+    mock_status.return_value = PRReviewStatus(
+        actionable_threads=[],
+        all_unresolved_threads=[],
+        bot_status=ReviewBotStatus.COMPLETED,
+        pending_reviewers=[PendingReviewer(name="copilot-pull-request-reviewer", is_team=False)],
+        latest_commit_pushed_at=old_commit_time,
+    )
+    # Simulate quiet timeout trigger: first call sets quiet_start, second triggers timeout
+    mock_time.side_effect = [100.0, 800.0]  # elapsed = 700s > quiet_timeout=600
+
+    result = poll_for_reviews(
+        _provider(),
+        tmp_path,
+        42,
+        "feat/42-test",
+        poll_interval=60,
+        quiet_timeout=600,
+    )
+
+    # Should return QUIET_TIMEOUT (not REVIEW_COMPLETE) — polling continued until timeout
+    assert result == PollOutcome.QUIET_TIMEOUT
 
 
 @patch(_SLEEP)

--- a/tests/unit/test_services/test_poll_for_reviews.py
+++ b/tests/unit/test_services/test_poll_for_reviews.py
@@ -509,6 +509,7 @@ def test_bot_completed_with_pending_reviewers_keeps_polling(
 
     # Should return QUIET_TIMEOUT (not REVIEW_COMPLETE) — polling continued until timeout
     assert result == PollOutcome.QUIET_TIMEOUT
+    assert mock_status.call_count >= 2
 
 
 @patch(_SLEEP)


### PR DESCRIPTION
Closes #268

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
When CodeRabbit (or any review bot) completes with no actionable comments,
`poll_for_reviews` in `review_service.py` returns `REVIEW_COMPLETE` immediately —
even if there are still pending reviewers (e.g. `@copilot-pull-request-reviewer`).

This traps the user in an infinite menu loop:
1. Polling exits with `REVIEW_COMPLETE`
2. `_quiet_next_steps_prompt` shows "Awaiting review from @copilot — Merge unavailable"
3. User selects "Keep polling"
4. Polling immediately exits again (same condition)
5. Repeat indefinitely

The root cause is in `poll_for_reviews` (review_service.py ~line 373):

```python
if (
    status.bot_status == ReviewBotStatus.COMPLETED
    and not eff_threads
    and not status.has_changes_requested
    # missing: and not status.pending_reviewers
):
    return PollOutcome.REVIEW_COMPLETE  # exits even with Copilot still pending
```

## Proposed Solution
Add `and not status.pending_reviewers` to the `REVIEW_COMPLETE` early-return guard
in `poll_for_reviews`. When pending reviewers exist, the code falls through to the
existing quiet-timeout branch. Add a `console.detail` message there (before the
`is_commit_fresh()` check) to inform the user which reviewers are still pending,
e.g.:

```python
if status.pending_reviewers:
    names = ", ".join(f"@{r.name}" for r in status.pending_reviewers)
    console.detail(f"Awaiting review from {names} — next check in {poll_interval}s...")
```

This lets the quiet-timeout clock run normally: if no reviewer acts within
`quiet_timeout` seconds (default 600s), the loop exits with `QUIET_TIMEOUT`
(acceptable fallback — better than an infinite menu loop).

## Tasks
- [ ] Add `and not status.pending_reviewers` to the REVIEW_COMPLETE early-return
      condition in `poll_for_reviews` (`review_service.py`)
- [ ] Add a `console.detail` message in the quiet-timeout fallthrough section
      for the pending-reviewers case (before the `is_commit_fresh()` check)
- [ ] Add a regression test: bot COMPLETED + pending reviewer → loop continues
      polling (does not return REVIEW_COMPLETE prematurely)
- [ ] Adjust existing `test_bot_completed_no_signals_returns_review_complete` to
      assert the no-pending-reviewers scenario remains unchanged (add explicit
      `pending_reviewers=[]` to the fixture for clarity)

## Acceptance Criteria
- [ ] When CodeRabbit completes with no comments but Copilot is still pending,
      polling continues rather than returning REVIEW_COMPLETE
- [ ] When CodeRabbit completes with no comments and no pending reviewers,
      REVIEW_COMPLETE is still returned (existing behavior preserved)
- [ ] A clear detail message is shown while waiting for the pending reviewer
- [ ] All existing tests pass; new regression test covers the bug scenario
- [ ] `./scripts/test.sh` and `./scripts/check.sh` both pass

<!-- wade:plan:end -->

## Summary

## What was addressed

Fixed 3 review comments across 2 files to improve code consistency and test robustness.

## Changes

- **review_service.py (line 402)**: Added `(team)` suffix to pending reviewers message for consistency with other messages in the module that include team labels
- **test_poll_for_reviews.py (line 512)**: Strengthened regression test by adding call count assertion (`assert mock_status.call_count >= 2`) to explicitly verify polling actually retried, ensuring the regression is properly tested

## Remaining

No remaining unresolved threads. All review comments have been addressed and resolved.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | **10,565** |
| Input tokens | **265** |
| Output tokens | **10,300** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review polling now properly waits when reviewers are pending. Reviews are only marked complete after all reviewers respond, and the system logs an “Awaiting review…” update (including pending reviewer names/teams) while scheduling the next poll.

* **Tests**
  * Added coverage for pending-reviewer scenarios to ensure polling behaves correctly when reviewers remain outstanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | **7,007** |
| Input tokens | **707** |
| Output tokens | **6,300** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `ac8b3af4-8453-4ee1-a4f2-aee5221937a5` |
| Review | `claude` | `1eb467c1-20ad-4076-bf2b-794d6607f87e` |

<!-- wade:sessions:end -->
