### PR TITLE
feat: plan-session prompt should ask open-ended question, not suggest options

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -66,3 +66,9 @@ Review cycles should be capped at 2 total runs: 1 run if findings are minor (fix
 Entry quality rules live in the `## Entry style` section of `templates/skills/knowledge/SKILL.md` (positioned before `## Adding entries`): one insight per entry, lead with key fact, ≤3 sentences, no preamble/hedging — a before/after example is included. Knowledge is not a changelog; `## Adding entries` explains what to capture vs. skip.
 
 ---
+
+## ddc10718 | 2026-04-27 | implementation | tags: plan-session, prompts, ai-behavior | Issue #281
+
+When writing instructions for AI tools, "ask the user X" is not sufficient to prevent the tool from using native UI components (e.g. AskUserQuestion with pre-defined options). You must explicitly say "output a plain text question" and "do NOT use a native selection/question component or present pre-defined categories."
+
+---

--- a/templates/prompts/plan-session.md
+++ b/templates/prompts/plan-session.md
@@ -10,7 +10,7 @@ You won't create the issues or implement the feature.
 
 # Workflow
 
-1. Ask the user what feature they want to plan.
+1. Ask the user what feature they want to plan. If the session is interactive and no feature was specified in the prompt, output a plain text question (e.g. "What would you like to plan?"). Do NOT use a native selection/question component or present pre-defined categories as options.
 2. Analyze the feature and break it down into one or more GitHub issues.
 3. Generate a plan for each issue.
 4. Format each plan following the format defined in @.claude/skills/plan-session/SKILL.md.

--- a/templates/skills/plan-session/SKILL.md
+++ b/templates/skills/plan-session/SKILL.md
@@ -60,7 +60,7 @@ Running `wade knowledge add` is allowed even though this is a planning session.
 
 ## Your role
 
-1. **Ask the user** what they want to plan. If the session prompt does not already specify a feature or issue, ask before proceeding.
+1. **Ask the user** what they want to plan. If the session prompt does not already specify a feature or issue, ask before proceeding. Output a plain text question (e.g. "What would you like to plan?") — do NOT use a native selection/question component or present pre-defined categories as options at this step.
 2. **Search relevant knowledge** — once you know the topic, search for entries relevant to that feature using `wade knowledge get --search <topic>` or `wade knowledge get --tag <tag>` (see @.claude/skills/knowledge/SKILL.md and the **Project Knowledge** section above). Do not dump all entries.
 3. **Plan the feature** with the user — analyze, break down, propose.
 4. **Present the plan(s)** to the user. Use your tool's native question component to ask: "Ready to write the plan file(s)?" before writing any files.

--- a/templates/skills/plan-session/SKILL.md
+++ b/templates/skills/plan-session/SKILL.md
@@ -60,7 +60,7 @@ Running `wade knowledge add` is allowed even though this is a planning session.
 
 ## Your role
 
-1. **Ask the user** what they want to plan. If the session prompt does not already specify a feature or issue, ask before proceeding. Output a plain text question (e.g. "What would you like to plan?") — do NOT use a native selection/question component or present pre-defined categories as options at this step.
+1. **Ask the user** what they want to plan. If the session is interactive and the prompt does not already specify a feature or issue, ask before proceeding. Output a plain text question (e.g. "What would you like to plan?") — do NOT use a native selection/question component or present pre-defined categories as options at this step.
 2. **Search relevant knowledge** — once you know the topic, search for entries relevant to that feature using `wade knowledge get --search <topic>` or `wade knowledge get --tag <tag>` (see @.claude/skills/knowledge/SKILL.md and the **Project Knowledge** section above). Do not dump all entries.
 3. **Plan the feature** with the user — analyze, break down, propose.
 4. **Present the plan(s)** to the user. Use your tool's native question component to ask: "Ready to write the plan file(s)?" before writing any files.


### PR DESCRIPTION
Closes #281

<!-- wade:plan:start -->

# feat: plan-session prompt should ask open-ended question, not suggest options

## Complexity
easy

## Context / Problem
The plan-session prompt (`templates/prompts/plan-session.md`) step 1 says
"Ask the user what feature they want to plan" but provides no guidance on
*how* to ask. In practice, AI tools interpret this as permission to use their
native selection component (`AskUserQuestion`) with pre-defined category
options such as "New sync writer", "CLI enhancement", "Config / model change".

This is undesirable: the pre-defined options nudge the user toward certain
choices and imply a limited set of possibilities, rather than inviting them to
describe freely what they actually want to build.

The same issue exists in `templates/skills/plan-session/SKILL.md` step 1 of
"Your role".

## Proposed Solution
Add an explicit instruction in both the prompt template and the skill file
clarifying that the initial "what to plan?" question must be asked as a plain
open-ended question in text — the AI should NOT use a native question/selection
component with pre-defined options at this step.

### Files to change

Both files live in the **wade** repository (`github.com/ivanviragine/wade`),
not in this crossby worktree:

- `templates/prompts/plan-session.md` — amend step 1 to say:
  "When the session is interactive and no feature was specified in the prompt,
  ask the user what they want to plan by outputting a plain text question (e.g.
  'What would you like to plan?'). Do NOT use a native selection/question
  component or present pre-defined categories as options."
- `templates/skills/plan-session/SKILL.md` — amend step 1 of "Your role" with
  the same prohibition, scoped to the interactive case.

No code changes; text-only edits to two template markdown files in the wade
repo.

## Tasks
- [ ] Update step 1 in `templates/prompts/plan-session.md` to require a plain
  text question in interactive mode — prohibit native selection components and
  pre-defined categories
- [ ] Update step 1 of "Your role" in
  `templates/skills/plan-session/SKILL.md` with the same prohibition, scoped
  to interactive sessions (non-interactive / `--feature` flag path unaffected)
- [ ] Verify in a fresh worktree: run `wade plan` (interactive), confirm the
  AI outputs a plain text question with no selection component
  (note: requires `wade plan` to re-install the skill from the updated template)

## Acceptance Criteria
- [ ] When `wade plan` starts a session, the AI asks "What would you like to
  plan?" (or equivalent) as a plain text question — no selection component
  with pre-defined options is shown
- [ ] Both template files contain the explicit prohibition against using a
  selection component for the initial question


<!-- wade:plan:end -->

## Summary

## What was done

Added an explicit prohibition against using native selection/question components for the initial "what do you want to plan?" question in both the plan-session prompt template and skill file. The instruction now specifies that AI tools must ask this question as a plain text output (e.g. "What would you like to plan?"), not via a UI selection component with pre-defined category options.

## Changes

- Updated step 1 in `templates/prompts/plan-session.md` to require a plain text question in interactive mode and prohibit native selection components and pre-defined categories
- Updated step 1 of "Your role" in `templates/skills/plan-session/SKILL.md` with the same prohibition, scoped to the interactive case (non-interactive / `--feature` flag path unaffected)
- Addressed CodeRabbit review: added "the session is interactive and" qualifier to SKILL.md step 1, matching the guard already present in the prompt template

## Testing

- Verified both template files contain the explicit prohibition
- No code changes — text-only edits to two markdown template files

## Notes for reviewers

The `.wade.yml` diff visible in the review is a pre-existing local config change (model routing adjustments, `review_batch` addition, `knowledge.path`) unrelated to this issue.

## Remaining

None — all 1 unresolved thread has been resolved.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **10,700** |
| Input tokens | **1,500** |
| Output tokens | **9,200** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated planning-session workflow so the assistant asks a plain-text question when no feature is specified, instead of showing interactive selection components or predefined option lists.
* **Documentation**
  * Added guidance clarifying that prompts must request plain-text questions and must not use native UI selection/question components or preset category options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **7,833** |
| Input tokens | **733** |
| Output tokens | **7,100** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `980b50ed-f49c-4f76-8073-192aa816ecfa` |
| Review | `claude` | `a7d3f829-d7fd-4f64-a583-1ff68f9a7d81` |

<!-- wade:sessions:end -->
