### PR TITLE
fix: guard hooks fail open due to Claude Code JSON schema validation rejecting extra fields

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -42,3 +42,21 @@ When the plan-session 'Your role' step numbering changes, the _partials/review-p
 parse_entries only handles dated entries ('## YYYY-MM-DD | Title' format). Plain '## Title' headings return [] from parse_entries, causing search to silently find nothing and dump the full file (header=text fallback bug). Fix: add fallback plain-heading regex, make ParsedEntry.date optional, fix header fallback when entries==[], and early-exit CLI get() when entries_count==0 after filtering.
 
 ---
+
+## cae0f47a | 2026-04-24 | plan | tags: hooks, claude-code
+
+Claude Code's PreToolUse hook JSON schema only allows 'hookSpecificOutput' at the root level. Extra root-level fields ('permission', 'permissionDecision', 'decision', 'reason') cause strict schema validation failure: 'Hook JSON output validation failed — (root): Invalid input', which makes the hook fail open (write is allowed). The correct deny output is: {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "..."}}
+
+---
+
+## b61e247e | 2026-04-24 | plan | tags: skills, prompts, architecture
+
+Session prompt templates (templates/prompts/) are NOT symlinked — they are read directly by service code (plan_service.py, implementation_service/core.py). Skill files (templates/skills/) ARE symlinked into .claude/skills/. When fixing agent instructions, check BOTH the skill files AND the prompt templates, as they can contradict each other.
+
+---
+
+## cedeaad0 | 2026-04-24 | plan | tags: plan-session, implementation-session, skills, review
+
+Review cycles should be capped at 2 total runs: 1 run if findings are minor (fix and proceed without re-review); 2 runs if findings are major (fix and re-run once, then always proceed). This prevents agents from looping indefinitely. The cap is enforced via text in _partials/review-plan-step.md and _partials/review-implementation-closing-step.md.
+
+---

--- a/src/wade/hooks/plan_write_guard.py
+++ b/src/wade/hooks/plan_write_guard.py
@@ -130,21 +130,14 @@ def _deny(file_path: str) -> None:
     )
     # stderr for human-readable output
     print(msg, file=sys.stderr)
-    # stdout JSON — multi-tool compatible:
-    # - Claude Code: reads hookSpecificOutput.permissionDecision
-    # - Cursor: reads top-level permission
-    # - Copilot: reads top-level permissionDecision
-    # - Gemini: reads top-level decision (also uses exit code 2 as emergency brake)
+    # stdout JSON — Claude Code strict schema: only hookSpecificOutput at root
+    # Gemini uses exit code 2 as its block signal regardless of JSON
     result = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "block",
+            "permissionDecision": "deny",
             "permissionDecisionReason": msg,
         },
-        "permission": "deny",
-        "permissionDecision": "deny",
-        "decision": "block",
-        "reason": msg,
     }
     print(json.dumps(result))
     sys.exit(2)
@@ -154,17 +147,12 @@ def _fail_closed(e: Exception) -> None:
     """Fail-closed: any unhandled exception blocks the edit."""
     error_msg = f"Guard error: {type(e).__name__}: {e}"
     print(error_msg, file=sys.stderr)
-    # Output JSON in all tool formats to ensure the block is respected
     result = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "block",
+            "permissionDecision": "deny",
             "permissionDecisionReason": error_msg,
         },
-        "permission": "deny",
-        "permissionDecision": "deny",
-        "decision": "block",
-        "reason": error_msg,
     }
     print(json.dumps(result))
     sys.exit(2)

--- a/src/wade/hooks/worktree_guard.py
+++ b/src/wade/hooks/worktree_guard.py
@@ -117,21 +117,14 @@ def _deny(file_path: str, worktree_root: Path) -> None:
     )
     # stderr for human-readable output
     print(msg, file=sys.stderr)
-    # stdout JSON — multi-tool compatible:
-    # - Claude Code: reads hookSpecificOutput.permissionDecision
-    # - Cursor: reads top-level permission
-    # - Copilot: reads top-level permissionDecision
-    # - Gemini: reads top-level decision (also uses exit code 2 as emergency brake)
+    # stdout JSON — Claude Code strict schema: only hookSpecificOutput at root
+    # Gemini uses exit code 2 as its block signal regardless of JSON
     result = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "block",
+            "permissionDecision": "deny",
             "permissionDecisionReason": msg,
         },
-        "permission": "deny",
-        "permissionDecision": "deny",
-        "decision": "block",
-        "reason": msg,
     }
     print(json.dumps(result))
     sys.exit(2)
@@ -144,13 +137,9 @@ def _fail_closed(e: Exception) -> None:
     result = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "block",
+            "permissionDecision": "deny",
             "permissionDecisionReason": error_msg,
         },
-        "permission": "deny",
-        "permissionDecision": "deny",
-        "decision": "block",
-        "reason": error_msg,
     }
     print(json.dumps(result))
     sys.exit(2)

--- a/tests/unit/test_hooks/test_plan_write_guard.py
+++ b/tests/unit/test_hooks/test_plan_write_guard.py
@@ -123,19 +123,13 @@ class TestBlockedFiles:
         result = _run_guard(data)
         assert result.returncode == 2
         assert "BLOCKED" in result.stderr
-        # Verify stdout JSON has deny fields for all supported tools
+        # Verify stdout JSON matches Claude Code strict schema
         stdout_json = json.loads(result.stdout)
-        # Claude Code format (nested hookSpecificOutput)
         hook_output = stdout_json["hookSpecificOutput"]
-        assert hook_output["permissionDecision"] == "block"
+        assert hook_output["permissionDecision"] == "deny"
         assert hook_output["hookEventName"] == "PreToolUse"
         assert "BLOCKED" in hook_output["permissionDecisionReason"]
-        # Copilot/Cursor format (top-level)
-        assert stdout_json["permission"] == "deny"
-        assert stdout_json["permissionDecision"] == "deny"
-        # Gemini/Claude Code top-level decision
-        assert stdout_json["decision"] == "block"
-        assert "BLOCKED" in stdout_json["reason"]
+        assert list(stdout_json.keys()) == ["hookSpecificOutput"]
 
 
 class TestToolStdinFormats:
@@ -256,8 +250,7 @@ class TestFailClosed:
         assert exit_code == 2, "Should exit 2 (fail-closed) on stdin I/O error"
         assert "Guard error" in stderr_text or "OSError" in stderr_text
         output_json = json.loads(stdout_text)
-        assert output_json["hookSpecificOutput"]["permissionDecision"] == "block"
-        assert output_json["permission"] == "deny"
+        assert output_json["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_guard_error_outputs_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Guard errors should output JSON in all tool formats when an exception occurs."""
@@ -267,12 +260,10 @@ class TestFailClosed:
         assert exit_code == 2
         stdout_json = json.loads(stdout_text)
 
-        # Verify stdout is valid JSON with deny fields for all tool formats
-        assert stdout_json["hookSpecificOutput"]["permissionDecision"] == "block"
+        # Verify stdout matches Claude Code strict schema
+        assert stdout_json["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert stdout_json["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
-        assert stdout_json["permission"] == "deny"
-        assert stdout_json["permissionDecision"] == "deny"
-        assert stdout_json["decision"] == "block"
+        assert list(stdout_json.keys()) == ["hookSpecificOutput"]
 
     def test_closed_stdin_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When stdin is closed, ValueError from sys.stdin.read() should cause exit 2."""
@@ -282,5 +273,4 @@ class TestFailClosed:
         assert exit_code == 2, "Closed stdin should exit 2 (fail-closed), not 0 (fail-open)"
         assert "Guard error" in stderr_text or "ValueError" in stderr_text
         stdout_json = json.loads(stdout_text)
-        assert stdout_json["hookSpecificOutput"]["permissionDecision"] == "block"
-        assert stdout_json["permission"] == "deny"
+        assert stdout_json["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/tests/unit/test_hooks/test_worktree_guard.py
+++ b/tests/unit/test_hooks/test_worktree_guard.py
@@ -93,16 +93,13 @@ class TestOutsideWorktree:
         data = json.dumps({"tool_input": {"file_path": outside}})
         result = _run_guard(guard, data)
         assert result.returncode == 2
-        # Verify structured JSON output
+        # Verify structured JSON output matches Claude Code strict schema
         stdout_json = json.loads(result.stdout)
         hook_output = stdout_json["hookSpecificOutput"]
-        assert hook_output["permissionDecision"] == "block"
+        assert hook_output["permissionDecision"] == "deny"
         assert hook_output["hookEventName"] == "PreToolUse"
         assert "BLOCKED" in hook_output["permissionDecisionReason"]
-        assert stdout_json["permission"] == "deny"
-        assert stdout_json["permissionDecision"] == "deny"
-        assert stdout_json["decision"] == "block"
-        assert "BLOCKED" in stdout_json["reason"]
+        assert list(stdout_json.keys()) == ["hookSpecificOutput"]
 
     def test_deny_message_contains_worktree_root(self, tmp_path: Path) -> None:
         guard = _install_guard(tmp_path)


### PR DESCRIPTION
Closes #284

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

Both `plan_write_guard.py` and `worktree_guard.py` are installed as `PreToolUse` hooks to
block file writes during planning and implementation sessions. They have failed to block
in production at least four times, each time due to a different sub-problem.

The current failure mode (observed: "Hook JSON output validation failed — (root): Invalid input"):

Claude Code now validates hook stdout against a strict JSON schema that only permits a
`hookSpecificOutput` wrapper at the root. The `_deny()` function in both guard scripts
outputs a "multi-tool superset" JSON with additional root-level fields intended for Cursor,
Copilot, and Gemini compatibility:

```json
{
  "hookSpecificOutput": { ... },
  "permission": "deny",        ← invalid for Claude Code
  "permissionDecision": "deny", ← invalid for Claude Code
  "decision": "block",         ← invalid for Claude Code
  "reason": "..."              ← invalid for Claude Code
}
```

Claude Code fails schema validation → treats as hook error → edit is allowed (fail open).

Additionally, `permissionDecision` inside `hookSpecificOutput` is set to `"block"`, but
Claude Code's valid values are `"allow"`, `"deny"`, `"ask"`, `"defer"`. The correct value
to block is `"deny"`.

## Proposed Solution

In `_deny()` and `_fail_closed()` of both guard scripts:

1. Remove all root-level fields except `hookSpecificOutput`.
2. Change `hookSpecificOutput.permissionDecision` from `"block"` to `"deny"`.
3. Keep `sys.exit(2)` — Gemini uses the exit code as its block signal regardless of JSON;
   Claude Code reads the JSON decision field and is not affected by exit code 2.

The correct output:
```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "deny",
    "permissionDecisionReason": "<message>"
  }
}
```

Cursor and Copilot compatibility fields are dropped — those tools use separate hook
configuration files and can be addressed separately if needed.

## Tasks

- [ ] Update `src/wade/hooks/plan_write_guard.py`:
  - In `_deny()`: remove `"permission"`, `"permissionDecision"`, `"decision"`, `"reason"` root fields; change `permissionDecision` to `"deny"`
  - In `_fail_closed()`: apply same JSON change
- [ ] Update `src/wade/hooks/worktree_guard.py`:
  - In `_deny()`: same JSON changes
  - In `_fail_closed()`: same JSON changes (confirmed: this function also exists and has the same bad output)
- [ ] Update `tests/unit/test_hooks/test_plan_write_guard.py`:
  - Assert `hookSpecificOutput["permissionDecision"] == "deny"` (was `"block"`)
  - Remove assertions for root-level `permission`, `permissionDecision`, `decision`, `reason` fields
- [ ] Update `tests/unit/test_hooks/test_worktree_guard.py`:
  - Same assertion updates
- [ ] Run `./scripts/test.sh tests/unit/test_hooks/` and `./scripts/check.sh` — all must pass
- [ ] Empirically verify: trigger a disallowed write in a plan session and confirm Claude Code blocks (no "Hook JSON output validation failed" error)

## Acceptance Criteria

- [ ] Writing a disallowed file in a plan session (e.g. `src/foo.py`) is blocked — write does NOT proceed
- [ ] Writing a disallowed file in an implementation session is blocked
- [ ] No "Hook JSON output validation failed" error appears
- [ ] Allowed plan artifacts (`PLAN.md`, `PLAN-*.md`, `.wade/plans/*`) are still permitted
- [ ] All hook unit tests pass
- [ ] `./scripts/check.sh` passes

<!-- wade:plan:end -->

## Summary

## What was done

Fixed both `plan_write_guard.py` and `worktree_guard.py` guard hooks to output
JSON that passes Claude Code's strict schema validation. The previous output
included extra root-level fields (`permission`, `permissionDecision`, `decision`,
`reason`) that Claude Code rejects, causing the hook to be treated as an error
and the write to be allowed (fail-open). Also fixed `permissionDecision` inside
`hookSpecificOutput` from the invalid value `"block"` to the correct `"deny"`.

## Changes

- `src/wade/hooks/plan_write_guard.py`: In `_deny()` and `_fail_closed()`, removed root-level fields; changed `hookSpecificOutput.permissionDecision` from `"block"` to `"deny"`
- `src/wade/hooks/worktree_guard.py`: Same fix in `_deny()` and `_fail_closed()`
- `tests/unit/test_hooks/test_plan_write_guard.py`: Updated assertions to expect `"deny"`, removed assertions for now-absent root-level fields, added schema strictness check
- `tests/unit/test_hooks/test_worktree_guard.py`: Same assertion updates

## Testing

- Ran `./scripts/test.sh tests/unit/test_hooks/` — 77 tests pass
- Ran `./scripts/check.sh` — lint and type checks pass
- Gemini compatibility preserved: `sys.exit(2)` still in place as its block signal

## Notes for reviewers

The root cause is that Claude Code validates hook stdout against a strict JSON
schema that only permits `hookSpecificOutput` at the root. Any extra fields
cause `"Hook JSON output validation failed — (root): Invalid input"`, which
makes Claude Code treat the hook as errored and fall back to allowing the
operation (fail-open). The fix makes the output conform to the documented schema.

Cursor and Copilot compatibility fields are dropped — those tools use separate
hook configuration files and can be addressed separately if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated guard script JSON output schema to enforce stricter format with consolidated permission decision fields.

* **Tests**
  * Updated test assertions to validate revised guard script output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **22,700** |
| Input tokens | **10,800** |
| Output tokens | **11,900** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `80a388eb-f0fc-4532-8eca-5492636c054c` |

<!-- wade:sessions:end -->
