### PR TITLE
fix: search knowledge after learning feature topic in plan-session skill

### DIFF
--- a/templates/skills/plan-session/SKILL.md
+++ b/templates/skills/plan-session/SKILL.md
@@ -49,8 +49,9 @@ dependency analysis hooks.
 Read @.claude/skills/knowledge/SKILL.md for knowledge operations (search,
 tagging, rating, adding entries).
 
-At the start of this session, search for knowledge relevant to your task
-(do not dump all entries). Before running `wade plan-session done`, capture
+After the user tells you what they want to plan, search for knowledge
+relevant to that feature topic (do not dump all entries). Before running
+`wade plan-session done`, capture
 important learnings if knowledge is enabled (`.wade.yml` → `knowledge.enabled`).
 
 The `--issue` flag is optional during planning (issue numbers may not exist yet).
@@ -153,8 +154,9 @@ At the start of this session, use your tool's native task/todo tracking
 mechanism to populate a checklist with the workflow steps below. This ensures
 you complete every mandatory step and the user can track progress.
 
+- [ ] Ask the user what they want to plan
 - [ ] Search relevant knowledge (`wade knowledge get --search <topic>` or `wade knowledge get --tag <tag>`)
-- [ ] Plan the feature with the user
+- [ ] Plan the feature with the user (analyze, break down, propose)
 - [ ] Write plan file(s) to the temp directory
 - [ ] Run `wade review plan` for each plan file (if review is enabled)
 - [ ] Capture knowledge (`wade knowledge add`) (if knowledge capture is enabled)


### PR DESCRIPTION
Closes #276

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

The `plan-session` skill instructs the AI to search the knowledge base "at the
start of this session", before the user has described what they want to plan.
This causes the AI to search for knowledge without a topic, making the search
meaningless or forcing it to skip the step. The Task Tracking checklist compounds
this by listing "Search relevant knowledge" as the first step, ahead of any
interaction with the user.

The `implementation-session` skill has the same "at the start" wording but is
unaffected: that session is launched with `wade implement <issue-number>`, so
the AI already has full topic context when it starts.

## Proposed Solution

Update `templates/skills/plan-session/SKILL.md`:

1. **Prose** — In the `## Project Knowledge` section, change the timing from
   "at the start of this session" to "after the user tells you what they want
   to plan". This makes the intent unambiguous.

2. **Task Tracking checklist** — Restructure the first two steps so the ordering
   reflects the correct sequence:
   - Add "Ask the user what they want to plan" as the first checklist item.
   - Keep "Search relevant knowledge" second (now clearly after knowing the topic).
   - Rename the subsequent "Plan the feature with the user" item to signal it
     covers analysis and breakdown, not the initial question.

No changes needed to `implementation-session`, `task`, or other skills.

Note: `.claude/skills/plan-session/SKILL.md` is a symlink to the template, so
editing the template is sufficient — no separate file needs to be updated.

## Tasks

- [ ] Update `## Project Knowledge` prose in `templates/skills/plan-session/SKILL.md` to replace "At the start of this session, search for knowledge relevant to your task" with "After the user tells you what they want to plan, search for knowledge relevant to that feature topic"
- [ ] Reorder the `## Task Tracking` checklist: split into (1) "Ask the user what they want to plan", (2) "Search relevant knowledge", (3) "Plan the feature with the user (analyze, break down, propose)"

## Acceptance Criteria

- [ ] The `## Project Knowledge` section no longer says "at the start of this session"
- [ ] The Task Tracking checklist lists "Ask the user what they want to plan" before "Search relevant knowledge"
- [ ] No other skill files are modified unnecessarily

<!-- wade:plan:end -->

## Summary

## What was done

Fixed the `plan-session` skill so the AI searches the knowledge base _after_ learning what the user wants to plan, rather than at session start when no topic is known yet. This makes the knowledge search meaningful and correctly sequenced.

## Changes

- Updated `## Project Knowledge` prose in `templates/skills/plan-session/SKILL.md`: replaced "At the start of this session, search for knowledge relevant to your task" with "After the user tells you what they want to plan, search for knowledge relevant to that feature topic"
- Restructured `## Task Tracking` checklist: added "Ask the user what they want to plan" as the first item, kept "Search relevant knowledge" second, and renamed "Plan the feature with the user" to "Plan the feature with the user (analyze, break down, propose)" for clarity

## Testing

- Verified the `.claude/skills/plan-session/SKILL.md` symlink points to the template, so no separate file needed updating
- Confirmed acceptance criteria: no "at the start of this session" wording remains in the Project Knowledge section; checklist now lists the ask step before the search step; no other skill files were modified

## Notes for reviewers

The `implementation-session` skill has the same "at the start of this session" wording but intentionally was not changed — it launches with `wade implement <issue-number>` so the AI already has full topic context before the session begins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session planning workflow to perform knowledge search after the user specifies their topic of interest, rather than at session start.
  * Refined checklist with explicit step requesting user input and clarified analysis guidance for planning phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **5,980** |
| Input tokens | **780** |
| Output tokens | **5,200** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `f74a479c-3207-4341-8818-6882faa2b3da` |

<!-- wade:sessions:end -->
