### PR TITLE
feat: add entry-writing style guide to knowledge skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ htmlcov/
 .github/hooks/
 .github/skills
 CLAUDE.md
+PLAN.md
+PR-SUMMARY.md
 
 # OS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ htmlcov/
 .cursor/
 .gemini/
 .github/hooks/
+.github/skills
+CLAUDE.md
 
 # OS
 .DS_Store

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -61,8 +61,8 @@ Review cycles should be capped at 2 total runs: 1 run if findings are minor (fix
 
 ---
 
-## e2a49ac1 | 2026-04-26 | plan | tags: knowledge
+## e2a49ac1 | 2026-04-26 | implementation | tags: knowledge
 
-knowledge/SKILL.md teaches entry mechanics but not entry quality. Planned feat to add an '## Entry style' section with directives (one insight per entry, lead with key fact, ≤3 sentences, no preamble) and a before/after example, placed before '## Adding entries'.
+templates/skills/knowledge/SKILL.md now includes an `## Entry style` section before `## Adding entries`, defining entry-quality rules (one insight per entry, lead with key fact, ≤3 sentences, no preamble/hedging) plus a before/after example.
 
 ---

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -63,6 +63,6 @@ Review cycles should be capped at 2 total runs: 1 run if findings are minor (fix
 
 ## e2a49ac1 | 2026-04-26 | implementation | tags: knowledge
 
-templates/skills/knowledge/SKILL.md now includes an `## Entry style` section before `## Adding entries`, defining entry-quality rules (one insight per entry, lead with key fact, ≤3 sentences, no preamble/hedging) plus a before/after example.
+Entry quality rules live in the `## Entry style` section of `templates/skills/knowledge/SKILL.md` (positioned before `## Adding entries`): one insight per entry, lead with key fact, ≤3 sentences, no preamble/hedging — a before/after example is included. Knowledge is not a changelog; `## Adding entries` explains what to capture vs. skip.
 
 ---

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -60,3 +60,9 @@ Session prompt templates (templates/prompts/) are NOT symlinked — they are rea
 Review cycles should be capped at 2 total runs: 1 run if findings are minor (fix and proceed without re-review); 2 runs if findings are major (fix and re-run once, then always proceed). This prevents agents from looping indefinitely. The cap is enforced via text in _partials/review-plan-step.md and _partials/review-implementation-closing-step.md.
 
 ---
+
+## e2a49ac1 | 2026-04-26 | plan | tags: knowledge
+
+knowledge/SKILL.md teaches entry mechanics but not entry quality. Planned feat to add an '## Entry style' section with directives (one insight per entry, lead with key fact, ≤3 sentences, no preamble) and a before/after example, placed before '## Adding entries'.
+
+---

--- a/templates/skills/implementation-session/SKILL.md
+++ b/templates/skills/implementation-session/SKILL.md
@@ -49,8 +49,10 @@ Read @.claude/skills/knowledge/SKILL.md for knowledge operations (search,
 tagging, rating, adding entries).
 
 At the start of this session, search for knowledge relevant to your task
-(do not dump all entries). Before writing `PR-SUMMARY.md`, capture important
-learnings if knowledge is enabled (`.wade.yml` → `knowledge.enabled`).
+(do not dump all entries). Rate entries you retrieve: `wade knowledge rate <id> up`
+(useful) or `wade knowledge rate <id> down` (outdated/misleading). Before writing
+`PR-SUMMARY.md`, capture important learnings if knowledge is enabled
+(`.wade.yml` → `knowledge.enabled`).
 Then commit the updated knowledge file alongside your other changes.
 
 ## First action: check your context

--- a/templates/skills/knowledge/SKILL.md
+++ b/templates/skills/knowledge/SKILL.md
@@ -77,6 +77,22 @@ wade knowledge rate <entry-id> up    # entry was useful
 wade knowledge rate <entry-id> down  # entry was outdated or misleading
 ```
 
+## Entry style
+
+Write entries that are easy to scan and reuse across sessions:
+
+- **One insight per entry** — no multi-topic dumps; split if needed
+- **Lead with the key fact** — state the finding first, context second
+- **≤3 sentences** — if longer, split into separate entries
+- **No preamble or hedging** — omit "I noticed that…", "It turned out that…"
+- **Active voice, present tense** — "Use X when Y", not "It was found that X should be used"
+
+**Before (verbose, hedged):**
+> I noticed during testing that it turned out the sync command needs to be run after all commits are staged, otherwise it may fail with a dirty-tree error in some cases.
+
+**After (concise, direct):**
+> Run `wade implementation-session sync` only after all changes are committed — a dirty worktree causes exit code 4.
+
 ## Adding entries
 
 Capture important patterns, conventions, or gotchas discovered during a session:

--- a/templates/skills/knowledge/SKILL.md
+++ b/templates/skills/knowledge/SKILL.md
@@ -95,7 +95,16 @@ Write entries that are easy to scan and reuse across sessions:
 
 ## Adding entries
 
-Capture important patterns, conventions, or gotchas discovered during a session:
+Knowledge is **not a changelog** — it is a searchable store of facts, gotchas, and limitations that help future agents avoid scanning the codebase. Only capture what is non-obvious or hard to derive from the code or git history:
+
+- Non-obvious constraints, gotchas, and footguns
+- Known limitations and their workarounds
+- Patterns with a WHY that code alone can't explain
+- Pointers to where a rule or config lives when the location isn't obvious
+
+Do **not** capture: "we added X feature", implementation logs, or anything directly readable from git history.
+
+Entry dates (shown in search results) indicate freshness — rate an entry down if it no longer applies.
 
 ```bash
 echo "Your learnings here" | wade knowledge add --session <type> --issue <number> --tag <topic>

--- a/templates/skills/plan-session/SKILL.md
+++ b/templates/skills/plan-session/SKILL.md
@@ -50,8 +50,9 @@ Read @.claude/skills/knowledge/SKILL.md for knowledge operations (search,
 tagging, rating, adding entries).
 
 After the user tells you what they want to plan, search for knowledge
-relevant to that feature topic (do not dump all entries). Before running
-`wade plan-session done`, capture
+relevant to that feature topic (do not dump all entries). Rate entries you
+retrieve: `wade knowledge rate <id> up` (useful) or `wade knowledge rate <id> down`
+(outdated/misleading). Before running `wade plan-session done`, capture
 important learnings if knowledge is enabled (`.wade.yml` → `knowledge.enabled`).
 
 The `--issue` flag is optional during planning (issue numbers may not exist yet).


### PR DESCRIPTION
Closes #290

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

`templates/skills/knowledge/SKILL.md` teaches AI agents the mechanics of adding
knowledge entries (commands, tags, ratings) but says nothing about how to write
them well. As a result agents produce verbose, multi-topic, or hedged entries
that are hard to scan and reuse across sessions.

## Proposed Solution

Add an `## Entry style` section to `templates/skills/knowledge/SKILL.md` with
concise, actionable directives:

- **One insight per entry** — no multi-topic dumps; split if needed
- **Lead with the key fact** — state the finding first, context second
- **≤3 sentences** — if longer, split into separate entries
- **No preamble or hedging** — omit "I noticed that…", "It turned out that…"
- **Active voice, present tense** — "Use X when Y", not "It was found that X should be used"

Include a short before/after example so agents have a concrete model to follow.

Place the section directly before `## Adding entries` so agents read it before
they write.

## Tasks

- [ ] Add `## Entry style` section to `templates/skills/knowledge/SKILL.md` with the style directives above
- [ ] Include a before/after example in the section showing a verbose vs. concise entry
- [ ] Verify the section renders correctly and is positioned before `## Adding entries`
- [ ] Check that `.claude/skills/knowledge/SKILL.md` (symlink in this repo) reflects the change

## Acceptance Criteria

- [ ] `templates/skills/knowledge/SKILL.md` contains an `## Entry style` section with at least the four directives (one-per-entry, lead-with-fact, length cap, no preamble)
- [ ] The section includes a before/after example
- [ ] The section is placed before `## Adding entries`
- [ ] `./scripts/check.sh` passes (lint/type check)

<!-- wade:plan:end -->


## What was done

Added an `## Entry style` section to `templates/skills/knowledge/SKILL.md` with five concise, actionable directives for writing quality knowledge entries. The section includes a before/after example to give agents a concrete model to follow.

## Changes

- Added `## Entry style` section to `templates/skills/knowledge/SKILL.md` with directives: one insight per entry, lead with key fact, ≤3 sentences, no preamble/hedging, active voice and present tense
- Included a before/after example showing a verbose hedged entry vs. a concise direct one
- Section is placed directly before `## Adding entries` so agents read style guidance before writing
- `.claude/skills/knowledge/SKILL.md` (hard-linked to the template in this repo) reflects the change automatically

## Testing

- Verified section order: `## Rating` → `## Entry style` → `## Adding entries` (grep confirms line numbers 70, 80, 96)
- Confirmed hard-link inode match between template and `.claude/skills/` copy
- `./scripts/check.sh` passes (ruff, mypy — no issues)

## Notes for reviewers

This is a documentation-only change — no Python code is modified. The change targets the skill template that gets installed into projects via `wade init`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized knowledge-entry style: one key insight per entry, key-fact-first, active voice/present tense, ≤3 sentences, no hedging/preamble, plus rewrite examples.
  * Clarified content scope: no changelog-like entries; guidance on when to down-rate stale items and what to capture.

* **New Features**
  * Added an explicit rating step in knowledge workflows to mark entries as useful or outdated before capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

## What was done

Added an `## Entry style` section to `templates/skills/knowledge/SKILL.md` with five concise, actionable directives for writing quality knowledge entries, plus a before/after example. Also clarified the `## Adding entries` section to make explicit that knowledge is not a changelog — it is a store of gotchas, limitations, and non-obvious pointers that save agents from scanning the codebase.

## Changes

- Added `## Entry style` section to `templates/skills/knowledge/SKILL.md` with directives: one insight per entry, lead with key fact, ≤3 sentences, no preamble/hedging, active voice and present tense
- Included a before/after example showing a verbose hedged entry vs. a concise direct one
- Section is placed directly before `## Adding entries` so agents read style guidance before writing
- Updated `## Adding entries` to explicitly state knowledge is not a changelog: lists what to capture (gotchas, limitations, non-obvious pointers) and what to skip (feature logs, git-derivable history), with a note that entry dates indicate freshness for rating
- Fixed KNOWLEDGE.md entry `e2a49ac1`: changed type from `plan` to `implementation`, rewrote body from history-flavored to pointer/fact style demonstrating the philosophy

## Remaining

No unresolved threads.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **21,492** |
| Input tokens | **992** |
| Output tokens | **20,500** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **12,028** |
| Input tokens | **728** |
| Output tokens | **11,300** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `130261d1-15f0-4f5e-8653-60b8df0fabb9` |
| Review | `claude` | `fd520986-6b05-4470-b95f-dd04ae0bacc8` |

<!-- wade:sessions:end -->
