### PR TITLE
docs: limit review cycles to at most 2 runs in skill partials

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -42,3 +42,21 @@ When the plan-session 'Your role' step numbering changes, the _partials/review-p
 parse_entries only handles dated entries ('## YYYY-MM-DD | Title' format). Plain '## Title' headings return [] from parse_entries, causing search to silently find nothing and dump the full file (header=text fallback bug). Fix: add fallback plain-heading regex, make ParsedEntry.date optional, fix header fallback when entries==[], and early-exit CLI get() when entries_count==0 after filtering.
 
 ---
+
+## cae0f47a | 2026-04-24 | plan | tags: hooks, claude-code
+
+Claude Code's PreToolUse hook JSON schema only allows 'hookSpecificOutput' at the root level. Extra root-level fields ('permission', 'permissionDecision', 'decision', 'reason') cause strict schema validation failure: 'Hook JSON output validation failed — (root): Invalid input', which makes the hook fail open (write is allowed). The correct deny output is: {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "..."}}
+
+---
+
+## b61e247e | 2026-04-24 | plan | tags: skills, prompts, architecture
+
+Session prompt templates (templates/prompts/) are NOT symlinked — they are read directly by service code (plan_service.py, implementation_service/core.py). Skill files (templates/skills/) ARE symlinked into .claude/skills/. When fixing agent instructions, check BOTH the skill files AND the prompt templates, as they can contradict each other.
+
+---
+
+## cedeaad0 | 2026-04-24 | plan | tags: plan-session, implementation-session, skills, review
+
+Review cycles should be capped at 2 total runs: 1 run if findings are minor (fix and proceed without re-review); 2 runs if findings are major (fix and re-run once, then always proceed). This prevents agents from looping indefinitely. The cap is enforced via text in _partials/review-plan-step.md and _partials/review-implementation-closing-step.md.
+
+---

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -11,6 +11,14 @@ Run `wade review implementation` to review your changes and check the exit code:
 
 For staged-only review: `wade review implementation --staged`.
 
+**Run at most 2 times total**:
+- If findings are **minor** (style, small fixes): Address them and proceed to
+  Step 2; no re-review needed.
+- If findings are **major** (logic errors, architectural issues): Address them
+  and re-run once. Always proceed to Step 2 after the 2nd run, regardless of
+  new findings.
+- Never re-run more than twice.
+
 **This step is mandatory when `review_implementation.enabled` is not `false`.
 Do NOT proceed to Step 2 until this step is complete and any actionable
 findings are addressed and committed.**

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -17,7 +17,7 @@ For staged-only review: `wade review implementation --staged`.
 - If findings are **major** (logic errors, architectural issues): Address them
   and re-run once. Always proceed to Step 2 after the 2nd run, regardless of
   new findings.
-- Never re-run more than twice.
+- Do not run a third time.
 
 **This step is mandatory when `review_implementation.enabled` is not `false`.
 Do NOT proceed to Step 2 until this step is complete and any actionable

--- a/templates/skills/_partials/review-plan-step.md
+++ b/templates/skills/_partials/review-plan-step.md
@@ -14,4 +14,4 @@
    - If findings are **major** (structural issues, unclear requirements): Fix and
      re-run once. Always proceed to validation after the 2nd run, regardless of
      new findings.
-   - Never re-run more than twice.
+   - Do not run a third time.

--- a/templates/skills/_partials/review-plan-step.md
+++ b/templates/skills/_partials/review-plan-step.md
@@ -7,3 +7,11 @@
      as the reviewer: read the instructions, analyze the plan, identify issues,
      and fix them before proceeding to validation.
    - **Exit 1**: Error — debug and retry.
+
+   **Run at most 2 times total**:
+   - If findings are **minor** (typos, small clarifications): Fix and proceed to
+     validation; no re-review needed.
+   - If findings are **major** (structural issues, unclear requirements): Fix and
+     re-run once. Always proceed to validation after the 2nd run, regardless of
+     new findings.
+   - Never re-run more than twice.


### PR DESCRIPTION
Closes #288

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
The plan and implementation session skills instruct agents to run review,
fix findings, and re-run — but there is no explicit cap on iterations.
Agents can loop indefinitely, or be overly conservative and re-run even
for trivial nits.

## Proposed Solution
Add a "run at most 2 times" rule to both review partials:
- 1 run if findings are minor (fix and proceed, no re-review needed)
- 2 runs if findings are major (fix and re-run once; always proceed after the 2nd run)
- Never run more than 2 times total

The two files to change:
- `templates/skills/_partials/review-plan-step.md`
- `templates/skills/_partials/review-implementation-closing-step.md`

## Tasks
- [ ] Edit `templates/skills/_partials/review-plan-step.md` to add the 2-run cap rule
- [ ] Edit `templates/skills/_partials/review-implementation-closing-step.md` to add the 2-run cap rule

## Acceptance Criteria
- [ ] Both partials explicitly state the "at most 2 reviews" rule
- [ ] Minor findings → 1 run (fix and proceed, no re-review); major findings → up to 2 runs (fix, re-run once, then always proceed)
- [ ] Installed skill symlinks automatically reflect the change (no extra steps needed)

<!-- wade:plan:end -->

## Summary

## What was addressed

Resolved wording ambiguity in skill partials regarding review cycle execution limits.

## Changes

- Fixed `templates/skills/_partials/review-implementation-closing-step.md`: Changed "Never re-run more than twice" to "Do not run a third time" for clarity
- Fixed `templates/skills/_partials/review-plan-step.md`: Changed "Never re-run more than twice" to "Do not run a third time" to match implementation partial

Both changes clarify that the maximum is 2 total executions, not 3 (which "re-run twice" could imply).

## Remaining

All review threads resolved (2/2).

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | **6,708** |
| Input tokens | **908** |
| Output tokens | **5,800** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PreToolUse hook JSON validation details and required root-field behavior
  * Clarified filesystem behavior: prompt templates are read directly; skill files are symlinked—check both for contradictions
  * Documented review-cycle execution limits (max 2 runs) and branching rules for minor vs. major findings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | **5,500** |
| Input tokens | **1,300** |
| Output tokens | **4,200** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `f17e2f96-d08a-464a-9f8e-1ab64f472be6` |
| Review | `claude` | `2b1ba260-dc36-47eb-92bb-4b96df14edbc` |

<!-- wade:sessions:end -->
