### PR TITLE
fix: integrate knowledge search step into plan-session workflow

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -30,3 +30,9 @@ that resolve paths directly (resolve_canonical_knowledge_path wrapper).
 claude-opus-4-7 is the current most-capable Claude model (dotted internal form: claude-opus-4.7). It introduces the xhigh effort level (between high and max). Cursor agent binary renamed short-form model IDs (opus-4.6 → claude-4.6-opus-high etc.) and embeds effort in names; thinking models are now claude-opus-4-7-thinking-{effort} not {model}-thinking. Codex renamed --yolo to --ask-for-approval (-a never for automation). probe_models.py had two bugs: claude parsing extracted prose words instead of model IDs, and opencode subcommand help check was wrong (should check 'opencode run --help' not top-level).
 
 ---
+
+## b6a3a637 | 2026-04-19 | implementation | tags: plan-session, skills, templates | Issue #278
+
+When the plan-session 'Your role' step numbering changes, the _partials/review-plan-step.md partial also has a hardcoded step number that must be kept in sync. After adding 2 steps in #278, the partial moved from step 5 to step 7.
+
+---

--- a/templates/skills/_partials/review-plan-step.md
+++ b/templates/skills/_partials/review-plan-step.md
@@ -1,4 +1,4 @@
-5. **Review** — after writing plan files, run `wade review plan <plan_file>` for
+7. **Review** — after writing plan files, run `wade review plan <plan_file>` for
    each plan file you created and check the exit code:
    - **Exit 0**: Review completed externally or skipped. If there is output, it
      is review feedback — read it and address any actionable findings before

--- a/templates/skills/plan-session/SKILL.md
+++ b/templates/skills/plan-session/SKILL.md
@@ -59,16 +59,18 @@ Running `wade knowledge add` is allowed even though this is a planning session.
 
 ## Your role
 
-1. **Plan the feature** with the user — analyze, break down, propose.
-2. **Present the plan(s)** to the user. Use your tool's native question component to ask: "Ready to write the plan file(s)?" before writing any files.
-3. **Write plan file(s)** to the temp directory shown in your prompt.
-4. **Review with the user** — present a summary of every plan file you wrote
-   (title, complexity, key tasks). Use your tool's native question component to ask: "Want any modifications?" If so, apply them and repeat; otherwise proceed to step 5.
+1. **Ask the user** what they want to plan. If the session prompt does not already specify a feature or issue, ask before proceeding.
+2. **Search relevant knowledge** — once you know the topic, search for entries relevant to that feature using `wade knowledge get --search <topic>` or `wade knowledge get --tag <tag>` (see @.claude/skills/knowledge/SKILL.md and the **Project Knowledge** section above). Do not dump all entries.
+3. **Plan the feature** with the user — analyze, break down, propose.
+4. **Present the plan(s)** to the user. Use your tool's native question component to ask: "Ready to write the plan file(s)?" before writing any files.
+5. **Write plan file(s)** to the temp directory shown in your prompt.
+6. **Review with the user** — present a summary of every plan file you wrote
+   (title, complexity, key tasks). Use your tool's native question component to ask: "Want any modifications?" If so, apply them and repeat; otherwise proceed to step 7.
 {review_plan_step}
-6. **Validate** — run `wade plan-session done <plan_dir>` (the temp dir from your prompt).
+8. **Validate** — run `wade plan-session done <plan_dir>` (the temp dir from your prompt).
    If it exits with errors, fix each reported issue and re-run until it passes.
    Warnings are informational and do not block proceeding.
-7. **Present results and suggest exit** — once validation passes, provide a
+9. **Present results and suggest exit** — once validation passes, provide a
    brief **workflow recap** and **what happens next**:
 
    Workflow recap (list only the steps you actually performed):

--- a/templates/skills/plan-session/SKILL.md
+++ b/templates/skills/plan-session/SKILL.md
@@ -67,10 +67,13 @@ Running `wade knowledge add` is allowed even though this is a planning session.
 6. **Review with the user** — present a summary of every plan file you wrote
    (title, complexity, key tasks). Use your tool's native question component to ask: "Want any modifications?" If so, apply them and repeat; otherwise proceed to step 7.
 {review_plan_step}
-8. **Validate** — run `wade plan-session done <plan_dir>` (the temp dir from your prompt).
+<!-- markdownlint-disable-next-line MD029 -->
+8. **Capture knowledge (if enabled)** — before validation, run `wade knowledge add` to store important learnings when `.wade.yml` has `knowledge.enabled: true`.
+<!-- markdownlint-disable-next-line MD029 -->
+9. **Validate** — run `wade plan-session done <plan_dir>` (the temp dir from your prompt).
    If it exits with errors, fix each reported issue and re-run until it passes.
    Warnings are informational and do not block proceeding.
-9. **Present results and suggest exit** — once validation passes, provide a
+10. **Present results and suggest exit** — once validation passes, provide a
    brief **workflow recap** and **what happens next**:
 
    Workflow recap (list only the steps you actually performed):


### PR DESCRIPTION
Closes #278

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

The "Your role" section in plan-session skill starts at "Plan the feature" but omits the two preceding steps: asking the user what to plan, and searching knowledge. This causes the workflow section to skip initial critical steps, making it ambiguous when/if these steps should occur. Agents reading only "Your role" wouldn't understand the full workflow, leading to the knowledge search happening at the wrong time.

## Proposed Solution

Prepend two new steps to the "Your role" section:
1. Ask the user what feature they want to plan
2. Search relevant knowledge (if applicable) using the user's specified topic

Reorder the existing steps as 3–7 and ensure all steps match the "Task Tracking" checklist order. This makes "Your role" a complete, sequential workflow that agents can follow from start to finish.

## Tasks
- [ ] Add step 1: "Ask the user what they want to plan" with guidance from the intro text
- [ ] Add step 2: "Search relevant knowledge" with details from the "Project Knowledge" section
- [ ] Renumber existing steps (plan → step 3, present → step 4, etc.)
- [ ] Verify all 7 steps match the "Task Tracking" checklist
- [ ] Verify step descriptions reference the correct documents/commands

## Acceptance Criteria
- [ ] "Your role" section lists all 7 workflow steps in correct order
- [ ] Steps 1–2 (ask, search knowledge) appear before "Plan the feature"
- [ ] Workflow is internally consistent with "Task Tracking" and "Project Knowledge" sections
- [ ] A developer reading only "Your role" understands the complete workflow start-to-finish

<!-- wade:plan:end -->

## Summary

## What was done

1. Added two missing steps to the `## Your role` section of the `plan-session` skill: (1) asking the user what they want to plan, and (2) searching relevant knowledge. The existing steps were renumbered from 3 onward so the section now reads as a complete, sequential workflow from session start to finish.

2. Addressed CodeRabbit review comments:
   - Added explicit "Capture knowledge" step (step 8) to align workflow with Task Tracking checklist
   - Fixed markdown lint warnings (MD029) by adding targeted markdownlint suppressions around the {review_plan_step} placeholder

## Changes

- `templates/skills/plan-session/SKILL.md`:
  - Initial commit: prepended steps 1–2 (ask user, search knowledge); renumbered old steps to 3–9
  - Review fix: inserted step 8 (capture knowledge); renumbered validation to step 9, presentation to step 10; added markdownlint suppressions
- `templates/skills/_partials/review-plan-step.md` — updated hardcoded step number from 5 to 7 to match position

## Testing

- Full test suite passes: 2357 tests, 0 failures
- `./scripts/check.sh` clean: ruff, mypy strict, no issues

## Notes for reviewers

The `{review_plan_step}` partial contains a hardcoded step number. It must stay in sync with its position in the `## Your role` numbered list — this is now documented in the knowledge base (entry b6a3a637).

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **32,800** |
| Input tokens | **3,600** |
| Output tokens | **29,200** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | **10,153** |
| Input tokens | **853** |
| Output tokens | **9,300** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `bac89884-6f69-41ac-8a83-4bac230a00d2` |
| Review | `claude` | `9fe61717-7e3e-40f7-b678-4ba0ebc76328` |

<!-- wade:sessions:end -->
