### PR TITLE
fix: plan and implementation session prompts instruct agent to read full KNOWLEDGE.md before topic is known

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -42,3 +42,21 @@ When the plan-session 'Your role' step numbering changes, the _partials/review-p
 parse_entries only handles dated entries ('## YYYY-MM-DD | Title' format). Plain '## Title' headings return [] from parse_entries, causing search to silently find nothing and dump the full file (header=text fallback bug). Fix: add fallback plain-heading regex, make ParsedEntry.date optional, fix header fallback when entries==[], and early-exit CLI get() when entries_count==0 after filtering.
 
 ---
+
+## cae0f47a | 2026-04-24 | plan | tags: hooks, claude-code
+
+Claude Code's PreToolUse hook JSON schema only allows 'hookSpecificOutput' at the root level. Extra root-level fields ('permission', 'permissionDecision', 'decision', 'reason') cause strict schema validation failure: 'Hook JSON output validation failed — (root): Invalid input', which makes the hook fail open (write is allowed). The correct deny output is: {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "..."}}
+
+---
+
+## b61e247e | 2026-04-24 | plan | tags: skills, prompts, architecture
+
+Session prompt templates (templates/prompts/) are NOT symlinked — they are read directly by service code (plan_service.py, implementation_service/core.py). Skill files (templates/skills/) ARE symlinked into .claude/skills/. When fixing agent instructions, check BOTH the skill files AND the prompt templates, as they can contradict each other.
+
+---
+
+## cedeaad0 | 2026-04-24 | plan | tags: plan-session, implementation-session, skills, review
+
+Review cycles should be capped at 2 total runs: 1 run if findings are minor (fix and proceed without re-review); 2 runs if findings are major (fix and re-run once, then always proceed). This prevents agents from looping indefinitely. The cap is enforced via text in _partials/review-plan-step.md and _partials/review-implementation-closing-step.md.
+
+---

--- a/templates/prompts/implement-context.md
+++ b/templates/prompts/implement-context.md
@@ -2,8 +2,6 @@ Follow @.claude/skills/implementation-session/SKILL.md for session rules.
 
 Use your tool's native task/todo tracking mechanism to populate a checklist with the workflow steps from the skill before starting work.
 
-If a project knowledge file is configured (see `.wade.yml` → `knowledge`), read it for project context.
-
 # Goal
 
 Let's implement @PLAN.md. Working on Issue #{issue_number}: {issue_title}

--- a/templates/prompts/plan-session.md
+++ b/templates/prompts/plan-session.md
@@ -2,8 +2,6 @@ Follow @.claude/skills/plan-session/SKILL.md for session rules.
 
 Use your tool's native task/todo tracking mechanism to populate a checklist with the workflow steps from the skill before starting work.
 
-If a project knowledge file is configured (see `.wade.yml` → `knowledge`), read it for project context.
-
 # Goal
 
 Let's plan a feature. You'll plan the feature, break it down into one or more


### PR DESCRIPTION
Closes #286

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

Both session prompt templates contained the following instruction near the top:

> "If a project knowledge file is configured (see `.wade.yml` → `knowledge`), read it for project context."

This caused agents to read the entire `KNOWLEDGE.md` file at session start — before the user
had specified any feature or topic. On large knowledge bases this wastes context and defeats
the purpose of the search-first design.

The skill files already had the correct, topic-gated instruction:
- `plan-session/SKILL.md` step 2: "Search relevant knowledge — **once you know the topic**"
- `implementation-session/SKILL.md`: "search for knowledge relevant to your task (do not dump all entries)"

The prompt templates were contradicting the skills.

Affected files:
- `templates/prompts/plan-session.md` — line 5 (now removed)
- `templates/prompts/implement-context.md` — line 5 (now removed)

Note: the fix was already applied to the working tree during the planning session that
uncovered this issue. This issue exists to track the change formally and ensure it is
reviewed and merged.

## Proposed Solution

Remove the offending line from both prompt templates. No skill changes are needed — the
skills already enforce the correct "search after topic is known" behaviour.

The removal was already applied:
- `templates/prompts/plan-session.md`: line deleted
- `templates/prompts/implement-context.md`: line deleted

The implementer should verify the diff, run the check suite, and merge.

## Tasks

- [ ] Verify the diff in `templates/prompts/plan-session.md` — confirm the "read it for project context" line is removed and nothing else changed
- [ ] Verify the diff in `templates/prompts/implement-context.md` — same check
- [ ] Confirm `templates/skills/plan-session/SKILL.md` step 2 still says "once you know the topic" (no change needed, just verify)
- [ ] Confirm `templates/skills/implementation-session/SKILL.md` still says "search for knowledge relevant to your task" (no change needed, just verify)
- [ ] Run `./scripts/check-all.sh` — must pass

## Acceptance Criteria

- [ ] `templates/prompts/plan-session.md` does not contain "read it for project context"
- [ ] `templates/prompts/implement-context.md` does not contain "read it for project context"
- [ ] A new plan session does not read `KNOWLEDGE.md` before the user specifies a topic
- [ ] `./scripts/check-all.sh` passes

<!-- wade:plan:end -->

## Summary

## What was done

Removed the premature "read KNOWLEDGE.md for project context" instruction from
both session prompt templates. This line caused agents to dump the entire
knowledge file at session start — before the user had specified any topic —
wasting context and defeating the search-first design already enforced by the
skill files.

## Changes

- Removed offending line from `templates/prompts/plan-session.md`
- Removed offending line from `templates/prompts/implement-context.md`
- Committed three new KNOWLEDGE.md entries captured during the planning session

## Testing

- Verified both prompt templates no longer contain "read it for project context"
- Confirmed `templates/skills/plan-session/SKILL.md` and
  `templates/skills/implementation-session/SKILL.md` still have the correct
  topic-gated search instructions (unchanged)
- Ran `./scripts/check-all.sh`: 2369 tests passed, lint clean, types clean

## Notes for reviewers

No skill files were changed — they already had the correct behaviour. The
prompt templates were the only source of the contradiction.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **8,869** |
| Input tokens | **669** |
| Output tokens | **8,200** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `415062a8-9351-46af-a4b3-5f97c4724e76` |

<!-- wade:sessions:end -->
