### PR TITLE
fix: knowledge search fails for plain ## Title entries and dumps full file

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -36,3 +36,9 @@ claude-opus-4-7 is the current most-capable Claude model (dotted internal form: 
 When the plan-session 'Your role' step numbering changes, the _partials/review-plan-step.md partial also has a hardcoded step number that must be kept in sync. After adding 2 steps in #278, the partial moved from step 5 to step 7.
 
 ---
+
+## 164c355e | 2026-04-23 | plan | tags: knowledge, bug
+
+parse_entries only handles dated entries ('## YYYY-MM-DD | Title' format). Plain '## Title' headings return [] from parse_entries, causing search to silently find nothing and dump the full file (header=text fallback bug). Fix: add fallback plain-heading regex, make ParsedEntry.date optional, fix header fallback when entries==[], and early-exit CLI get() when entries_count==0 after filtering.
+
+---

--- a/src/wade/cli/knowledge.py
+++ b/src/wade/cli/knowledge.py
@@ -147,6 +147,7 @@ def get(
     # Check if search or tag filters returned no results
     if (search or tag) and result.entries_count == 0:
         print("No entries matched your search.", file=sys.stderr)
+        raise typer.Exit(0)
 
     console.raw(result.content)
 

--- a/src/wade/services/knowledge_service.py
+++ b/src/wade/services/knowledge_service.py
@@ -34,7 +34,8 @@ _ENTRY_HEADING_RE = re.compile(
 )
 
 # Fallback regex for hand-authored plain headings with no date or ID: ## Title
-_PLAIN_ENTRY_HEADING_RE = re.compile(r"^## (.+?)(?:\s+\[.*\])?\s*$")
+# Title must start with alphanumeric to avoid matching `## ---` separators.
+_PLAIN_ENTRY_HEADING_RE = re.compile(r"^## ([A-Za-z0-9].*?)(?:\s+\[.*\])?\s*$")
 
 # Tag validation: lowercase kebab-case, max 30 chars
 _TAG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")

--- a/src/wade/services/knowledge_service.py
+++ b/src/wade/services/knowledge_service.py
@@ -33,6 +33,9 @@ _ENTRY_HEADING_RE = re.compile(
     r"^## (?:([a-zA-Z0-9_-]+) \| )?(\d{4}-\d{2}-\d{2}) \| (.+?)(?:\s+\[.*\])?\s*$"
 )
 
+# Fallback regex for hand-authored plain headings with no date or ID: ## Title
+_PLAIN_ENTRY_HEADING_RE = re.compile(r"^## (.+?)(?:\s+\[.*\])?\s*$")
+
 # Tag validation: lowercase kebab-case, max 30 chars
 _TAG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _TAG_MAX_LEN = 30
@@ -49,7 +52,7 @@ class ParsedEntry(BaseModel, frozen=True):
     """A parsed knowledge entry from the knowledge file."""
 
     entry_id: str | None
-    date: str
+    date: str | None
     heading_rest: str
     tags: list[str] = []
     content: str
@@ -185,23 +188,32 @@ def parse_entries(text: str) -> list[ParsedEntry]:
     """Parse knowledge file text into individual entries.
 
     Handles entries with and without IDs. Skips the template header.
+    Also handles plain ## Title headings with no date or ID.
     """
     entries: list[ParsedEntry] = []
     lines = text.split("\n")
     i = 0
     while i < len(lines):
         match = _ENTRY_HEADING_RE.match(lines[i])
-        if match:
-            entry_id = match.group(1)  # None for old-style entries
-            date = match.group(2)
-            heading_rest = match.group(3)
+        plain_match = _PLAIN_ENTRY_HEADING_RE.match(lines[i]) if not match else None
+
+        if match or plain_match:
+            if match:
+                entry_id: str | None = match.group(1)
+                date: str | None = match.group(2)
+                heading_rest = match.group(3)
+            else:
+                assert plain_match is not None
+                entry_id = None
+                date = None
+                heading_rest = plain_match.group(1)
             heading_line = lines[i]
 
             # Collect content lines until next heading or end
             content_lines: list[str] = []
             i += 1
             while i < len(lines):
-                if _ENTRY_HEADING_RE.match(lines[i]):
+                if _ENTRY_HEADING_RE.match(lines[i]) or _PLAIN_ENTRY_HEADING_RE.match(lines[i]):
                     break
                 content_lines.append(lines[i])
                 i += 1
@@ -432,7 +444,8 @@ def get_annotated_knowledge(
         first_entry_pos = text.find(entries[0].raw)
         header = text[:first_entry_pos] if first_entry_pos > 0 else ""
     else:
-        header = text
+        m = re.search(r"^##\s", text, re.MULTILINE)
+        header = text[: m.start()] if m else text
 
     result_parts = [header]
     filtered_entry_count = 0
@@ -474,6 +487,7 @@ def get_annotated_knowledge(
         heading_match = _ENTRY_HEADING_RE.match(entry.raw.split("\n")[0])
         if heading_match and should_annotate:
             id_part = f"{entry.entry_id} | " if entry.entry_id else ""
+            assert entry.date is not None  # entry_id is always accompanied by a date
             heading = f"## {id_part}{entry.date} | {entry.heading_rest} [+{up}/-{down}]"
             raw_lines = entry.raw.split("\n")
             raw_lines[0] = heading
@@ -584,6 +598,7 @@ def add_tag_to_entry(
             if tag in target.tags:
                 return  # Already has the tag
 
+            assert target.date is not None  # entries with entry_id always have a date
             session_type, tags, issue_part = _decompose_heading_rest(target.heading_rest)
             tags.append(tag)
             new_heading = _rebuild_heading_line(
@@ -626,6 +641,7 @@ def remove_tag_from_entry(
             if tag not in target.tags:
                 raise ValueError(f"Tag '{tag}' not found on entry {entry_id}")
 
+            assert target.date is not None  # entries with entry_id always have a date
             session_type, tags, issue_part = _decompose_heading_rest(target.heading_rest)
             tags.remove(tag)
             new_heading = _rebuild_heading_line(

--- a/tests/unit/test_cli/test_knowledge_cli.py
+++ b/tests/unit/test_cli/test_knowledge_cli.py
@@ -157,6 +157,7 @@ class TestKnowledgeGetCommand:
             result = runner.invoke(app, ["knowledge", "get", "--search", "nonexistent"])
         assert result.exit_code == 0
         assert "No entries matched your search." in result.output
+        assert "Docker stuff." not in result.output
 
     def test_tag_filter_with_no_matches_prints_no_results(self, tmp_path: Path) -> None:
         content = (
@@ -172,6 +173,37 @@ class TestKnowledgeGetCommand:
             result = runner.invoke(app, ["knowledge", "get", "--tag", "docker"])
         assert result.exit_code == 0
         assert "No entries matched your search." in result.output
+        assert "Git stuff." not in result.output
+
+    def test_search_finds_plain_entries(self, tmp_path: Path) -> None:
+        content = (
+            KNOWLEDGE_TEMPLATE
+            + "\n## Git Worktree Tips\n\nAlways isolate work in worktrees.\n\n---\n\n"
+            + "## Docker Tips\n\nUnrelated.\n\n---\n"
+        )
+        (tmp_path / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        config = ProjectConfig(
+            project_root=str(tmp_path),
+            knowledge=KnowledgeConfig(enabled=True, path="KNOWLEDGE.md"),
+        )
+        with patch("wade.config.loader.load_config", return_value=config):
+            result = runner.invoke(app, ["knowledge", "get", "--search", "worktree", "--no-filter"])
+        assert result.exit_code == 0
+        assert "Worktree" in result.output
+        assert "Unrelated." not in result.output
+
+    def test_plain_entry_not_score_annotated(self, tmp_path: Path) -> None:
+        content = KNOWLEDGE_TEMPLATE + "\n## My Plain Entry\n\nPlain content.\n\n---\n"
+        (tmp_path / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        config = ProjectConfig(
+            project_root=str(tmp_path),
+            knowledge=KnowledgeConfig(enabled=True, path="KNOWLEDGE.md"),
+        )
+        with patch("wade.config.loader.load_config", return_value=config):
+            result = runner.invoke(app, ["knowledge", "get"])
+        assert result.exit_code == 0
+        assert "Plain content." in result.output
+        assert "[+" not in result.output
 
 
 class TestKnowledgeRateCommand:

--- a/tests/unit/test_services/test_knowledge_service.py
+++ b/tests/unit/test_services/test_knowledge_service.py
@@ -1257,3 +1257,117 @@ class TestAppendKnowledgeWorktreeRedirect:
         assert not (worktree_root / "KNOWLEDGE.md").exists()
         text = (main_root / "KNOWLEDGE.md").read_text(encoding="utf-8")
         assert "Learned from worktree." in text
+
+
+# --- Plain ## Title entry support ---
+
+
+class TestPlainEntryParsing:
+    def test_parses_plain_heading(self) -> None:
+        text = "## My Plain Entry\n\nSome plain content.\n\n---\n"
+        entries = parse_entries(text)
+        assert len(entries) == 1
+        assert entries[0].entry_id is None
+        assert entries[0].date is None
+        assert entries[0].heading_rest == "My Plain Entry"
+        assert entries[0].content == "Some plain content."
+
+    def test_parses_multiple_plain_entries(self) -> None:
+        text = (
+            "## First Entry\n\nFirst content.\n\n---\n\n## Second Entry\n\nSecond content.\n\n---\n"
+        )
+        entries = parse_entries(text)
+        assert len(entries) == 2
+        assert entries[0].heading_rest == "First Entry"
+        assert entries[1].heading_rest == "Second Entry"
+
+    def test_plain_entries_mixed_with_dated_entries(self) -> None:
+        text = (
+            KNOWLEDGE_TEMPLATE
+            + "\n## My Plain Entry\n\nPlain content.\n\n---\n\n"
+            + "## a1b2c3d4 | 2026-03-24 | plan\n\nDated content.\n\n---\n"
+        )
+        entries = parse_entries(text)
+        assert len(entries) == 2
+        assert entries[0].entry_id is None
+        assert entries[0].date is None
+        assert entries[1].entry_id == "a1b2c3d4"
+        assert entries[1].date == "2026-03-24"
+
+    def test_plain_entry_not_score_annotated(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        content = KNOWLEDGE_TEMPLATE + "\n## My Plain Entry\n\nPlain content.\n\n---\n"
+        (project_root / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        result = get_annotated_knowledge(project_root, config)
+        assert result.content is not None
+        assert "Plain content." in result.content
+        assert "[+" not in result.content
+
+    def test_search_finds_plain_entry_by_content(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        content = (
+            KNOWLEDGE_TEMPLATE
+            + "\n## My Plain Entry\n\nWorktree isolation tip.\n\n---\n\n"
+            + "## Another Entry\n\nUnrelated stuff.\n\n---\n"
+        )
+        (project_root / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        result = get_annotated_knowledge(
+            project_root, config, search_query="worktree", no_filter=True
+        )
+        assert result.content is not None
+        assert "Worktree isolation tip." in result.content
+        assert "Unrelated stuff." not in result.content
+        assert result.entries_count == 1
+
+    def test_search_finds_plain_entry_by_heading(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        content = (
+            KNOWLEDGE_TEMPLATE
+            + "\n## Git Worktree Tips\n\nSome content here.\n\n---\n\n"
+            + "## Docker Tips\n\nOther content.\n\n---\n"
+        )
+        (project_root / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        result = get_annotated_knowledge(
+            project_root, config, search_query="worktree", no_filter=True
+        )
+        assert result.content is not None
+        assert "Git Worktree Tips" in result.content
+        assert "Docker Tips" not in result.content
+
+    def test_plain_entries_not_excluded_by_score_filter(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        content = KNOWLEDGE_TEMPLATE + "\n## My Plain Entry\n\nPlain content.\n\n---\n"
+        (project_root / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        result = get_annotated_knowledge(project_root, config, min_score=0)
+        assert result.content is not None
+        assert "Plain content." in result.content
+
+
+class TestNoMatchHeaderOnlyOutput:
+    def test_no_match_returns_header_not_full_file(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        content = KNOWLEDGE_TEMPLATE + "\n## a1b2c3d4 | 2026-03-24 | plan\n\nDocker tips.\n\n---\n"
+        (project_root / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        result = get_annotated_knowledge(
+            project_root, config, search_query="nonexistent", no_filter=True
+        )
+        assert result.entries_count == 0
+        assert result.content is not None
+        assert "Docker tips." not in result.content
+
+    def test_no_match_with_plain_entries_returns_header_not_full_file(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        content = KNOWLEDGE_TEMPLATE + "\n## My Plain Entry\n\nPlain content.\n\n---\n"
+        (project_root / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        result = get_annotated_knowledge(
+            project_root, config, search_query="nonexistent", no_filter=True
+        )
+        assert result.entries_count == 0
+        assert result.content is not None
+        assert "Plain content." not in result.content

--- a/tests/unit/test_services/test_knowledge_service.py
+++ b/tests/unit/test_services/test_knowledge_service.py
@@ -1371,3 +1371,16 @@ class TestNoMatchHeaderOnlyOutput:
         assert result.entries_count == 0
         assert result.content is not None
         assert "Plain content." not in result.content
+
+
+class TestPlainEntrySubheadingBehavior:
+    def test_dated_entry_body_with_hash_hash_subheading(self) -> None:
+        # Document current behavior: ## subheading inside a dated entry body is
+        # treated as a boundary and becomes a second plain entry.
+        text = (
+            "## a1b2c3d4 | 2026-03-24 | plan\n\nIntro.\n\n## Background\n\nMore content.\n\n---\n"
+        )
+        entries = parse_entries(text)
+        assert len(entries) == 2
+        assert entries[0].entry_id == "a1b2c3d4"
+        assert entries[1].heading_rest == "Background"


### PR DESCRIPTION
Closes #282

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem

`wade knowledge get --search <term>` produces confusing output when the knowledge file contains plain `## Title` headings (hand-authored, without the `## YYYY-MM-DD | Title` format the parser expects):

1. **Parser silently returns no entries.** `_ENTRY_HEADING_RE` requires a date field, so plain headings don't match and `parse_entries` returns `[]`. Search has nothing to operate on.
2. **Full file is dumped despite the warning.** When `entries == []`, `get_annotated_knowledge` sets `header = text` (the full file). Since `console.raw(result.content)` always executes, the user sees "No entries matched your search." on stderr followed by the entire knowledge file on stdout — deeply misleading.

Affected files:
- `src/wade/services/knowledge_service.py` — `_ENTRY_HEADING_RE`, `ParsedEntry`, `parse_entries`, `get_annotated_knowledge`
- `src/wade/cli/knowledge.py` — `get()` command
- `tests/unit/test_services/test_knowledge_service.py` (and/or `test_cli/test_knowledge_cli.py`)

## Proposed Solution

### 1. Extend `parse_entries` to handle plain `## Title` entries

Add a fallback regex for headings that have no date or ID:

```python
_PLAIN_ENTRY_HEADING_RE = re.compile(r"^## (.+?)(?:\s+\[.*\])?\s*$")
```

In `parse_entries`, after the existing `_ENTRY_HEADING_RE` check fails, try `_PLAIN_ENTRY_HEADING_RE`. Plain entries get `entry_id=None`, `date=None`, `heading_rest=<title>`.

### 2. Make `ParsedEntry.date` optional

```python
class ParsedEntry(BaseModel, frozen=True):
    entry_id: str | None
    date: str | None        # None for plain entries
    heading_rest: str
    tags: list[str] = []
    content: str
    raw: str
```

### 3. Skip score annotation for plain entries in `get_annotated_knowledge`

`should_annotate` is already gated on `entry.entry_id is not None`. Plain entries have no ID so they pass through unmodified (no `[+N/-M]` suffix). Score filtering also already skips entries without IDs (the auto-threshold check requires `entry.entry_id is not None`). No additional changes needed there.

**Type safety:** Making `date: str | None` means the annotation line `f"## {id_part}{entry.date} | ..."` will get a mypy error since `date` could be `None`. At runtime this path is unreachable for plain entries (guarded by `should_annotate`), but the implementer must add a type guard (e.g., `assert entry.date is not None`) before that f-string to satisfy mypy.

**Tag extraction:** Tags are parsed from entry content (not the heading), so they work identically for plain entries — no changes needed.

### 4. Fix the `header = text` fallback

When `entries == []`, the current code sets `header = text` (the full file). Fix it to extract only the true preamble (everything before the first `##` heading):

```python
if entries:
    first_entry_pos = text.find(entries[0].raw)
    header = text[:first_entry_pos] if first_entry_pos > 0 else ""
else:
    # No entries parsed — extract preamble before the first ## heading
    import re as _re
    m = _re.search(r"^##\s", text, _re.MULTILINE)
    header = text[: m.start()] if m else text
```

### 5. Return early in CLI `get()` when no results after filtering

```python
if (search or tag) and result.entries_count == 0:
    print("No entries matched your search.", file=sys.stderr)
    raise typer.Exit(0)

console.raw(result.content)
```

## Tasks

- [ ] Add `_PLAIN_ENTRY_HEADING_RE` and update `parse_entries` to match plain `## Title` headings as a fallback
- [ ] Make `ParsedEntry.date` `str | None` and add a `assert entry.date is not None` type guard before the annotation f-string (only reached when `should_annotate=True`, which requires a non-None `entry_id` — and those entries always have a date)
- [ ] Fix `get_annotated_knowledge`: compute real preamble when `entries == []` instead of using full file text
- [ ] Fix CLI `get()`: return early (exit 0) when `entries_count == 0` after search/tag filter
- [ ] Add unit tests for plain-entry parsing (parse_entries returns entries for plain headings)
- [ ] Add unit tests for search over plain entries (`--search` finds plain entries by keyword)
- [ ] Add unit tests for the no-match early-exit (no content printed when search returns 0 results)
- [ ] Run `./scripts/check-all.sh` and ensure all tests and type checks pass

## Acceptance Criteria

- [ ] `wade knowledge get --search <term>` finds entries in plain `## Title` format when the term appears in the heading or body
- [ ] When no entries match a search/tag filter, only the warning message is printed — no file content is dumped
- [ ] Plain entries are not score-annotated (no `[+N/-M]` suffix)
- [ ] Score filtering does not exclude plain entries (they have no votes to filter on)
- [ ] All existing knowledge tests continue to pass
- [ ] `./scripts/check-all.sh` passes (tests + lint + types)

<!-- wade:plan:end -->

## Summary

## What was done

Fixed two bugs in `wade knowledge get --search`: (1) plain `## Title` headings
(hand-authored, without the `## YYYY-MM-DD | ...` format) were silently ignored
by `parse_entries`, so searches returned nothing; (2) when `entries == []` after
filtering, the full file was printed alongside the "No entries matched" warning.

## Changes

- Added `_PLAIN_ENTRY_HEADING_RE` fallback regex; `parse_entries` now parses
  plain `## Title` headings as entries with `entry_id=None`, `date=None`
- Made `ParsedEntry.date` `str | None` and added `assert entry.date is not None`
  guards in `get_annotated_knowledge`, `add_tag_to_entry`, `remove_tag_from_entry`
- Fixed `get_annotated_knowledge`: extract real preamble (before first `##`) when
  `entries == []` instead of returning full file as `header`
- Fixed CLI `get()`: `raise typer.Exit(0)` after the no-match warning so file
  content is never printed when search/tag filter returns 0 entries
- Tightened `_PLAIN_ENTRY_HEADING_RE` to require title starts with `[A-Za-z0-9]`,
  preventing stray `## ---` lines from being mis-parsed as entries

## Testing

- Added `TestPlainEntryParsing` and `TestNoMatchHeaderOnlyOutput` classes to
  `test_knowledge_service.py` (plain heading parse, search by content/heading,
  score-filter pass-through, header-only output on no match)
- Added `test_search_finds_plain_entries`, `test_plain_entry_not_score_annotated`,
  and `not in result.output` assertions to existing no-match CLI tests
- Added `TestPlainEntrySubheadingBehavior` to document split behavior when a
  dated entry body contains a `## ` subheading
- `./scripts/check-all.sh` passes: 141 tests, lint clean, mypy strict

## Notes for reviewers

Plain entries are not score-annotated (`should_annotate` requires a non-None
`entry_id`) and are never excluded by score filtering, matching the spec.
The content-collection loop in `parse_entries` now breaks on both the dated and
plain heading regexes so consecutive plain entries are correctly separated.

## Remaining

No unresolved threads.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **27,787** |
| Input tokens | **687** |
| Output tokens | **27,100** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search/knowledge retrieval now exits cleanly when filters return zero matches, preventing incorrect content from being shown.

* **New Features**
  * Plain headings (e.g., "## Title" without date/ID) are recognized as knowledge entries and are searchable; they are not decorated with score markers by default.

* **Tests**
  * New and updated tests cover plain-entry parsing, search/annotation behavior, and no-results scenarios.

* **Documentation**
  * Updated knowledge notes describing the parsing and search fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **9,430** |
| Input tokens | **730** |
| Output tokens | **8,700** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `f85074e7-9612-458f-8f78-315bb983756c` |
| Review | `claude` | `8e5a3826-d190-4413-8328-a1e69f2a7702` |

<!-- wade:sessions:end -->
