### PR TITLE
feat: rework wade init wizard — order, skippability, effort/yolo defaults

### DIFF
--- a/.wade.yml
+++ b/.wade.yml
@@ -33,10 +33,14 @@ ai:
     enabled: true
 models:
   claude:
-    easy: claude-sonnet-4.6
-    medium: claude-sonnet-4.6
-    complex: claude-opus-4.7
-    very_complex: claude-opus-4.7
+    easy:
+      model: claude-sonnet-4.6
+    medium:
+      model: claude-sonnet-4.6
+    complex:
+      model: claude-opus-4.7
+    very_complex:
+      model: claude-opus-4.7
 provider:
   name: github
 knowledge:

--- a/.wade.yml
+++ b/.wade.yml
@@ -13,27 +13,39 @@ ai:
     tool: claude
     model: claude-opus-4.7
   deps:
-    tool: gemini
-    model: gemini-3-pro-preview
+    tool: copilot
+    model: claude-sonnet-4.6
     mode: headless
   review_plan:
-    mode: prompt
+    tool: copilot
+    model: claude-sonnet-4.6
+    mode: headless
     enabled: true
   review_implementation:
-    mode: prompt
+    tool: copilot
+    model: claude-sonnet-4.6
+    mode: headless
+    enabled: true
+  review_batch:
+    tool: copilot
+    model: claude-sonnet-4.6
+    mode: interactive
     enabled: true
 models:
   claude:
-    easy: claude-haiku-4.5
+    easy: claude-sonnet-4.6
     medium: claude-sonnet-4.6
-    complex: claude-sonnet-4.6
+    complex: claude-opus-4.7
     very_complex: claude-opus-4.7
 provider:
   name: github
 knowledge:
   enabled: true
+  path: KNOWLEDGE.md
 hooks:
   post_worktree_create: scripts/setup-worktree.sh
   copy_to_worktree:
   - .env
   - .wade.yml
+  - KNOWLEDGE.md
+  - KNOWLEDGE.ratings.yml

--- a/.wade.yml
+++ b/.wade.yml
@@ -33,14 +33,10 @@ ai:
     enabled: true
 models:
   claude:
-    easy:
-      model: claude-sonnet-4.6
-    medium:
-      model: claude-sonnet-4.6
-    complex:
-      model: claude-opus-4.7
-    very_complex:
-      model: claude-opus-4.7
+    easy: claude-sonnet-4.6
+    medium: claude-sonnet-4.6
+    complex: claude-opus-4.7
+    very_complex: claude-opus-4.7
 provider:
   name: github
 knowledge:

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -72,3 +72,9 @@ Entry quality rules live in the `## Entry style` section of `templates/skills/kn
 When writing instructions for AI tools, "ask the user X" is not sufficient to prevent the tool from using native UI components (e.g. AskUserQuestion with pre-defined options). You must explicitly say "output a plain text question" and "do NOT use a native selection/question component or present pre-defined categories."
 
 ---
+
+## 3463fbd4 | 2026-04-27 | implementation | tags: skills, prompts, architecture | Issue #295
+
+When editing agent session rules, check BOTH templates/skills/<name>/SKILL.md AND templates/prompts/<name>.md — skills are symlinked into .claude/skills/ while prompts are read directly by service code. Changes to one without the other can leave contradictory instructions.
+
+---

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -1,6 +1,12 @@
 164c355e:
   down: 0
   up: 1
+3463fbd4:
+  down: 0
+  up: 1
+b61e247e:
+  down: 0
+  up: 2
 b6a3a637:
   down: 0
   up: 1
@@ -9,4 +15,4 @@ cedeaad0:
   up: 1
 e2a49ac1:
   down: 0
-  up: 1
+  up: 2

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -1,0 +1,12 @@
+164c355e:
+  down: 0
+  up: 1
+b6a3a637:
+  down: 0
+  up: 1
+cedeaad0:
+  down: 0
+  up: 1
+e2a49ac1:
+  down: 0
+  up: 1

--- a/src/wade/config/loader.py
+++ b/src/wade/config/loader.py
@@ -105,6 +105,22 @@ def _section_mapping(raw: dict[str, Any], key: str) -> dict[str, Any]:
     return section
 
 
+def _parse_tier_value(v: Any) -> tuple[str | None, str | None]:
+    """Parse a complexity-tier value into (model, effort).
+
+    Accepts both the legacy string form and the new ``{model, effort}`` dict form.
+    """
+    if v is None:
+        return None, None
+    if isinstance(v, str):
+        return v or None, None
+    if isinstance(v, dict):
+        model = v.get("model") or None
+        effort = v.get("effort") or None
+        return model, effort
+    return None, None
+
+
 def _build_config(raw: dict[str, Any], config_path: Path) -> ProjectConfig:
     """Build a ProjectConfig from raw YAML dict."""
     version = raw.get("version", 2)
@@ -134,16 +150,24 @@ def _build_config(raw: dict[str, Any], config_path: Path) -> ProjectConfig:
         **command_configs,
     )
 
-    # Parse models section (nested: tool → complexity → model)
+    # Parse models section (nested: tool → complexity → model/effort)
     models_raw = _section_mapping(raw, "models")
     models: dict[str, ComplexityModelMapping] = {}
     for tool_name, mapping_raw in models_raw.items():
         if isinstance(mapping_raw, dict):
+            em, ee = _parse_tier_value(mapping_raw.get("easy"))
+            mm, me = _parse_tier_value(mapping_raw.get("medium"))
+            cm, ce = _parse_tier_value(mapping_raw.get("complex"))
+            vm, ve = _parse_tier_value(mapping_raw.get("very_complex"))
             models[tool_name] = ComplexityModelMapping(
-                easy=mapping_raw.get("easy"),
-                medium=mapping_raw.get("medium"),
-                complex=mapping_raw.get("complex"),
-                very_complex=mapping_raw.get("very_complex"),
+                easy=em,
+                easy_effort=ee,
+                medium=mm,
+                medium_effort=me,
+                complex=cm,
+                complex_effort=ce,
+                very_complex=vm,
+                very_complex_effort=ve,
             )
 
     # Parse provider section

--- a/src/wade/config/migrations.py
+++ b/src/wade/config/migrations.py
@@ -25,6 +25,34 @@ def ensure_version(raw: dict[str, Any]) -> bool:
     return False
 
 
+_TIER_KEYS = ("easy", "medium", "complex", "very_complex")
+
+
+def migrate_string_tiers_to_tier_config(raw: dict[str, Any]) -> bool:
+    """Upgrade legacy string-valued complexity tiers to ``{model, effort}`` form.
+
+    Converts ``easy: claude-haiku-4.5`` → ``easy: {model: claude-haiku-4.5, effort: null}``.
+    Already-structured values are left untouched. Idempotent.
+    """
+    models = raw.get("models")
+    if not isinstance(models, dict):
+        return False
+
+    changed = False
+    for tool_mapping in models.values():
+        if not isinstance(tool_mapping, dict):
+            continue
+        for tier in _TIER_KEYS:
+            val = tool_mapping.get(tier)
+            if val is None:
+                continue
+            if isinstance(val, str):
+                tool_mapping[tier] = {"model": val, "effort": None}
+                changed = True
+            # dict form already canonical — leave alone
+    return changed
+
+
 def run_all_migrations(config_path: Path) -> bool:
     """Run all migrations on a .wade.yml file.
 
@@ -48,6 +76,7 @@ def run_all_migrations(config_path: Path) -> bool:
 
     try:
         changed = ensure_version(raw)
+        changed = migrate_string_tiers_to_tier_config(raw) or changed
 
         if changed:
             config_path.write_text(

--- a/src/wade/models/config.py
+++ b/src/wade/models/config.py
@@ -45,16 +45,24 @@ class ProviderID(StrEnum):
 
 
 class ComplexityModelMapping(BaseModel):
-    """Model IDs for each complexity tier.
+    """Model IDs and optional effort levels for each complexity tier.
 
     Values are exact model IDs as returned by the tool's get_models().
     Defaults are None — populated at init time by querying the tool.
+    Effort values mirror ``EffortLevel`` but are stored as plain strings to
+    avoid a circular import (``models.ai`` is not importable here).
     """
 
     easy: str | None = None
     medium: str | None = None
     complex: str | None = None
     very_complex: str | None = None
+
+    # Per-tier effort overrides — optional, parallel to the model fields.
+    easy_effort: str | None = None
+    medium_effort: str | None = None
+    complex_effort: str | None = None
+    very_complex_effort: str | None = None
 
 
 class ProviderConfig(BaseModel):
@@ -190,6 +198,13 @@ class ProjectConfig(BaseModel):
         mapping = self.models.get(tool)
         if mapping:
             return getattr(mapping, complexity, None)
+        return None
+
+    def get_complexity_effort(self, tool: str, complexity: str) -> str | None:
+        """Get effort level for a tool + complexity combination."""
+        mapping = self.models.get(tool)
+        if mapping:
+            return getattr(mapping, f"{complexity}_effort", None)
         return None
 
     def get_effort(self, command: str | None = None) -> str | None:

--- a/src/wade/services/ai_resolution.py
+++ b/src/wade/services/ai_resolution.py
@@ -103,6 +103,7 @@ def resolve_effort(
     command: str = "plan",
     *,
     tool: str | None = None,
+    complexity: str | None = None,
 ) -> EffortLevel | None:
     """Resolve effort level from args -> env var -> config -> None.
 
@@ -110,7 +111,8 @@ def resolve_effort(
       1. Explicit *effort* arg (e.g. ``--effort`` CLI flag)
       2. ``WADE_EFFORT`` environment variable
       3. Command-specific config (``ai.<command>.effort``)
-      4. Global config (``ai.effort``)
+      4. Per-complexity-tier config (``models.<tool>.<tier>.effort``)
+      5. Global config (``ai.effort``)
 
     When *tool* is provided and the tool does not support effort, a warning
     is logged and ``None`` is returned.
@@ -120,8 +122,19 @@ def resolve_effort(
     if not resolved:
         resolved = os.environ.get("WADE_EFFORT")
 
+    # Command-specific config (ai.<command>.effort)
     if not resolved:
-        resolved = config.get_effort(command)
+        cmd_config = getattr(config.ai, command, None)
+        if isinstance(cmd_config, AICommandConfig) and cmd_config.effort:
+            resolved = cmd_config.effort
+
+    # Per-complexity-tier config (models.<tool>.<tier>.effort)
+    if not resolved and tool and complexity:
+        resolved = config.get_complexity_effort(tool, complexity)
+
+    # Global config (ai.effort)
+    if not resolved:
+        resolved = config.ai.effort
 
     if not resolved:
         return None

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -848,8 +848,14 @@ def start(
             complexity=task.complexity.value if task.complexity else None,
         )
 
-        # Resolve effort level
-        resolved_effort = resolve_effort(effort, config, "implement", tool=resolved_tool)
+        # Resolve effort level (per-tier when complexity is known)
+        resolved_effort = resolve_effort(
+            effort,
+            config,
+            "implement",
+            tool=resolved_tool,
+            complexity=task.complexity.value if task.complexity else None,
+        )
 
         # Resolve YOLO mode
         resolved_yolo = resolve_yolo(yolo, config, "implement", tool=resolved_tool)

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -22,6 +22,7 @@ from wade.git.repo import GitError
 from wade.models.ai import AIToolID
 from wade.models.config import (
     AI_COMMAND_NAMES,
+    AICommandConfig,
     ComplexityModelMapping,
     KnowledgeConfig,
 )
@@ -71,6 +72,88 @@ def get_wade_root() -> Path:
 # ---------------------------------------------------------------------------
 
 
+def _show_init_summary(
+    *,
+    provider_setup: dict[str, Any],
+    project_settings: dict[str, str],
+    selected_tool: str | None,
+    default_model: str | None,
+    default_effort: str | None,
+    default_yolo: bool | None,
+    implementation_setup: dict[str, Any],
+    command_overrides: dict[str, dict[str, Any]],
+    hooks_setup: dict[str, Any],
+    knowledge_setup: dict[str, Any],
+) -> None:
+    """Render a summary of all wizard selections before the write phase."""
+    console.rule("Configuration summary")
+
+    # Provider + Project
+    console.kv("Provider", provider_setup.get("name", "github"))
+    console.kv("Main branch", project_settings.get("main_branch", "main"))
+    console.kv("Merge strategy", project_settings.get("merge_strategy", "PR"))
+    console.kv("Branch prefix", project_settings.get("branch_prefix", "feat"))
+    console.kv("Worktrees dir", project_settings.get("worktrees_dir", "../.worktrees"))
+
+    # AI defaults
+    console.kv("AI tool", selected_tool or "(not set)")
+    if default_model:
+        console.kv("Default model", default_model)
+    if default_effort:
+        console.kv("Default effort", default_effort)
+    if default_yolo is not None:
+        console.kv("Default YOLO", str(default_yolo).lower())
+
+    # Implementation tiers
+    mapping = implementation_setup.get("model_mapping")
+    impl_tool = implementation_setup.get("tool")
+    if impl_tool:
+        console.kv("Implement tool", impl_tool)
+    if mapping:
+        for tier, label in (
+            ("easy", "Easy"),
+            ("medium", "Medium"),
+            ("complex", "Complex"),
+            ("very_complex", "Very complex"),
+        ):
+            model = getattr(mapping, tier, None)
+            effort = getattr(mapping, f"{tier}_effort", None)
+            if model:
+                val = f"{model}" + (f" [{effort}]" if effort else "")
+                console.kv(f"  {label}", val)
+
+    # Per-command overrides (only non-empty)
+    for cmd_name, overrides in command_overrides.items():
+        if not overrides:
+            continue
+        parts = []
+        if overrides.get("tool"):
+            parts.append(f"tool={overrides['tool']}")
+        if overrides.get("model"):
+            parts.append(f"model={overrides['model']}")
+        if overrides.get("effort"):
+            parts.append(f"effort={overrides['effort']}")
+        if overrides.get("yolo") == "true":
+            parts.append("yolo")
+        if overrides.get("enabled") == "false":
+            parts.append("disabled")
+        elif overrides.get("mode"):
+            parts.append(f"mode={overrides['mode']}")
+        if parts:
+            console.kv(f"  {cmd_name}", ", ".join(parts))
+
+    # Hooks
+    if hooks_setup.get("post_worktree_create"):
+        console.kv("Post-worktree script", hooks_setup["post_worktree_create"])
+    copy_files = hooks_setup.get("copy_to_worktree", [])
+    if copy_files:
+        console.kv("Copy to worktrees", ", ".join(copy_files))
+
+    # Knowledge
+    if knowledge_setup.get("enabled"):
+        console.kv("Knowledge file", knowledge_setup.get("path", "KNOWLEDGE.md"))
+
+
 def init(
     project_root: Path | None = None,
     ai_tool: str | None = None,
@@ -80,12 +163,11 @@ def init(
 
     Steps:
     1. Validate git repo
-    2. Detect/select AI tool
-    3. Collect project settings
-    4. Generate .wade.yml config
-    5. Write .wade-managed manifest
-    6. Make .wade/ self-ignoring
-    7. Commit .wade.yml
+    2. Detect installed AI tools
+    3. Parse existing .wade.yml for re-init pre-fill
+    4. Run interactive wizard (loop until confirmed or cancelled)
+    5. Write config
+    6. Write manifest and make .wade/ self-ignoring
 
     Returns True on success.
     """
@@ -105,71 +187,187 @@ def init(
         )
         return False
 
-    # Compute installed tools once — doesn't depend on any wizard step
+    # 2. Detect installed tools (once — independent of wizard)
     installed_tools = [str(t) for t in AbstractAITool.detect_installed()]
 
-    # Interactive wizard — all prompts before any writes
-
-    # Detect existing provider for re-init pre-selection
+    # 3. Parse existing config for re-init pre-fill
     config_path = root / ".wade.yml"
-    current_provider: str | None = None
+    existing_config = None
     if config_path.exists():
         try:
-            existing_raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-            if isinstance(existing_raw, dict):
-                provider_raw = existing_raw.get("provider")
-                if isinstance(provider_raw, dict):
-                    current_provider = provider_raw.get("name")
-        except (yaml.YAMLError, OSError):
+            from wade.config.loader import parse_config_file
+
+            existing_config = parse_config_file(config_path)
+        except Exception:
             pass
 
-    provider_setup = _prompt_provider_setup(
-        root, non_interactive, current_provider=current_provider
-    )
+    # --- Interactive wizard (loop supports Modify) ---
+    provider_setup: dict[str, Any] = {}
+    project_settings: dict[str, str] = {}
+    selected_tool: str | None = None
+    default_model: str | None = None
+    default_effort: str | None = None
+    default_yolo: bool | None = None
+    implementation_setup: dict[str, Any] = {}
+    command_overrides: dict[str, dict[str, Any]] = {}
+    hooks_setup: dict[str, Any] = {}
+    knowledge_setup: dict[str, Any] = {}
 
-    project_settings = _prompt_project_settings(root, non_interactive)
-    hooks_setup = _prompt_hooks_setup(non_interactive)
-    knowledge_setup = _prompt_knowledge_setup(non_interactive)
-    normalized_knowledge_setup = _normalize_knowledge_setup(root, knowledge_setup)
-    if normalized_knowledge_setup is None:
-        return False
-    knowledge_setup = normalized_knowledge_setup
+    while True:
+        # 4a. Provider
+        current_provider = existing_config.provider.name.value if existing_config else None
+        provider_setup = _prompt_provider_setup(
+            root, non_interactive, current_provider=current_provider
+        )
 
-    # If provider setup requested adding .env to copy_to_worktree, inject it
+        # 4b. Project settings
+        ps = existing_config.project if existing_config else None
+        project_settings = _prompt_project_settings(
+            root,
+            non_interactive,
+            current_main_branch=ps.main_branch if ps else None,
+            current_merge_strategy=ps.merge_strategy.value if ps else None,
+            current_branch_prefix=ps.branch_prefix if ps else None,
+            current_issue_label=ps.issue_label if ps else None,
+            current_worktrees_dir=ps.worktrees_dir if ps else None,
+        )
+
+        # 4c. AI (tool, model, effort, yolo)
+        try:
+            selected_tool, default_model, default_effort, default_yolo = _prompt_ai_section(
+                ai_tool,
+                non_interactive,
+                current_tool=existing_config.ai.default_tool if existing_config else None,
+                current_model=existing_config.ai.default_model if existing_config else None,
+                current_effort=existing_config.ai.effort if existing_config else None,
+                current_yolo=existing_config.ai.yolo if existing_config else None,
+            )
+        except ValueError as exc:
+            console.error(str(exc))
+            return False
+
+        # 4d. Implementation (per-tier models + effort)
+        current_impl_tool = existing_config.ai.implement.tool if existing_config else None
+        current_mm = (
+            existing_config.models.get(current_impl_tool or selected_tool or "")
+            if existing_config
+            else None
+        )
+        implementation_setup = _prompt_implementation_setup(
+            selected_tool,
+            installed_tools,
+            non_interactive,
+            current_implement_tool=current_impl_tool,
+            current_model_mapping=current_mm,
+        )
+
+        # 4e. Per-command overrides (tool, model, effort, yolo)
+        current_cmd_overrides: dict[str, dict[str, Any]] = {}
+        if existing_config:
+            for cmd in _COMMAND_OVERRIDE_NAMES:
+                cfg = getattr(existing_config.ai, cmd, None)
+                if isinstance(cfg, AICommandConfig):
+                    entry: dict[str, Any] = {}
+                    if cfg.tool:
+                        entry["tool"] = cfg.tool
+                    if cfg.model:
+                        entry["model"] = cfg.model
+                    if cfg.mode:
+                        entry["mode"] = cfg.mode
+                    if cfg.effort:
+                        entry["effort"] = cfg.effort
+                    if cfg.enabled is not None:
+                        entry["enabled"] = "true" if cfg.enabled else "false"
+                    if cfg.yolo is not None:
+                        entry["yolo"] = "true" if cfg.yolo else "false"
+                    if entry:
+                        current_cmd_overrides[cmd] = entry
+        command_overrides = _prompt_command_overrides(
+            installed_tools,
+            non_interactive,
+            default_model=default_model,
+            default_tool=selected_tool,
+            current_overrides=current_cmd_overrides,
+        )
+
+        # 4f. Tool-specific settings (after per-command so tools_in_use is known)
+        tools_in_use: set[str] = set()
+        if selected_tool:
+            tools_in_use.add(selected_tool)
+        if implementation_setup.get("tool"):
+            tools_in_use.add(implementation_setup["tool"])
+        for cmd_cfg in command_overrides.values():
+            if cmd_cfg.get("tool"):
+                tools_in_use.add(cmd_cfg["tool"])
+
+        if "claude" in tools_in_use:
+            _prompt_claude_code_settings(non_interactive)
+        if "gemini" in tools_in_use:
+            _prompt_configure_gemini_experimental(non_interactive)
+
+        # 4g. Worktree hooks
+        hk = existing_config.hooks if existing_config else None
+        hooks_setup = _prompt_hooks_setup(
+            non_interactive,
+            current_post_worktree_create=hk.post_worktree_create if hk else None,
+            current_copy_to_worktree=list(hk.copy_to_worktree) if hk else None,
+        )
+
+        # 4h. Project knowledge
+        kn = existing_config.knowledge if existing_config else None
+        knowledge_setup = _prompt_knowledge_setup(
+            non_interactive,
+            current_enabled=kn.enabled if kn else False,
+            current_path=kn.path if kn else "KNOWLEDGE.md",
+        )
+
+        # 4i. Shell integration + completions
+        _prompt_configure_shell_integration(non_interactive)
+        _prompt_configure_completions(non_interactive)
+
+        # 4j. Summary + Yes / Modify / Cancel
+        if non_interactive:
+            break  # Skip summary in non-interactive mode
+
+        _show_init_summary(
+            provider_setup=provider_setup,
+            project_settings=project_settings,
+            selected_tool=selected_tool,
+            default_model=default_model,
+            default_effort=default_effort,
+            default_yolo=default_yolo,
+            implementation_setup=implementation_setup,
+            command_overrides=command_overrides,
+            hooks_setup=hooks_setup,
+            knowledge_setup=knowledge_setup,
+        )
+
+        from wade.ui import prompts as _ui_prompts
+
+        confirm_choices = ["Write .wade.yml", "Modify (re-run wizard)", "Cancel"]
+        confirm_idx = _ui_prompts.select(
+            "Write these values to .wade.yml?", confirm_choices, default=0
+        )
+        chosen = confirm_choices[confirm_idx]
+        if chosen == "Cancel":
+            console.info("Initialization cancelled — no files written.")
+            return False
+        if chosen == "Modify (re-run wizard)":
+            continue  # Restart wizard from the top
+        break  # "Write .wade.yml" — proceed to write phase
+
+    # Post-wizard injections (idempotent — safe regardless of loop iterations)
     if provider_setup.get("add_env_to_copy"):
         copy_list: list[str] = hooks_setup.get("copy_to_worktree", [])
         if ".env" not in copy_list:
             copy_list.append(".env")
         hooks_setup["copy_to_worktree"] = copy_list
-    try:
-        selected_tool, default_model, default_effort = _prompt_ai_section(ai_tool, non_interactive)
-    except ValueError as exc:
-        console.error(str(exc))
+
+    normalized_knowledge_setup = _normalize_knowledge_setup(root, knowledge_setup)
+    if normalized_knowledge_setup is None:
         return False
-    implementation_setup = _prompt_implementation_setup(
-        selected_tool, installed_tools, non_interactive
-    )
-    command_overrides = _prompt_command_overrides(
-        installed_tools, non_interactive, default_model=default_model, default_tool=selected_tool
-    )
-    # Compute which tools are actually in use (selected + per-command overrides)
-    tools_in_use: set[str] = set()
-    if selected_tool:
-        tools_in_use.add(selected_tool)
-    if implementation_setup.get("tool"):
-        tools_in_use.add(implementation_setup["tool"])
-    for cmd_cfg in command_overrides.values():
-        if cmd_cfg.get("tool"):
-            tools_in_use.add(cmd_cfg["tool"])
+    knowledge_setup = normalized_knowledge_setup
 
-    if "claude" in tools_in_use:
-        _prompt_claude_code_settings(non_interactive)
-    if "gemini" in tools_in_use:
-        _prompt_configure_gemini_experimental(non_interactive)
-    _prompt_configure_shell_integration(non_interactive)
-    _prompt_configure_completions(non_interactive)
-
-    # If knowledge is enabled, add the knowledge + ratings paths to copy_to_worktree.
     if knowledge_setup.get("enabled"):
         from wade.services.knowledge_service import resolve_ratings_path
 
@@ -185,7 +383,6 @@ def init(
     if not non_interactive:
         console.rule("Initing")
 
-    # Generate config
     if config_path.exists():
         console.info("Config .wade.yml already exists — updating with selected values")
         _patch_config(
@@ -194,6 +391,7 @@ def init(
             implementation_setup["model_mapping"],
             default_model=default_model,
             default_effort=default_effort,
+            default_yolo=default_yolo,
             project_settings=project_settings,
             implement_tool=implementation_setup["tool"],
             command_overrides=command_overrides,
@@ -211,6 +409,7 @@ def init(
             implement_tool=implementation_setup["tool"],
             default_model=default_model,
             default_effort=default_effort,
+            default_yolo=default_yolo,
             command_overrides=command_overrides,
             hooks_setup=hooks_setup,
             provider_setup=provider_setup,
@@ -234,14 +433,11 @@ def init(
         else:
             console.success(f"Created {kpath.name}")
 
-    # 5. Write manifest (no skills on main — skills are installed per-session in worktrees)
     _write_manifest(root, [])
     console.success("Wrote .wade/.wade-managed manifest")
 
-    # 6. Make .wade/ self-ignoring so it doesn't appear as untracked on main
     _ensure_wade_dir_self_ignoring(root)
 
-    # Validate the config we just wrote
     from wade.services.check_service import validate_config
 
     check_result = validate_config(root)
@@ -252,7 +448,6 @@ def init(
         for err in check_result.errors:
             console.detail(err)
 
-    # 8. Final hint for committing .wade.yml
     console.hint("Commit .wade.yml to your repo:")
     console.detail('git add .wade.yml && git commit -m "chore: initialize wade"')
 
@@ -909,6 +1104,30 @@ def _prompt_claude_code_settings(non_interactive: bool) -> None:
     _prompt_configure_statusline(non_interactive)
 
 
+def _select_or_skip(
+    label: str,
+    options: list[str],
+    current: str | None = None,
+) -> str | None:
+    """Select from *options* with a uniform 'Skip (use default)' appended.
+
+    Returns the chosen value, or ``None`` if the user chose Skip.
+    When *current* is provided and matches an option it is pre-selected.
+    """
+    from wade.ui import prompts
+
+    skip_label = "Skip (use default)"
+    all_options = [*options, skip_label]
+
+    default_idx = len(all_options) - 1  # default to Skip
+    if current and current in all_options:
+        default_idx = all_options.index(current)
+
+    idx = prompts.select(label, all_options, default=default_idx)
+    chosen = all_options[idx]
+    return None if chosen == skip_label else chosen
+
+
 def _select_ai_tool(
     requested: str | None,
     non_interactive: bool,
@@ -957,38 +1176,60 @@ def _select_ai_tool(
 def _prompt_ai_section(
     ai_tool: str | None,
     non_interactive: bool,
-) -> tuple[str | None, str | None, str | None]:
-    """Run the AI wizard section: select default tool, model, and effort.
+    *,
+    current_tool: str | None = None,
+    current_model: str | None = None,
+    current_effort: str | None = None,
+    current_yolo: bool | None = None,
+) -> tuple[str | None, str | None, str | None, bool | None]:
+    """Run the AI wizard section: select default tool, model, effort, and yolo.
 
     The rule is shown here (before any detection messages) so both the
     single-tool and multi-tool cases are grouped under the same header.
 
-    Returns ``(selected_tool, default_model, default_effort)``.
+    Returns ``(selected_tool, default_model, default_effort, default_yolo)``.
     """
     if not non_interactive:
         console.rule("AI")
     selected_tool = _select_ai_tool(ai_tool, non_interactive)
     if non_interactive or not selected_tool:
-        return selected_tool, None, None
+        return selected_tool, None, None, None
     mapping = _resolve_models(selected_tool)
     default_model = _prompt_default_model(selected_tool, mapping, non_interactive=False)
 
-    # Prompt for default effort level (only when tool supports it)
     default_effort: str | None = None
+    default_yolo: bool | None = None
     try:
         adapter = AbstractAITool.get(selected_tool)
-        if adapter.capabilities().supports_effort:
+        caps = adapter.capabilities()
+
+        # Prompt for default effort level (only when tool supports it)
+        if caps.supports_effort:
             from wade.models.ai import EffortLevel
             from wade.ui import prompts as ui_prompts
 
             effort_choices = ["(none — use tool default)", *[e.value for e in EffortLevel]]
-            idx = ui_prompts.select("Default reasoning effort level", effort_choices)
+            current_idx = 0
+            if current_effort and current_effort in effort_choices:
+                current_idx = effort_choices.index(current_effort)
+            idx = ui_prompts.select(
+                "Default reasoning effort level", effort_choices, default=current_idx
+            )
             # "" sentinel signals explicit "none" so _patch_config can clear on force
             default_effort = effort_choices[idx] if idx > 0 else ""
+
+        # Prompt for global yolo (only when tool supports it)
+        if caps.supports_yolo:
+            from wade.ui import prompts as ui_prompts
+
+            default_yolo = ui_prompts.confirm(
+                "Enable YOLO mode by default? (auto-accepts all AI session prompts)",
+                default=current_yolo if current_yolo is not None else False,
+            )
     except (ValueError, KeyError):
         pass
 
-    return selected_tool, default_model, default_effort
+    return selected_tool, default_model, default_effort, default_yolo
 
 
 def _resolve_models(tool: str | None) -> ComplexityModelMapping:
@@ -1030,6 +1271,10 @@ def _normalize_mapping(
         medium=_normalize_model(mapping.medium),
         complex=_normalize_model(mapping.complex),
         very_complex=_normalize_model(mapping.very_complex),
+        easy_effort=mapping.easy_effort,
+        medium_effort=mapping.medium_effort,
+        complex_effort=mapping.complex_effort,
+        very_complex_effort=mapping.very_complex_effort,
     )
 
 
@@ -1253,6 +1498,12 @@ def _prompt_provider_setup(
 def _prompt_project_settings(
     project_root: Path,
     non_interactive: bool,
+    *,
+    current_main_branch: str | None = None,
+    current_merge_strategy: str | None = None,
+    current_branch_prefix: str | None = None,
+    current_issue_label: str | None = None,
+    current_worktrees_dir: str | None = None,
 ) -> dict[str, str]:
     """Collect project settings — interactively or with defaults.
 
@@ -1269,11 +1520,11 @@ def _prompt_project_settings(
         main_branch = "main"
 
     defaults = {
-        "main_branch": main_branch,
-        "merge_strategy": "PR",
-        "branch_prefix": "feat",
-        "issue_label": "feature-plan",
-        "worktrees_dir": "../.worktrees",
+        "main_branch": current_main_branch or main_branch,
+        "merge_strategy": current_merge_strategy or "PR",
+        "branch_prefix": current_branch_prefix or "feat",
+        "issue_label": current_issue_label or "feature-plan",
+        "worktrees_dir": current_worktrees_dir or "../.worktrees",
     }
 
     if non_interactive:
@@ -1300,6 +1551,9 @@ def _prompt_project_settings(
 
 def _prompt_hooks_setup(
     non_interactive: bool,
+    *,
+    current_post_worktree_create: str | None = None,
+    current_copy_to_worktree: list[str] | None = None,
 ) -> dict[str, Any]:
     """Collect worktree hooks settings — setup script and files to copy.
 
@@ -1308,8 +1562,8 @@ def _prompt_hooks_setup(
     from wade.ui import prompts
 
     defaults: dict[str, Any] = {
-        "post_worktree_create": None,
-        "copy_to_worktree": [],
+        "post_worktree_create": current_post_worktree_create,
+        "copy_to_worktree": current_copy_to_worktree or [],
     }
 
     if non_interactive:
@@ -1319,25 +1573,30 @@ def _prompt_hooks_setup(
 
     script_path = prompts.input_prompt(
         "Setup script for new worktrees (e.g. scripts/setup-worktree.sh)",
-        default="",
+        default=current_post_worktree_create or "",
         allow_empty=True,
     )
-    if script_path.strip():
-        defaults["post_worktree_create"] = script_path.strip()
+    defaults["post_worktree_create"] = script_path.strip() or None
 
+    current_copy_str = ", ".join(current_copy_to_worktree or [])
     copy_files = prompts.input_prompt(
         "Files to copy into worktrees (comma-separated, e.g. .env)",
-        default="",
+        default=current_copy_str,
         allow_empty=True,
     )
     if copy_files.strip():
         defaults["copy_to_worktree"] = [f.strip() for f in copy_files.split(",") if f.strip()]
+    else:
+        defaults["copy_to_worktree"] = []
 
     return defaults
 
 
 def _prompt_knowledge_setup(
     non_interactive: bool,
+    *,
+    current_enabled: bool = False,
+    current_path: str = "KNOWLEDGE.md",
 ) -> dict[str, Any]:
     """Collect knowledge file settings — opt-in feature for cross-session learning.
 
@@ -1346,8 +1605,8 @@ def _prompt_knowledge_setup(
     from wade.ui import prompts
 
     defaults: dict[str, Any] = {
-        "enabled": False,
-        "path": "KNOWLEDGE.md",
+        "enabled": current_enabled,
+        "path": current_path,
     }
 
     if non_interactive:
@@ -1356,15 +1615,16 @@ def _prompt_knowledge_setup(
     console.rule("Project knowledge")
 
     enabled = prompts.confirm(
-        "Enable project knowledge file for cross-session AI learning?", default=False
+        "Enable project knowledge file for cross-session AI learning?", default=current_enabled
     )
     if not enabled:
+        defaults["enabled"] = False
         return defaults
 
     defaults["enabled"] = True
     path = prompts.input_prompt(
         "Knowledge file path",
-        default="KNOWLEDGE.md",
+        default=current_path,
         allow_empty=False,
     )
     if path.strip():
@@ -1408,13 +1668,14 @@ def _prompt_model_mapping(
     mapping: ComplexityModelMapping,
     non_interactive: bool,
 ) -> ComplexityModelMapping:
-    """Let the user review/edit the complexity-to-model mapping.
+    """Let the user review/edit the complexity-to-model mapping (and per-tier effort).
 
     If non_interactive, returns the mapping unchanged.
     Falls back to Claude defaults when the tool has no model suggestions.
 
     Shows a select menu with available models for each tier, plus a Custom
-    option for typing a model name directly.
+    option for typing a model name directly.  When the tool supports effort,
+    also asks for an effort level per tier (skippable).
     """
     from wade.ui import prompts
 
@@ -1431,22 +1692,41 @@ def _prompt_model_mapping(
         very_complex=(
             mapping.very_complex or tool_defaults.very_complex or claude_defaults.very_complex
         ),
+        easy_effort=mapping.easy_effort,
+        medium_effort=mapping.medium_effort,
+        complex_effort=mapping.complex_effort,
+        very_complex_effort=mapping.very_complex_effort,
     )
 
     # Collect model IDs from the registry for the select menu
     available = _collect_model_options(tool)
 
+    # Determine if tool supports effort prompts
+    tool_supports_effort = False
+    try:
+        if tool:
+            adapter = AbstractAITool.get(tool)
+            tool_supports_effort = adapter.capabilities().supports_effort
+    except (ValueError, KeyError):
+        pass
+
     custom_label = "Custom..."
     tiers = [
-        ("Easy tasks", mapping.easy or ""),
-        ("Medium tasks", mapping.medium or ""),
-        ("Complex tasks", mapping.complex or ""),
-        ("Very complex tasks", mapping.very_complex or ""),
+        ("easy", "Easy tasks", mapping.easy or "", mapping.easy_effort),
+        ("medium", "Medium tasks", mapping.medium or "", mapping.medium_effort),
+        ("complex", "Complex tasks", mapping.complex or "", mapping.complex_effort),
+        (
+            "very_complex",
+            "Very complex tasks",
+            mapping.very_complex or "",
+            mapping.very_complex_effort,
+        ),
     ]
 
-    results: list[str] = []
+    result_models: list[str] = []
+    result_efforts: list[str | None] = []
 
-    for tier_label, tier_default in tiers:
+    for _tier_key, tier_label, tier_default, current_tier_effort in tiers:
         options = list(available)
         if tier_default and tier_default not in options:
             options.insert(0, tier_default)
@@ -1456,15 +1736,34 @@ def _prompt_model_mapping(
         chosen_idx = prompts.select(tier_label, options, default=default_idx)
 
         if options[chosen_idx] == custom_label:
-            results.append(prompts.input_prompt(f"{tier_label} (model ID)", tier_default))
+            result_models.append(prompts.input_prompt(f"{tier_label} (model ID)", tier_default))
         else:
-            results.append(options[chosen_idx])
+            result_models.append(options[chosen_idx])
+
+        # Per-tier effort (capability-gated, skippable)
+        tier_effort: str | None = current_tier_effort
+        if tool_supports_effort:
+            from wade.models.ai import EffortLevel
+
+            effort_choices = ["(none — use tool default)", *[e.value for e in EffortLevel]]
+            effort_default_idx = 0
+            if current_tier_effort and current_tier_effort in effort_choices:
+                effort_default_idx = effort_choices.index(current_tier_effort)
+            effort_idx = prompts.select(
+                f"  Effort for {tier_label.lower()}", effort_choices, default=effort_default_idx
+            )
+            tier_effort = effort_choices[effort_idx] if effort_idx > 0 else None
+        result_efforts.append(tier_effort)
 
     return ComplexityModelMapping(
-        easy=results[0] or mapping.easy,
-        medium=results[1] or mapping.medium,
-        complex=results[2] or mapping.complex,
-        very_complex=results[3] or mapping.very_complex,
+        easy=result_models[0] or mapping.easy,
+        medium=result_models[1] or mapping.medium,
+        complex=result_models[2] or mapping.complex,
+        very_complex=result_models[3] or mapping.very_complex,
+        easy_effort=result_efforts[0],
+        medium_effort=result_efforts[1],
+        complex_effort=result_efforts[2],
+        very_complex_effort=result_efforts[3],
     )
 
 
@@ -1540,6 +1839,9 @@ def _prompt_implementation_setup(
     default_tool: str | None,
     installed_tools: list[str],
     non_interactive: bool,
+    *,
+    current_implement_tool: str | None = None,
+    current_model_mapping: ComplexityModelMapping | None = None,
 ) -> dict[str, Any]:
     """Prompt for implementation tool and per-complexity model overrides.
 
@@ -1551,7 +1853,7 @@ def _prompt_implementation_setup(
         ``model_mapping`` - ComplexityModelMapping for the effective tool
     """
     if non_interactive:
-        mapping = _resolve_models(default_tool)
+        mapping = current_model_mapping or _resolve_models(default_tool)
         return {"tool": None, "model_mapping": mapping}
 
     from wade.ui import prompts
@@ -1563,13 +1865,16 @@ def _prompt_implementation_setup(
         skip_label
     ]
 
-    idx = prompts.select(
-        "AI tool for implementation work", tool_options, default=len(tool_options) - 1
-    )
+    # Pre-select current implement tool if present
+    tool_default_idx = len(tool_options) - 1  # default: Skip
+    if current_implement_tool and current_implement_tool in tool_options:
+        tool_default_idx = tool_options.index(current_implement_tool)
+
+    idx = prompts.select("AI tool for implementation work", tool_options, default=tool_default_idx)
     implement_tool = None if tool_options[idx] == skip_label else tool_options[idx]
 
     current_effective = implement_tool or default_tool
-    mapping = _resolve_models(current_effective)
+    mapping = current_model_mapping or _resolve_models(current_effective)
     mapping = _prompt_model_mapping(current_effective, mapping, non_interactive=False)
 
     return {"tool": implement_tool, "model_mapping": mapping}
@@ -1580,24 +1885,29 @@ def _prompt_command_overrides(
     non_interactive: bool,
     default_model: str | None = None,
     default_tool: str | None = None,
-) -> dict[str, dict[str, str]]:
-    """Prompt for per-command AI tool and model overrides.
+    current_overrides: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Prompt for per-command AI tool, model, effort, and yolo overrides.
 
     Implementation configuration is handled separately by ``_prompt_implementation_setup()``.
 
     Returns a dict like:
-        {"plan": {"tool": "claude", "model": "..."}, "deps": {},
+        {"plan": {"tool": "claude", "model": "...", "effort": "high", "yolo": "true"},
+         "deps": {},
          "review_plan": {"enabled": "true", "mode": "prompt"},
          "review_implementation": {"enabled": "false"},
          "review_batch": {"enabled": "true", "mode": "interactive"}}
 
     Empty dicts for commands with no overrides.
     Review commands include an "enabled" key ("true"/"false" as strings).
+    Effort and yolo values are stored as strings for uniform serialization.
     """
     from wade.ui import prompts
 
     if non_interactive:
         return {cmd_name: {} for cmd_name in _COMMAND_OVERRIDE_NAMES}
+
+    current = current_overrides or {}
 
     # Build selectable list: installed tools + "Skip (use default)"
     skip_label = "Skip (use default)"
@@ -1612,8 +1922,42 @@ def _prompt_command_overrides(
         ("review_implementation", "AI tool", "Implementation review"),
         ("review_batch", "AI tool", "Batch review"),
     ]
-    result: dict[str, dict[str, str]] = {cmd_name: {} for cmd_name in _COMMAND_OVERRIDE_NAMES}
+    result: dict[str, dict[str, Any]] = {cmd_name: {} for cmd_name in _COMMAND_OVERRIDE_NAMES}
     tool_for_cmd: list[str | None] = [None] * len(cmd_triples)
+
+    def _ask_effort_and_yolo(cmd_name: str, effective_tool: str | None) -> None:
+        """Prompt for per-command effort and yolo overrides (capability-gated)."""
+        if not effective_tool:
+            return
+        try:
+            adapter = AbstractAITool.get(effective_tool)
+            caps = adapter.capabilities()
+        except (ValueError, KeyError):
+            return
+
+        current_cmd = current.get(cmd_name, {})
+
+        if caps.supports_effort:
+            from wade.models.ai import EffortLevel
+
+            effort_choices = ["(none — use tool default)", *[e.value for e in EffortLevel]]
+            current_effort = current_cmd.get("effort")
+            effort_default_idx = 0
+            if current_effort and current_effort in effort_choices:
+                effort_default_idx = effort_choices.index(current_effort)
+            effort_idx = prompts.select(
+                "  Effort level", effort_choices, default=effort_default_idx
+            )
+            if effort_idx > 0:
+                result[cmd_name]["effort"] = effort_choices[effort_idx]
+
+        if caps.supports_yolo:
+            current_yolo_val = current_cmd.get("yolo")
+            current_yolo_bool = current_yolo_val is True or current_yolo_val == "true"
+            yolo_on = prompts.confirm(
+                "  Enable YOLO mode for this command?", default=current_yolo_bool
+            )
+            result[cmd_name]["yolo"] = "true" if yolo_on else "false"
 
     def _ask_tool_and_model(
         cmd_idx: int,
@@ -1624,11 +1968,17 @@ def _prompt_command_overrides(
         allow_skip: bool = True,
     ) -> None:
         """Ask for AI tool and model, updating result and tool_for_cmd in place."""
+        current_cmd = current.get(cmd_name, {})
         selectable_tools = (
             tool_options if allow_skip else [t for t in tool_options if t != skip_label]
         )
-        default_idx = len(selectable_tools) - 1 if allow_skip else 0
-        idx = prompts.select(prompt_label, selectable_tools, default=default_idx)
+        # Pre-select current tool if present
+        tool_default_idx = len(selectable_tools) - 1 if allow_skip else 0
+        current_tool_val = current_cmd.get("tool")
+        if current_tool_val and current_tool_val in selectable_tools:
+            tool_default_idx = selectable_tools.index(current_tool_val)
+
+        idx = prompts.select(prompt_label, selectable_tools, default=tool_default_idx)
         selected_tool = selectable_tools[idx]
         tool_for_cmd[cmd_idx] = None if selected_tool == skip_label else selected_tool
 
@@ -1638,7 +1988,10 @@ def _prompt_command_overrides(
 
             available = _collect_model_options(maybe_tool)
             suggested = _suggest_model_for_tool(maybe_tool)
-            if default_model and default_model in available:
+            current_model_val = current_cmd.get("model")
+            if current_model_val and current_model_val in available:
+                model_default = current_model_val
+            elif default_model and default_model in available:
                 model_default = default_model
             else:
                 model_default = suggested
@@ -1650,11 +2003,11 @@ def _prompt_command_overrides(
                 model_options.insert(0, model_default)
             model_options += [custom_label, skip_model_label]
 
-            default_idx = (
+            model_default_idx = (
                 model_options.index(model_default) if model_default in model_options else 0
             )
             chosen_idx = prompts.select(
-                f"  Model for {section.lower()}", model_options, default=default_idx
+                f"  Model for {section.lower()}", model_options, default=model_default_idx
             )
 
             chosen = model_options[chosen_idx]
@@ -1665,8 +2018,13 @@ def _prompt_command_overrides(
             if chosen and chosen != skip_model_label:
                 result[cmd_name]["model"] = chosen
 
+        # Effort + yolo — only when user explicitly selected a tool for this command
+        if tool_for_cmd[cmd_idx] is not None:
+            _ask_effort_and_yolo(cmd_name, tool_for_cmd[cmd_idx])
+
     for cmd_idx, (cmd_name, prompt_label, section) in enumerate(cmd_triples):
         console.rule(section)
+        current_cmd = current.get(cmd_name, {})
 
         if cmd_name == "plan":
             result[cmd_name] = {}
@@ -1674,10 +2032,12 @@ def _prompt_command_overrides(
 
         elif cmd_name.startswith("review_"):
             # 1. Enable?
+            current_enabled = current_cmd.get("enabled")
+            enabled_default = 0 if current_enabled != "false" else 1
             enable_idx = prompts.select(
                 f"Enable {section.lower()}?",
                 ["Yes", "No"],
-                default=0,
+                default=enabled_default,
             )
             if enable_idx == 1:
                 result[cmd_name] = {"enabled": "false"}
@@ -1691,7 +2051,11 @@ def _prompt_command_overrides(
                 "interactive (AI session)",
             ]
             mode_values = ["prompt", "headless", "interactive"]
-            default_mode_idx = 2 if cmd_name == "review_batch" else 0
+            current_mode = current_cmd.get("mode")
+            if current_mode and current_mode in mode_values:
+                default_mode_idx = mode_values.index(current_mode)
+            else:
+                default_mode_idx = 2 if cmd_name == "review_batch" else 0
             mode_idx = prompts.select(
                 f"  Delegation mode for {section.lower()}",
                 mode_options,
@@ -1728,14 +2092,31 @@ def _prompt_command_overrides(
                     "interactive (AI session)",
                 ]
                 deps_mode_values = ["headless", "interactive"]
+                current_mode = current_cmd.get("mode")
+                deps_mode_default = 0
+                if current_mode and current_mode in deps_mode_values:
+                    deps_mode_default = deps_mode_values.index(current_mode)
                 mode_idx = prompts.select(
                     f"  Delegation mode for {section.lower()}",
                     deps_mode_options,
-                    default=0,
+                    default=deps_mode_default,
                 )
                 result[cmd_name]["mode"] = deps_mode_values[mode_idx]
 
     return result
+
+
+def _tier_yaml_value(model: str | None, effort: str | None) -> str | dict[str, Any] | None:
+    """Return the YAML representation for a complexity tier.
+
+    Uses the compact string form when no effort is configured, otherwise the
+    structured ``{model, effort}`` form.
+    """
+    if not model:
+        return None
+    if effort:
+        return {"model": model, "effort": effort}
+    return model
 
 
 def _write_config(
@@ -1746,7 +2127,8 @@ def _write_config(
     implement_tool: str | None = None,
     default_model: str | None = None,
     default_effort: str | None = None,
-    command_overrides: dict[str, dict[str, str]] | None = None,
+    default_yolo: bool | None = None,
+    command_overrides: dict[str, dict[str, Any]] | None = None,
     hooks_setup: dict[str, Any] | None = None,
     provider_setup: dict[str, Any] | None = None,
     knowledge_setup: dict[str, Any] | None = None,
@@ -1778,6 +2160,8 @@ def _write_config(
         ai_section["default_model"] = default_model
     if default_effort:
         ai_section["effort"] = default_effort
+    if default_yolo is not None:
+        ai_section["yolo"] = default_yolo
 
     # Write implement tool override (only when different from default_tool)
     if implement_tool and implement_tool != ai_tool:
@@ -1792,9 +2176,11 @@ def _write_config(
                 for key in ("tool", "model", "mode", "effort"):
                     if overrides.get(key):
                         cmd_section[key] = overrides[key]
-                # Handle boolean 'enabled' field (stored as string in overrides)
+                # Handle boolean fields (stored as strings in overrides)
                 if "enabled" in overrides:
                     cmd_section["enabled"] = overrides["enabled"] == "true"
+                if "yolo" in overrides:
+                    cmd_section["yolo"] = overrides["yolo"] == "true"
                 if cmd_section:
                     ai_section[cmd_name] = cmd_section
 
@@ -1810,10 +2196,14 @@ def _write_config(
             str(models_key): {
                 k: v
                 for k, v in {
-                    "easy": model_mapping.easy,
-                    "medium": model_mapping.medium,
-                    "complex": model_mapping.complex,
-                    "very_complex": model_mapping.very_complex,
+                    "easy": _tier_yaml_value(model_mapping.easy, model_mapping.easy_effort),
+                    "medium": _tier_yaml_value(model_mapping.medium, model_mapping.medium_effort),
+                    "complex": _tier_yaml_value(
+                        model_mapping.complex, model_mapping.complex_effort
+                    ),
+                    "very_complex": _tier_yaml_value(
+                        model_mapping.very_complex, model_mapping.very_complex_effort
+                    ),
                 }.items()
                 if v
             }
@@ -1857,9 +2247,10 @@ def _patch_config(
     model_mapping: ComplexityModelMapping,
     default_model: str | None = None,
     default_effort: str | None = None,
+    default_yolo: bool | None = None,
     project_settings: dict[str, str] | None = None,
     implement_tool: str | None = None,
-    command_overrides: dict[str, dict[str, str]] | None = None,
+    command_overrides: dict[str, dict[str, Any]] | None = None,
     hooks_setup: dict[str, Any] | None = None,
     force: bool = False,
     provider_setup: dict[str, Any] | None = None,
@@ -1924,6 +2315,10 @@ def _patch_config(
             ai["effort"] = default_effort
             raw["ai"] = ai
             changed = True
+    if default_yolo is not None and (force or ai.get("yolo") is None):
+        ai["yolo"] = default_yolo
+        raw["ai"] = ai
+        changed = True
 
     # Patch implement tool override
     if force:
@@ -1951,6 +2346,8 @@ def _patch_config(
                             cmd_section[key] = overrides[key]
                     if "enabled" in overrides:
                         cmd_section["enabled"] = overrides["enabled"] == "true"
+                    if "yolo" in overrides:
+                        cmd_section["yolo"] = overrides["yolo"] == "true"
                     if cmd_section:
                         ai[cmd_name] = cmd_section
                         raw["ai"] = ai
@@ -1966,6 +2363,8 @@ def _patch_config(
                         cmd_section[key] = overrides[key]
                 if "enabled" in overrides:
                     cmd_section["enabled"] = overrides["enabled"] == "true"
+                if "yolo" in overrides:
+                    cmd_section["yolo"] = overrides["yolo"] == "true"
                 if cmd_section:
                     ai[cmd_name] = cmd_section
                     raw["ai"] = ai
@@ -1980,10 +2379,11 @@ def _patch_config(
         models = raw.get("models", {}) or {}
         tool_models = models.get(tool_key, {}) or {}
 
-        for key in ("easy", "medium", "complex", "very_complex"):
-            value = getattr(model_mapping, key, None)
-            if value and (force or not tool_models.get(key)):
-                tool_models[key] = value
+        for tier in ("easy", "medium", "complex", "very_complex"):
+            model_val = getattr(model_mapping, tier, None)
+            effort_val = getattr(model_mapping, f"{tier}_effort", None)
+            if model_val and (force or not tool_models.get(tier)):
+                tool_models[tier] = _tier_yaml_value(model_val, effort_val)
                 changed = True
 
         if tool_models:

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -198,8 +198,15 @@ def init(
             from wade.config.loader import parse_config_file
 
             existing_config = parse_config_file(config_path)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "init.existing_config_parse_failed",
+                path=str(config_path),
+                error=str(exc),
+            )
+            console.warn(
+                f"Could not parse existing {config_path.name} — continuing with fresh defaults"
+            )
 
     # --- Interactive wizard (loop supports Modify) ---
     provider_setup: dict[str, Any] = {}
@@ -212,24 +219,77 @@ def init(
     command_overrides: dict[str, dict[str, Any]] = {}
     hooks_setup: dict[str, Any] = {}
     knowledge_setup: dict[str, Any] = {}
+    tools_in_use: set[str] = set()
+
+    # Current values for pre-fill — derived from existing config on first pass,
+    # then updated from in-memory selections before each "Modify" iteration so
+    # the second pass shows the values chosen in the first pass, not stale disk state.
+    _cur_provider: str | None = existing_config.provider.name.value if existing_config else None
+    _cur_main_branch: str | None = existing_config.project.main_branch if existing_config else None
+    _cur_merge_strategy: str | None = (
+        existing_config.project.merge_strategy.value if existing_config else None
+    )
+    _cur_branch_prefix: str | None = (
+        existing_config.project.branch_prefix if existing_config else None
+    )
+    _cur_issue_label: str | None = existing_config.project.issue_label if existing_config else None
+    _cur_worktrees_dir: str | None = (
+        existing_config.project.worktrees_dir if existing_config else None
+    )
+    _cur_ai_tool: str | None = existing_config.ai.default_tool if existing_config else None
+    _cur_ai_model: str | None = existing_config.ai.default_model if existing_config else None
+    _cur_ai_effort: str | None = existing_config.ai.effort if existing_config else None
+    _cur_ai_yolo: bool | None = existing_config.ai.yolo if existing_config else None
+    _cur_impl_tool: str | None = existing_config.ai.implement.tool if existing_config else None
+    _cur_model_mapping: ComplexityModelMapping | None = (
+        existing_config.models.get(_cur_impl_tool or _cur_ai_tool or "")
+        if existing_config
+        else None
+    )
+    _cur_cmd_overrides: dict[str, dict[str, Any]] = {}
+    if existing_config:
+        for _cmd in _COMMAND_OVERRIDE_NAMES:
+            _cfg = getattr(existing_config.ai, _cmd, None)
+            if isinstance(_cfg, AICommandConfig):
+                _entry: dict[str, Any] = {}
+                if _cfg.tool:
+                    _entry["tool"] = _cfg.tool
+                if _cfg.model:
+                    _entry["model"] = _cfg.model
+                if _cfg.mode:
+                    _entry["mode"] = _cfg.mode
+                if _cfg.effort:
+                    _entry["effort"] = _cfg.effort
+                if _cfg.enabled is not None:
+                    _entry["enabled"] = "true" if _cfg.enabled else "false"
+                if _cfg.yolo is not None:
+                    _entry["yolo"] = "true" if _cfg.yolo else "false"
+                if _entry:
+                    _cur_cmd_overrides[_cmd] = _entry
+    _cur_hooks_post: str | None = (
+        existing_config.hooks.post_worktree_create if existing_config else None
+    )
+    _cur_hooks_copy: list[str] | None = (
+        list(existing_config.hooks.copy_to_worktree) if existing_config else None
+    )
+    _cur_knowledge_enabled: bool = existing_config.knowledge.enabled if existing_config else False
+    _cur_knowledge_path: str = existing_config.knowledge.path if existing_config else "KNOWLEDGE.md"
 
     while True:
         # 4a. Provider
-        current_provider = existing_config.provider.name.value if existing_config else None
         provider_setup = _prompt_provider_setup(
-            root, non_interactive, current_provider=current_provider
+            root, non_interactive, current_provider=_cur_provider
         )
 
         # 4b. Project settings
-        ps = existing_config.project if existing_config else None
         project_settings = _prompt_project_settings(
             root,
             non_interactive,
-            current_main_branch=ps.main_branch if ps else None,
-            current_merge_strategy=ps.merge_strategy.value if ps else None,
-            current_branch_prefix=ps.branch_prefix if ps else None,
-            current_issue_label=ps.issue_label if ps else None,
-            current_worktrees_dir=ps.worktrees_dir if ps else None,
+            current_main_branch=_cur_main_branch,
+            current_merge_strategy=_cur_merge_strategy,
+            current_branch_prefix=_cur_branch_prefix,
+            current_issue_label=_cur_issue_label,
+            current_worktrees_dir=_cur_worktrees_dir,
         )
 
         # 4c. AI (tool, model, effort, yolo)
@@ -237,61 +297,35 @@ def init(
             selected_tool, default_model, default_effort, default_yolo = _prompt_ai_section(
                 ai_tool,
                 non_interactive,
-                current_tool=existing_config.ai.default_tool if existing_config else None,
-                current_model=existing_config.ai.default_model if existing_config else None,
-                current_effort=existing_config.ai.effort if existing_config else None,
-                current_yolo=existing_config.ai.yolo if existing_config else None,
+                current_tool=_cur_ai_tool,
+                current_model=_cur_ai_model,
+                current_effort=_cur_ai_effort,
+                current_yolo=_cur_ai_yolo,
             )
         except ValueError as exc:
             console.error(str(exc))
             return False
 
         # 4d. Implementation (per-tier models + effort)
-        current_impl_tool = existing_config.ai.implement.tool if existing_config else None
-        current_mm = (
-            existing_config.models.get(current_impl_tool or selected_tool or "")
-            if existing_config
-            else None
-        )
         implementation_setup = _prompt_implementation_setup(
             selected_tool,
             installed_tools,
             non_interactive,
-            current_implement_tool=current_impl_tool,
-            current_model_mapping=current_mm,
+            current_implement_tool=_cur_impl_tool,
+            current_model_mapping=_cur_model_mapping,
         )
 
         # 4e. Per-command overrides (tool, model, effort, yolo)
-        current_cmd_overrides: dict[str, dict[str, Any]] = {}
-        if existing_config:
-            for cmd in _COMMAND_OVERRIDE_NAMES:
-                cfg = getattr(existing_config.ai, cmd, None)
-                if isinstance(cfg, AICommandConfig):
-                    entry: dict[str, Any] = {}
-                    if cfg.tool:
-                        entry["tool"] = cfg.tool
-                    if cfg.model:
-                        entry["model"] = cfg.model
-                    if cfg.mode:
-                        entry["mode"] = cfg.mode
-                    if cfg.effort:
-                        entry["effort"] = cfg.effort
-                    if cfg.enabled is not None:
-                        entry["enabled"] = "true" if cfg.enabled else "false"
-                    if cfg.yolo is not None:
-                        entry["yolo"] = "true" if cfg.yolo else "false"
-                    if entry:
-                        current_cmd_overrides[cmd] = entry
         command_overrides = _prompt_command_overrides(
             installed_tools,
             non_interactive,
             default_model=default_model,
             default_tool=selected_tool,
-            current_overrides=current_cmd_overrides,
+            current_overrides=_cur_cmd_overrides,
         )
 
-        # 4f. Tool-specific settings (after per-command so tools_in_use is known)
-        tools_in_use: set[str] = set()
+        # 4f. Compute tools_in_use (needed to gate tool-specific side effects)
+        tools_in_use = set()
         if selected_tool:
             tools_in_use.add(selected_tool)
         if implementation_setup.get("tool"):
@@ -300,32 +334,21 @@ def init(
             if cmd_cfg.get("tool"):
                 tools_in_use.add(cmd_cfg["tool"])
 
-        if "claude" in tools_in_use:
-            _prompt_claude_code_settings(non_interactive)
-        if "gemini" in tools_in_use:
-            _prompt_configure_gemini_experimental(non_interactive)
-
         # 4g. Worktree hooks
-        hk = existing_config.hooks if existing_config else None
         hooks_setup = _prompt_hooks_setup(
             non_interactive,
-            current_post_worktree_create=hk.post_worktree_create if hk else None,
-            current_copy_to_worktree=list(hk.copy_to_worktree) if hk else None,
+            current_post_worktree_create=_cur_hooks_post,
+            current_copy_to_worktree=_cur_hooks_copy,
         )
 
         # 4h. Project knowledge
-        kn = existing_config.knowledge if existing_config else None
         knowledge_setup = _prompt_knowledge_setup(
             non_interactive,
-            current_enabled=kn.enabled if kn else False,
-            current_path=kn.path if kn else "KNOWLEDGE.md",
+            current_enabled=_cur_knowledge_enabled,
+            current_path=_cur_knowledge_path,
         )
 
-        # 4i. Shell integration + completions
-        _prompt_configure_shell_integration(non_interactive)
-        _prompt_configure_completions(non_interactive)
-
-        # 4j. Summary + Yes / Modify / Cancel
+        # 4i. Summary + Yes / Modify / Cancel
         if non_interactive:
             break  # Skip summary in non-interactive mode
 
@@ -353,8 +376,36 @@ def init(
             console.info("Initialization cancelled — no files written.")
             return False
         if chosen == "Modify (re-run wizard)":
-            continue  # Restart wizard from the top
+            # Update current values from this iteration so the next pass pre-fills
+            # with the choices just made rather than the stale on-disk state.
+            _cur_provider = provider_setup.get("name")
+            _cur_main_branch = project_settings.get("main_branch")
+            _cur_merge_strategy = project_settings.get("merge_strategy")
+            _cur_branch_prefix = project_settings.get("branch_prefix")
+            _cur_issue_label = project_settings.get("issue_label")
+            _cur_worktrees_dir = project_settings.get("worktrees_dir")
+            _cur_ai_tool = selected_tool
+            _cur_ai_model = default_model
+            _cur_ai_effort = default_effort if default_effort != "" else None
+            _cur_ai_yolo = default_yolo
+            _cur_impl_tool = implementation_setup.get("tool")
+            _cur_model_mapping = implementation_setup.get("model_mapping")
+            _cur_cmd_overrides = command_overrides
+            _cur_hooks_post = hooks_setup.get("post_worktree_create")
+            _cur_hooks_copy = hooks_setup.get("copy_to_worktree")
+            _cur_knowledge_enabled = bool(knowledge_setup.get("enabled"))
+            _cur_knowledge_path = str(knowledge_setup.get("path", "KNOWLEDGE.md"))
+            continue
         break  # "Write .wade.yml" — proceed to write phase
+
+    # 4j. Tool-specific settings + shell integration — deferred to here so that
+    # choosing "Cancel" or iterating through "Modify" never triggers side effects.
+    if "claude" in tools_in_use:
+        _prompt_claude_code_settings(non_interactive)
+    if "gemini" in tools_in_use:
+        _prompt_configure_gemini_experimental(non_interactive)
+    _prompt_configure_shell_integration(non_interactive)
+    _prompt_configure_completions(non_interactive)
 
     # Post-wizard injections (idempotent — safe regardless of loop iterations)
     if provider_setup.get("add_env_to_copy"):
@@ -1131,6 +1182,8 @@ def _select_or_skip(
 def _select_ai_tool(
     requested: str | None,
     non_interactive: bool,
+    *,
+    current_tool: str | None = None,
 ) -> str | None:
     """Select an AI tool — from argument, detection, or interactive prompt."""
     from wade.ui import prompts
@@ -1163,7 +1216,12 @@ def _select_ai_tool(
     # Interactive: show menu with Skip option (rule shown by _prompt_ai_section)
     skip_label = "Skip (configure later)"
     items = [str(t) for t in installed] + [skip_label]
-    idx = prompts.select("Select default AI tool", items)
+
+    default_idx = len(items) - 1  # default to Skip
+    if current_tool and current_tool in items:
+        default_idx = items.index(current_tool)
+
+    idx = prompts.select("Select default AI tool", items, default=default_idx)
 
     if items[idx] == skip_label:
         return None
@@ -1191,11 +1249,13 @@ def _prompt_ai_section(
     """
     if not non_interactive:
         console.rule("AI")
-    selected_tool = _select_ai_tool(ai_tool, non_interactive)
+    selected_tool = _select_ai_tool(ai_tool, non_interactive, current_tool=current_tool)
     if non_interactive or not selected_tool:
         return selected_tool, None, None, None
     mapping = _resolve_models(selected_tool)
-    default_model = _prompt_default_model(selected_tool, mapping, non_interactive=False)
+    default_model = _prompt_default_model(
+        selected_tool, mapping, non_interactive=False, current_model=current_model
+    )
 
     default_effort: str | None = None
     default_yolo: bool | None = None
@@ -1782,6 +1842,8 @@ def _prompt_default_model(
     tool: str | None,
     model_mapping: ComplexityModelMapping,
     non_interactive: bool,
+    *,
+    current_model: str | None = None,
 ) -> str | None:
     """Prompt the user to select a default model for the AI tool.
 
@@ -1806,9 +1868,11 @@ def _prompt_default_model(
     skip_label = "Skip (configure per-complexity)"
     options = [*available, skip_label]
 
-    # Pre-select the "complex" tier model as a sensible starting default
+    # Pre-select existing model when re-initializing; fall back to "complex" tier
     default_idx = 0
-    if model_mapping.complex and model_mapping.complex in options:
+    if current_model and current_model in options:
+        default_idx = options.index(current_model)
+    elif model_mapping.complex and model_mapping.complex in options:
         default_idx = options.index(model_mapping.complex)
 
     idx = prompts.select(f"Select default model for {tool}", options, default=default_idx)
@@ -1856,22 +1920,12 @@ def _prompt_implementation_setup(
         mapping = current_model_mapping or _resolve_models(default_tool)
         return {"tool": None, "model_mapping": mapping}
 
-    from wade.ui import prompts
-
     console.rule("Implementation")
 
-    skip_label = "Skip (use default)"
-    tool_options = (installed_tools if installed_tools else ["claude", "copilot", "gemini"]) + [
-        skip_label
-    ]
-
-    # Pre-select current implement tool if present
-    tool_default_idx = len(tool_options) - 1  # default: Skip
-    if current_implement_tool and current_implement_tool in tool_options:
-        tool_default_idx = tool_options.index(current_implement_tool)
-
-    idx = prompts.select("AI tool for implementation work", tool_options, default=tool_default_idx)
-    implement_tool = None if tool_options[idx] == skip_label else tool_options[idx]
+    base_tools = installed_tools if installed_tools else ["claude", "copilot", "gemini"]
+    implement_tool = _select_or_skip(
+        "AI tool for implementation work", base_tools, current_implement_tool
+    )
 
     current_effective = implement_tool or default_tool
     mapping = current_model_mapping or _resolve_models(current_effective)
@@ -1953,11 +2007,20 @@ def _prompt_command_overrides(
 
         if caps.supports_yolo:
             current_yolo_val = current_cmd.get("yolo")
-            current_yolo_bool = current_yolo_val is True or current_yolo_val == "true"
-            yolo_on = prompts.confirm(
-                "  Enable YOLO mode for this command?", default=current_yolo_bool
+            yolo_choices = ["Skip (use default)", "Yes", "No"]
+            yolo_default = 0  # default to Skip (inherit global ai.yolo)
+            if current_yolo_val == "true" or current_yolo_val is True:
+                yolo_default = 1
+            elif current_yolo_val == "false" or current_yolo_val is False:
+                yolo_default = 2
+            yolo_idx = prompts.select(
+                "  Enable YOLO mode for this command?", yolo_choices, default=yolo_default
             )
-            result[cmd_name]["yolo"] = "true" if yolo_on else "false"
+            if yolo_idx == 1:
+                result[cmd_name]["yolo"] = "true"
+            elif yolo_idx == 2:
+                result[cmd_name]["yolo"] = "false"
+            # idx == 0 means Skip — omit yolo to inherit the global ai.yolo setting
 
     def _ask_tool_and_model(
         cmd_idx: int,
@@ -2106,17 +2169,15 @@ def _prompt_command_overrides(
     return result
 
 
-def _tier_yaml_value(model: str | None, effort: str | None) -> str | dict[str, Any] | None:
+def _tier_yaml_value(model: str | None, effort: str | None) -> dict[str, Any] | None:
     """Return the YAML representation for a complexity tier.
 
-    Uses the compact string form when no effort is configured, otherwise the
-    structured ``{model, effort}`` form.
+    Always uses the structured ``{model, effort}`` form so the format is stable
+    after migration from the legacy plain-string form.
     """
     if not model:
         return None
-    if effort:
-        return {"model": model, "effort": effort}
-    return model
+    return {"model": model, "effort": effort or None}
 
 
 def _write_config(

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -193,19 +193,21 @@ def init(
     # 3. Parse existing config for re-init pre-fill
     config_path = root / ".wade.yml"
     existing_config = None
+    parse_failed = False
     if config_path.exists():
         try:
             from wade.config.loader import parse_config_file
 
             existing_config = parse_config_file(config_path)
         except Exception as exc:
+            parse_failed = True
             logger.warning(
                 "init.existing_config_parse_failed",
                 path=str(config_path),
                 error=str(exc),
             )
             console.warn(
-                f"Could not parse existing {config_path.name} — continuing with fresh defaults"
+                f"Could not parse existing {config_path.name} — will overwrite after confirmation"
             )
 
     # --- Interactive wizard (loop supports Modify) ---
@@ -225,6 +227,12 @@ def init(
     # then updated from in-memory selections before each "Modify" iteration so
     # the second pass shows the values chosen in the first pass, not stale disk state.
     _cur_provider: str | None = existing_config.provider.name.value if existing_config else None
+    _cur_provider_api_token_env: str | None = (
+        existing_config.provider.api_token_env if existing_config else None
+    )
+    _cur_provider_settings: dict[str, str] = (
+        dict(existing_config.provider.settings) if existing_config else {}
+    )
     _cur_main_branch: str | None = existing_config.project.main_branch if existing_config else None
     _cur_merge_strategy: str | None = (
         existing_config.project.merge_strategy.value if existing_config else None
@@ -246,6 +254,7 @@ def init(
         if existing_config
         else None
     )
+    _cur_effective_tool: str | None = _cur_impl_tool or _cur_ai_tool
     _cur_cmd_overrides: dict[str, dict[str, Any]] = {}
     if existing_config:
         for _cmd in _COMMAND_OVERRIDE_NAMES:
@@ -278,7 +287,11 @@ def init(
     while True:
         # 4a. Provider
         provider_setup = _prompt_provider_setup(
-            root, non_interactive, current_provider=_cur_provider
+            root,
+            non_interactive,
+            current_provider=_cur_provider,
+            current_api_token_env=_cur_provider_api_token_env,
+            current_settings=_cur_provider_settings,
         )
 
         # 4b. Project settings
@@ -313,6 +326,7 @@ def init(
             non_interactive,
             current_implement_tool=_cur_impl_tool,
             current_model_mapping=_cur_model_mapping,
+            current_effective_tool=_cur_effective_tool,
         )
 
         # 4e. Per-command overrides (tool, model, effort, yolo)
@@ -379,6 +393,8 @@ def init(
             # Update current values from this iteration so the next pass pre-fills
             # with the choices just made rather than the stale on-disk state.
             _cur_provider = provider_setup.get("name")
+            _cur_provider_api_token_env = provider_setup.get("api_token_env")
+            _cur_provider_settings = dict(provider_setup.get("settings") or {})
             _cur_main_branch = project_settings.get("main_branch")
             _cur_merge_strategy = project_settings.get("merge_strategy")
             _cur_branch_prefix = project_settings.get("branch_prefix")
@@ -390,6 +406,7 @@ def init(
             _cur_ai_yolo = default_yolo
             _cur_impl_tool = implementation_setup.get("tool")
             _cur_model_mapping = implementation_setup.get("model_mapping")
+            _cur_effective_tool = _cur_impl_tool or selected_tool
             _cur_cmd_overrides = command_overrides
             _cur_hooks_post = hooks_setup.get("post_worktree_create")
             _cur_hooks_copy = hooks_setup.get("copy_to_worktree")
@@ -434,37 +451,42 @@ def init(
     if not non_interactive:
         console.rule("Initing")
 
-    if config_path.exists():
+    _write_config_kwargs: dict[str, Any] = dict(
+        project_settings=project_settings,
+        implement_tool=implementation_setup["tool"],
+        default_model=default_model,
+        default_effort=default_effort,
+        default_yolo=default_yolo,
+        command_overrides=command_overrides,
+        hooks_setup=hooks_setup,
+        provider_setup=provider_setup,
+        knowledge_setup=knowledge_setup,
+    )
+    if config_path.exists() and not parse_failed:
         console.info("Config .wade.yml already exists — updating with selected values")
         _patch_config(
             config_path,
             selected_tool,
             implementation_setup["model_mapping"],
-            default_model=default_model,
-            default_effort=default_effort,
-            default_yolo=default_yolo,
-            project_settings=project_settings,
-            implement_tool=implementation_setup["tool"],
-            command_overrides=command_overrides,
-            hooks_setup=hooks_setup,
             force=not non_interactive,
-            provider_setup=provider_setup,
-            knowledge_setup=knowledge_setup,
+            **_write_config_kwargs,
         )
     else:
+        if parse_failed:
+            from wade.ui import prompts as _prompts
+
+            if not non_interactive and not _prompts.confirm(
+                f"{config_path.name} could not be parsed — overwrite with new config?",
+                default=True,
+            ):
+                console.error("Aborting — cannot patch a corrupted config file")
+                return False
+            console.warn(f"Overwriting corrupted {config_path.name}")
         _write_config(
             config_path,
             selected_tool,
             implementation_setup["model_mapping"],
-            project_settings=project_settings,
-            implement_tool=implementation_setup["tool"],
-            default_model=default_model,
-            default_effort=default_effort,
-            default_yolo=default_yolo,
-            command_overrides=command_overrides,
-            hooks_setup=hooks_setup,
-            provider_setup=provider_setup,
-            knowledge_setup=knowledge_setup,
+            **_write_config_kwargs,
         )
         console.success(f"Created {config_path.name}")
 
@@ -1421,6 +1443,8 @@ def _prompt_provider_setup(
     project_root: Path,
     non_interactive: bool,
     current_provider: str | None = None,
+    current_api_token_env: str | None = None,
+    current_settings: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Collect task provider selection and authentication setup.
 
@@ -1480,6 +1504,8 @@ def _prompt_provider_setup(
     if prompts.confirm("Open ClickUp settings in browser?", default=True):
         webbrowser.open("https://app.clickup.com/settings/apps")
 
+    _cur_settings = current_settings or {}
+
     # Prompt for token with validation
     token = ""
     token_validated = False
@@ -1508,7 +1534,8 @@ def _prompt_provider_setup(
     env_var = ""
     while not env_var:
         candidate = prompts.input_prompt(
-            "Environment variable name for the token", default="CLICKUP_API_TOKEN"
+            "Environment variable name for the token",
+            default=current_api_token_env or "CLICKUP_API_TOKEN",
         )
         if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", candidate):
             env_var = candidate
@@ -1527,19 +1554,23 @@ def _prompt_provider_setup(
     # Required IDs — re-prompt until non-empty
     team_id = ""
     while not team_id:
-        team_id = prompts.input_prompt("ClickUp team/workspace ID").strip()
+        team_id = prompts.input_prompt(
+            "ClickUp team/workspace ID", default=_cur_settings.get("team_id", "")
+        ).strip()
         if not team_id:
             console.warn("Team/workspace ID is required")
     list_id = ""
     while not list_id:
-        list_id = prompts.input_prompt("ClickUp list ID").strip()
+        list_id = prompts.input_prompt(
+            "ClickUp list ID", default=_cur_settings.get("list_id", "")
+        ).strip()
         if not list_id:
             console.warn("List ID is required")
 
     # Optional space ID
     space_id = prompts.input_prompt(
         "ClickUp space ID",
-        default="",
+        default=_cur_settings.get("space_id", ""),
         allow_empty=True,
     ).strip()
 
@@ -1805,7 +1836,7 @@ def _prompt_model_mapping(
         if tool_supports_effort:
             from wade.models.ai import EffortLevel
 
-            effort_choices = ["(none — use tool default)", *[e.value for e in EffortLevel]]
+            effort_choices = ["Skip (inherit defaults)", *[e.value for e in EffortLevel]]
             effort_default_idx = 0
             if current_tier_effort and current_tier_effort in effort_choices:
                 effort_default_idx = effort_choices.index(current_tier_effort)
@@ -1906,6 +1937,7 @@ def _prompt_implementation_setup(
     *,
     current_implement_tool: str | None = None,
     current_model_mapping: ComplexityModelMapping | None = None,
+    current_effective_tool: str | None = None,
 ) -> dict[str, Any]:
     """Prompt for implementation tool and per-complexity model overrides.
 
@@ -1928,7 +1960,9 @@ def _prompt_implementation_setup(
     )
 
     current_effective = implement_tool or default_tool
-    mapping = current_model_mapping or _resolve_models(current_effective)
+    # Discard stale mapping when the effective tool has changed since last pass.
+    cached = current_model_mapping if current_effective == current_effective_tool else None
+    mapping = cached or _resolve_models(current_effective)
     mapping = _prompt_model_mapping(current_effective, mapping, non_interactive=False)
 
     return {"tool": implement_tool, "model_mapping": mapping}
@@ -1994,7 +2028,7 @@ def _prompt_command_overrides(
         if caps.supports_effort:
             from wade.models.ai import EffortLevel
 
-            effort_choices = ["(none — use tool default)", *[e.value for e in EffortLevel]]
+            effort_choices = ["Skip (inherit defaults)", *[e.value for e in EffortLevel]]
             current_effort = current_cmd.get("effort")
             effort_default_idx = 0
             if current_effort and current_effort in effort_choices:
@@ -2081,9 +2115,10 @@ def _prompt_command_overrides(
             if chosen and chosen != skip_model_label:
                 result[cmd_name]["model"] = chosen
 
-        # Effort + yolo — only when user explicitly selected a tool for this command
-        if tool_for_cmd[cmd_idx] is not None:
-            _ask_effort_and_yolo(cmd_name, tool_for_cmd[cmd_idx])
+        # Effort + yolo — use effective tool (explicit override or inherited default_tool)
+        effective_tool = tool_for_cmd[cmd_idx] or default_tool
+        if effective_tool:
+            _ask_effort_and_yolo(cmd_name, effective_tool)
 
     for cmd_idx, (cmd_name, prompt_label, section) in enumerate(cmd_triples):
         console.rule(section)

--- a/tests/e2e/test_admin_contract.py
+++ b/tests/e2e/test_admin_contract.py
@@ -41,9 +41,15 @@ class TestInitCommand:
         assert result.returncode == 0
         config = yaml.safe_load((repo / ".wade.yml").read_text(encoding="utf-8"))
         assert config["ai"]["default_tool"] == "claude"
-        assert config["models"]["claude"]["easy"] == "claude-haiku-4.5"
-        assert config["models"]["claude"]["medium"] == "claude-sonnet-4.6"
-        assert config["models"]["claude"]["complex"] == "claude-sonnet-4.6"
+        assert config["models"]["claude"]["easy"] == {"model": "claude-haiku-4.5", "effort": None}
+        assert config["models"]["claude"]["medium"] == {
+            "model": "claude-sonnet-4.6",
+            "effort": None,
+        }
+        assert config["models"]["claude"]["complex"] == {
+            "model": "claude-sonnet-4.6",
+            "effort": None,
+        }
         assert config["models"]["claude"]["medium"] != config["models"]["claude"]["easy"]
         assert "permissions" not in config
         assert (repo / ".wade" / ".wade-managed").is_file()

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -30,7 +30,10 @@ class TestInit:
         config = yaml.safe_load(config_path.read_text())
         assert config["version"] == 2
         assert config["ai"]["default_tool"] == "claude"
-        assert config["models"]["claude"]["medium"] == "claude-sonnet-4.6"
+        assert config["models"]["claude"]["medium"] == {
+            "model": "claude-sonnet-4.6",
+            "effort": None,
+        }
         assert config["models"]["claude"]["medium"] != config["models"]["claude"]["easy"]
         assert "permissions" not in config
 

--- a/tests/unit/test_config/test_defaults.py
+++ b/tests/unit/test_config/test_defaults.py
@@ -47,9 +47,9 @@ class TestWriteLoadRoundtrip:
         config = yaml.safe_load(config_path.read_text())
         models = config["models"]["claude"]
 
-        assert models["easy"] == defaults.easy
-        assert models["medium"] == defaults.medium
-        assert models["complex"] == defaults.complex
-        assert models["very_complex"] == defaults.very_complex
+        assert models["easy"] == {"model": defaults.easy, "effort": None}
+        assert models["medium"] == {"model": defaults.medium, "effort": None}
+        assert models["complex"] == {"model": defaults.complex, "effort": None}
+        assert models["very_complex"] == {"model": defaults.very_complex, "effort": None}
         # medium must not equal easy
         assert models["medium"] != models["easy"]

--- a/tests/unit/test_config/test_migrations.py
+++ b/tests/unit/test_config/test_migrations.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 
-from wade.config.migrations import ensure_version, run_all_migrations
+from wade.config.migrations import (
+    ensure_version,
+    migrate_string_tiers_to_tier_config,
+    run_all_migrations,
+)
 
 # ---------------------------------------------------------------------------
 # ensure_version
@@ -102,3 +107,78 @@ class TestRunAllMigrations:
         mtime_after = config_path.stat().st_mtime_ns
 
         assert mtime_before == mtime_after
+
+
+# ---------------------------------------------------------------------------
+# migrate_string_tiers_to_tier_config
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateStringTiersToTierConfig:
+    def test_converts_string_tier_to_dict_form(self) -> None:
+        raw: dict[str, Any] = {
+            "version": 2,
+            "models": {"claude": {"easy": "haiku", "complex": "sonnet"}},
+        }
+        result = migrate_string_tiers_to_tier_config(raw)
+        assert result is True
+        assert raw["models"]["claude"]["easy"] == {"model": "haiku", "effort": None}
+        assert raw["models"]["claude"]["complex"] == {"model": "sonnet", "effort": None}
+
+    def test_idempotent_on_already_dict_form(self) -> None:
+        raw: dict[str, Any] = {
+            "version": 2,
+            "models": {"claude": {"easy": {"model": "haiku", "effort": "low"}}},
+        }
+        result = migrate_string_tiers_to_tier_config(raw)
+        assert result is False
+        assert raw["models"]["claude"]["easy"] == {"model": "haiku", "effort": "low"}
+
+    def test_no_op_when_no_models_key(self) -> None:
+        raw: dict[str, Any] = {"version": 2, "ai": {"default_tool": "claude"}}
+        result = migrate_string_tiers_to_tier_config(raw)
+        assert result is False
+
+    def test_no_op_when_models_is_not_dict(self) -> None:
+        raw: dict[str, Any] = {"version": 2, "models": "not-a-dict"}
+        result = migrate_string_tiers_to_tier_config(raw)
+        assert result is False
+
+    def test_skips_none_tier_values(self) -> None:
+        raw: dict[str, Any] = {
+            "version": 2,
+            "models": {"claude": {"easy": None, "complex": "sonnet"}},
+        }
+        result = migrate_string_tiers_to_tier_config(raw)
+        assert result is True
+        assert raw["models"]["claude"]["easy"] is None
+        assert raw["models"]["claude"]["complex"] == {"model": "sonnet", "effort": None}
+
+    def test_all_four_tiers_converted(self) -> None:
+        raw: dict[str, Any] = {
+            "models": {
+                "claude": {
+                    "easy": "haiku",
+                    "medium": "haiku",
+                    "complex": "sonnet",
+                    "very_complex": "opus",
+                }
+            }
+        }
+        migrate_string_tiers_to_tier_config(raw)
+        tool = raw["models"]["claude"]
+        for tier in ("easy", "medium", "complex", "very_complex"):
+            assert isinstance(tool[tier], dict)
+            assert "model" in tool[tier]
+            assert "effort" in tool[tier]
+
+    def test_run_all_migrations_applies_tier_conversion(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text(
+            "version: 2\nmodels:\n  claude:\n    easy: haiku\n    complex: sonnet\n"
+        )
+        result = run_all_migrations(config_path)
+        assert result is True
+        migrated = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert migrated["models"]["claude"]["easy"] == {"model": "haiku", "effort": None}
+        assert migrated["models"]["claude"]["complex"] == {"model": "sonnet", "effort": None}

--- a/tests/unit/test_services/test_ai_resolution.py
+++ b/tests/unit/test_services/test_ai_resolution.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 
 import wade.ai_tools  # noqa: F401 — registers all adapters via __init_subclass__
 from wade.models.ai import EffortLevel
-from wade.services.ai_resolution import confirm_ai_selection
+from wade.models.config import AICommandConfig, AIConfig, ComplexityModelMapping, ProjectConfig
+from wade.services.ai_resolution import confirm_ai_selection, resolve_effort
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -415,3 +416,62 @@ class TestChangeEffort:
         assert tool == _COPILOT
         assert model == _MODEL_B
         assert effort is None  # stale effort cleared when copilot doesn't support it
+
+
+# ---------------------------------------------------------------------------
+# resolve_effort — per-tier priority chain
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    *,
+    global_effort: str | None = None,
+    plan_effort: str | None = None,
+    claude_complex_effort: str | None = None,
+) -> ProjectConfig:
+    """Build a minimal ProjectConfig for testing resolve_effort."""
+    mapping = ComplexityModelMapping(complex_effort=claude_complex_effort)
+    ai = AIConfig(effort=global_effort, plan=AICommandConfig(effort=plan_effort))
+    return ProjectConfig(ai=ai, models={"claude": mapping})
+
+
+class TestResolveEffortPerTier:
+    """resolve_effort honours: CLI → env → command-config → tier → global."""
+
+    def test_explicit_effort_arg_wins(self) -> None:
+        config = _make_config(global_effort="low", plan_effort="medium")
+        result = resolve_effort("high", config, "plan")
+        assert result == EffortLevel.HIGH
+
+    def test_command_specific_effort_beats_global(self) -> None:
+        config = _make_config(global_effort="low", plan_effort="medium")
+        result = resolve_effort(None, config, "plan")
+        assert result == EffortLevel.MEDIUM
+
+    def test_tier_effort_used_when_no_command_config(self) -> None:
+        """When command has no effort override, per-complexity-tier effort is used."""
+        config = _make_config(global_effort="low", claude_complex_effort="high")
+        result = resolve_effort(None, config, "plan", tool="claude", complexity="complex")
+        assert result == EffortLevel.HIGH
+
+    def test_command_effort_beats_tier_effort(self) -> None:
+        """Command-specific config takes priority over per-tier effort."""
+        config = _make_config(plan_effort="medium", claude_complex_effort="high")
+        result = resolve_effort(None, config, "plan", tool="claude", complexity="complex")
+        assert result == EffortLevel.MEDIUM
+
+    def test_global_effort_is_fallback(self) -> None:
+        """When neither command nor tier has effort, global ai.effort is used."""
+        config = _make_config(global_effort="low")
+        result = resolve_effort(None, config, "plan", tool="claude", complexity="complex")
+        assert result == EffortLevel.LOW
+
+    def test_returns_none_when_no_effort_anywhere(self) -> None:
+        config = _make_config()
+        result = resolve_effort(None, config, "plan")
+        assert result is None
+
+    def test_invalid_effort_string_returns_none(self) -> None:
+        config = _make_config()
+        result = resolve_effort("not-a-valid-level", config, "plan")
+        assert result is None

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -648,25 +648,24 @@ class TestPromptCommandOverrides:
     @patch("wade.ui.prompts.select")
     def test_deps_with_default_tool_shows_mode(self, mock_select: MagicMock) -> None:
         """When default_tool is set, deps should show headless/interactive mode prompt."""
-        # plan: Skip (idx=1)
-        # deps: Skip tool (idx=1), effective_tool=default_tool → mode prompt appears
-        #   mode=headless (idx=0 in [headless, interactive])
-        # review_plan/review_implementation/review_batch: Enable=No (idx=1)
-        mock_select.side_effect = [1, 1, 0, 1, 1, 1]
+        # plan: Skip tool (1), effort=Skip (0), yolo=Skip (0) — inherits default_tool
+        # deps: Skip tool (1), effort=Skip (0), yolo=Skip (0), mode=headless (0)
+        # review_plan/review_implementation/review_batch: Enable=No (1)
+        mock_select.side_effect = [1, 0, 0, 1, 0, 0, 0, 1, 1, 1]
         result = _prompt_command_overrides(["claude"], non_interactive=False, default_tool="claude")
         assert result["deps"] == {"mode": "headless"}
 
     @patch("wade.ui.prompts.select")
     def test_deps_mode_excludes_self_review(self, mock_select: MagicMock) -> None:
         """Deps mode prompt must not include 'prompt (self-review)' as an option."""
-        # plan: Skip (idx=1)
-        # deps: Skip tool (idx=1), effective_tool=default_tool → mode prompt
-        #   select mode=headless (idx=0)
-        # review_plan/review_implementation/review_batch: Enable=No (idx=1)
-        mock_select.side_effect = [1, 1, 0, 1, 1, 1]
+        # plan: Skip tool (1), effort=Skip (0), yolo=Skip (0) — inherits default_tool
+        # deps: Skip tool (1), effort=Skip (0), yolo=Skip (0), mode=headless (0)
+        # review_plan/review_implementation/review_batch: Enable=No (1)
+        mock_select.side_effect = [1, 0, 0, 1, 0, 0, 0, 1, 1, 1]
         _prompt_command_overrides(["claude"], non_interactive=False, default_tool="claude")
-        # The deps mode call is the 3rd select call (index 2)
-        deps_mode_call = mock_select.call_args_list[2]
+        # The deps mode call is the 7th select call (index 6):
+        # 0=plan-tool 1=plan-effort 2=plan-yolo 3=deps-tool 4=deps-effort 5=deps-yolo 6=deps-mode
+        deps_mode_call = mock_select.call_args_list[6]
         mode_options_arg = deps_mode_call.args[1]
         assert "prompt (self-review)" not in mode_options_arg
         assert "headless (AI one-shot)" in mode_options_arg

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -591,10 +591,11 @@ class TestPromptCommandOverrides:
         mock_suggest.return_value = "gemini-2.5-pro"
         # installed_tools=["claude", "gemini"], tool_options=["claude", "gemini", "Skip"]
         # plan: idx 1 = gemini; model for plan: idx 1 = "gemini-2.5-pro" (2nd in gemini list)
+        # plan YOLO: idx 0 = Skip (gemini supports_yolo=True; Skip means inherit global)
         # deps: idx 2 = Skip, no effective tool (no default_tool) → mode skipped
         # review_plan/review_implementation/review_batch:
         #   Enable=Yes (idx 0), mode=prompt (idx 0) → skip tool/model
-        mock_select.side_effect = [1, 1, 2, 0, 0, 0, 0, 0, 0]
+        mock_select.side_effect = [1, 1, 0, 2, 0, 0, 0, 0, 0, 0]
         result = _prompt_command_overrides(["claude", "gemini"], non_interactive=False)
         assert result["plan"]["tool"] == "gemini"
         assert result["plan"]["model"] == "gemini-2.5-pro"
@@ -753,10 +754,10 @@ class TestWriteConfig:
         )
         _write_config(config_path, "claude", mapping)
         config = yaml.safe_load(config_path.read_text())
-        assert config["models"]["claude"]["easy"] == "haiku"
-        assert config["models"]["claude"]["medium"] == "sonnet"
-        assert config["models"]["claude"]["complex"] == "sonnet"
-        assert config["models"]["claude"]["very_complex"] == "opus"
+        assert config["models"]["claude"]["easy"] == {"model": "haiku", "effort": None}
+        assert config["models"]["claude"]["medium"] == {"model": "sonnet", "effort": None}
+        assert config["models"]["claude"]["complex"] == {"model": "sonnet", "effort": None}
+        assert config["models"]["claude"]["very_complex"] == {"model": "opus", "effort": None}
 
     def test_write_config_with_only_medium_and_very_complex(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
@@ -764,8 +765,8 @@ class TestWriteConfig:
         _write_config(config_path, "claude", mapping)
         config = yaml.safe_load(config_path.read_text())
         assert "models" in config
-        assert config["models"]["claude"]["medium"] == "sonnet"
-        assert config["models"]["claude"]["very_complex"] == "opus"
+        assert config["models"]["claude"]["medium"] == {"model": "sonnet", "effort": None}
+        assert config["models"]["claude"]["very_complex"] == {"model": "opus", "effort": None}
 
     def test_no_tool_omits_ai_and_models(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
@@ -907,8 +908,8 @@ class TestPatchConfig:
         mapping = ComplexityModelMapping(easy="new-haiku", complex="sonnet")
         _patch_config(config_path, "claude", mapping, force=True)
         config = yaml.safe_load(config_path.read_text())
-        assert config["models"]["claude"]["easy"] == "new-haiku"
-        assert config["models"]["claude"]["complex"] == "sonnet"
+        assert config["models"]["claude"]["easy"] == {"model": "new-haiku", "effort": None}
+        assert config["models"]["claude"]["complex"] == {"model": "sonnet", "effort": None}
 
     def test_patch_config_writes_all_four_tiers(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
@@ -918,10 +919,10 @@ class TestPatchConfig:
         )
         _patch_config(config_path, "claude", mapping, force=True)
         config = yaml.safe_load(config_path.read_text())
-        assert config["models"]["claude"]["easy"] == "haiku"
-        assert config["models"]["claude"]["medium"] == "sonnet"
-        assert config["models"]["claude"]["complex"] == "sonnet"
-        assert config["models"]["claude"]["very_complex"] == "opus"
+        assert config["models"]["claude"]["easy"] == {"model": "haiku", "effort": None}
+        assert config["models"]["claude"]["medium"] == {"model": "sonnet", "effort": None}
+        assert config["models"]["claude"]["complex"] == {"model": "sonnet", "effort": None}
+        assert config["models"]["claude"]["very_complex"] == {"model": "opus", "effort": None}
 
     def test_no_force_preserves_existing_models(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
@@ -933,7 +934,7 @@ class TestPatchConfig:
         _patch_config(config_path, "claude", mapping, force=False)
         config = yaml.safe_load(config_path.read_text())
         assert config["models"]["claude"]["easy"] == "existing-haiku"
-        assert config["models"]["claude"]["complex"] == "sonnet"
+        assert config["models"]["claude"]["complex"] == {"model": "sonnet", "effort": None}
 
     def test_models_keyed_by_implement_tool_when_provided(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
@@ -2267,23 +2268,29 @@ class TestPromptModelMappingPerTierEffort:
 
 class TestShowInitSummary:
     def test_renders_without_error_minimal(self) -> None:
-        _show_init_summary(
-            provider_setup={"name": "github"},
-            project_settings={
-                "main_branch": "main",
-                "merge_strategy": "PR",
-                "branch_prefix": "feat",
-                "worktrees_dir": "../.worktrees",
-            },
-            selected_tool=None,
-            default_model=None,
-            default_effort=None,
-            default_yolo=None,
-            implementation_setup={},
-            command_overrides={},
-            hooks_setup={},
-            knowledge_setup={},
-        )
+        with patch("wade.services.init_service.console") as mock_console:
+            _show_init_summary(
+                provider_setup={"name": "github"},
+                project_settings={
+                    "main_branch": "main",
+                    "merge_strategy": "PR",
+                    "branch_prefix": "feat",
+                    "worktrees_dir": "../.worktrees",
+                },
+                selected_tool=None,
+                default_model=None,
+                default_effort=None,
+                default_yolo=None,
+                implementation_setup={},
+                command_overrides={},
+                hooks_setup={},
+                knowledge_setup={},
+            )
+        kv_calls = {call.args[0]: call.args[1] for call in mock_console.kv.call_args_list}
+        assert kv_calls.get("Provider") == "github"
+        assert kv_calls.get("Main branch") == "main"
+        assert kv_calls.get("AI tool") == "(not set)"
+        assert "Default YOLO" not in kv_calls
 
     def test_renders_with_full_data(self) -> None:
         mapping = ComplexityModelMapping(
@@ -2293,30 +2300,41 @@ class TestShowInitSummary:
             very_complex="opus",
             complex_effort="high",
         )
-        _show_init_summary(
-            provider_setup={"name": "github"},
-            project_settings={
-                "main_branch": "main",
-                "merge_strategy": "direct",
-                "branch_prefix": "fix",
-                "worktrees_dir": "../trees",
-            },
-            selected_tool="claude",
-            default_model="claude-sonnet-4-6",
-            default_effort="medium",
-            default_yolo=True,
-            implementation_setup={"tool": "claude", "model_mapping": mapping},
-            command_overrides={
-                "plan": {"tool": "gemini", "model": "gemini-2.5-pro"},
-                "deps": {"mode": "headless"},
-                "review_plan": {"enabled": "true", "mode": "prompt"},
-            },
-            hooks_setup={
-                "post_worktree_create": "scripts/setup.sh",
-                "copy_to_worktree": [".env"],
-            },
-            knowledge_setup={"enabled": True, "path": "docs/KNOWLEDGE.md"},
-        )
+        with patch("wade.services.init_service.console") as mock_console:
+            _show_init_summary(
+                provider_setup={"name": "github"},
+                project_settings={
+                    "main_branch": "main",
+                    "merge_strategy": "direct",
+                    "branch_prefix": "fix",
+                    "worktrees_dir": "../trees",
+                },
+                selected_tool="claude",
+                default_model="claude-sonnet-4-6",
+                default_effort="medium",
+                default_yolo=True,
+                implementation_setup={"tool": "claude", "model_mapping": mapping},
+                command_overrides={
+                    "plan": {"tool": "gemini", "model": "gemini-2.5-pro"},
+                    "deps": {"mode": "headless"},
+                    "review_plan": {"enabled": "true", "mode": "prompt"},
+                },
+                hooks_setup={
+                    "post_worktree_create": "scripts/setup.sh",
+                    "copy_to_worktree": [".env"],
+                },
+                knowledge_setup={"enabled": True, "path": "docs/KNOWLEDGE.md"},
+            )
+        kv_calls = {call.args[0]: call.args[1] for call in mock_console.kv.call_args_list}
+        assert kv_calls.get("AI tool") == "claude"
+        assert kv_calls.get("Default YOLO") == "true"
+        assert kv_calls.get("Default effort") == "medium"
+        assert kv_calls.get("Knowledge file") == "docs/KNOWLEDGE.md"
+        # Verify per-tier effort shows up in implementation mapping output
+        assert any("high" in str(v) for v in kv_calls.values())
+        # Verify per-command overrides are shown
+        plan_entry = kv_calls.get("  plan")
+        assert plan_entry is not None and "gemini" in plan_entry
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -20,6 +20,7 @@ from wade.services.init_service import (
     _ensure_wade_dir_self_ignoring,
     _migrate_gitignore_block,
     _patch_config,
+    _prompt_ai_section,
     _prompt_command_overrides,
     _prompt_hooks_setup,
     _prompt_model_mapping,
@@ -29,6 +30,8 @@ from wade.services.init_service import (
     _resolve_models,
     _save_token_to_env,
     _select_ai_tool,
+    _select_or_skip,
+    _show_init_summary,
     _validate_clickup_token,
     _write_config,
     deinit,
@@ -600,6 +603,7 @@ class TestPromptCommandOverrides:
         assert result["review_implementation"] == {"enabled": "true", "mode": "prompt"}
         assert result["review_batch"] == {"enabled": "true", "mode": "prompt"}
 
+    @patch("wade.services.init_service.AbstractAITool.get")
     @patch("wade.services.init_service._collect_model_options")
     @patch("wade.services.init_service._suggest_model_for_tool")
     @patch("wade.ui.prompts.select")
@@ -608,10 +612,16 @@ class TestPromptCommandOverrides:
         mock_select: MagicMock,
         mock_suggest: MagicMock,
         mock_collect: MagicMock,
+        mock_get_tool: MagicMock,
     ) -> None:
         """Selecting headless/interactive for review should trigger tool and model prompts."""
         mock_suggest.return_value = "claude-sonnet"
         mock_collect.return_value = ["claude-haiku", "claude-sonnet"]
+        # Patch capability to disable effort/yolo so this test stays focused on tool/model
+        mock_caps = MagicMock()
+        mock_caps.supports_effort = False
+        mock_caps.supports_yolo = False
+        mock_get_tool.return_value.capabilities.return_value = mock_caps
         # tool_options=["claude", "Skip"]
         # model_options=["claude-haiku", "claude-sonnet", "Custom...", "Skip"]
         # plan: Skip (idx=1)
@@ -2057,3 +2067,328 @@ class TestInitProvider:
         init(project_root=tmp_git_repo, non_interactive=True)
         config = yaml.safe_load((tmp_git_repo / ".wade.yml").read_text())
         assert config["provider"]["name"] == "github"
+
+
+# ---------------------------------------------------------------------------
+# _select_or_skip tests
+# ---------------------------------------------------------------------------
+
+
+class TestSelectOrSkip:
+    @patch("wade.ui.prompts.select")
+    def test_returns_none_when_skip_chosen(self, mock_select: MagicMock) -> None:
+        mock_select.return_value = 2  # index of "Skip (use default)" in ["a", "b", "Skip..."]
+        result = _select_or_skip("Pick one", ["a", "b"])
+        assert result is None
+
+    @patch("wade.ui.prompts.select")
+    def test_returns_option_when_chosen(self, mock_select: MagicMock) -> None:
+        mock_select.return_value = 1  # "b"
+        result = _select_or_skip("Pick one", ["a", "b"])
+        assert result == "b"
+
+    @patch("wade.ui.prompts.select")
+    def test_current_value_is_pre_selected(self, mock_select: MagicMock) -> None:
+        mock_select.return_value = 0  # consume the call
+        _select_or_skip("Pick one", ["a", "b", "c"], current="b")
+        _, kwargs = mock_select.call_args
+        assert kwargs.get("default") == 1  # "b" is index 1 in ["a","b","c","Skip..."]
+
+    @patch("wade.ui.prompts.select")
+    def test_skip_is_default_when_no_current(self, mock_select: MagicMock) -> None:
+        mock_select.return_value = 2
+        _select_or_skip("Pick one", ["a", "b"])
+        _, kwargs = mock_select.call_args
+        assert kwargs.get("default") == 2  # last index = Skip
+
+    @patch("wade.ui.prompts.select")
+    def test_unrecognized_current_defaults_to_skip(self, mock_select: MagicMock) -> None:
+        mock_select.return_value = 2
+        _select_or_skip("Pick one", ["a", "b"], current="unknown")
+        _, kwargs = mock_select.call_args
+        assert kwargs.get("default") == 2  # Skip is the fallback
+
+
+# ---------------------------------------------------------------------------
+# _prompt_ai_section yolo + effort tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptAiSectionYoloEffort:
+    @patch("wade.services.init_service._prompt_default_model", return_value=None)
+    @patch("wade.services.init_service._select_ai_tool", return_value="claude")
+    def test_non_interactive_returns_none_extras(
+        self, _mock_tool: MagicMock, _mock_model: MagicMock
+    ) -> None:
+        tool, model, effort, yolo = _prompt_ai_section(None, non_interactive=True)
+        assert tool == "claude"
+        assert model is None
+        assert effort is None
+        assert yolo is None
+
+    @patch("wade.ui.prompts.confirm")
+    @patch("wade.ui.prompts.select")
+    @patch("wade.services.init_service._prompt_default_model", return_value=None)
+    @patch("wade.services.init_service._select_ai_tool", return_value="claude")
+    @patch("wade.services.init_service.AbstractAITool.get")
+    def test_effort_and_yolo_prompted_when_supported(
+        self,
+        mock_get_tool: MagicMock,
+        _mock_tool: MagicMock,
+        _mock_model: MagicMock,
+        mock_select: MagicMock,
+        mock_confirm: MagicMock,
+    ) -> None:
+        mock_caps = MagicMock()
+        mock_caps.supports_effort = True
+        mock_caps.supports_yolo = True
+        mock_get_tool.return_value.capabilities.return_value = mock_caps
+        mock_select.return_value = 2  # "medium" effort (index 2 = medium in [none, low, medium...])
+        mock_confirm.return_value = True  # yolo = True
+
+        tool, _model, effort, yolo = _prompt_ai_section(None, non_interactive=False)
+        assert tool == "claude"
+        assert effort is not None  # some effort selected
+        assert yolo is True
+
+    @patch("wade.ui.prompts.confirm")
+    @patch("wade.ui.prompts.select")
+    @patch("wade.services.init_service._prompt_default_model", return_value=None)
+    @patch("wade.services.init_service._select_ai_tool", return_value="claude")
+    @patch("wade.services.init_service.AbstractAITool.get")
+    def test_no_effort_or_yolo_when_unsupported(
+        self,
+        mock_get_tool: MagicMock,
+        _mock_tool: MagicMock,
+        _mock_model: MagicMock,
+        mock_select: MagicMock,
+        mock_confirm: MagicMock,
+    ) -> None:
+        mock_caps = MagicMock()
+        mock_caps.supports_effort = False
+        mock_caps.supports_yolo = False
+        mock_get_tool.return_value.capabilities.return_value = mock_caps
+
+        _prompt_ai_section(None, non_interactive=False)
+        mock_select.assert_not_called()
+        mock_confirm.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _prompt_model_mapping per-tier effort tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptModelMappingPerTierEffort:
+    @patch("wade.services.init_service.AbstractAITool.get")
+    @patch("wade.ui.prompts.select")
+    def test_effort_prompts_shown_when_tool_supports_effort(
+        self, mock_select: MagicMock, mock_get_tool: MagicMock
+    ) -> None:
+        mock_caps = MagicMock()
+        mock_caps.supports_effort = True
+        mock_get_tool.return_value.capabilities.return_value = mock_caps
+
+        mapping = ComplexityModelMapping(
+            easy="haiku", medium="haiku", complex="sonnet", very_complex="opus"
+        )
+        # Always return default index (accept current selection)
+        mock_select.side_effect = lambda title, items, default=0, **kw: default
+
+        result = _prompt_model_mapping("claude", mapping, non_interactive=False)
+
+        # 4 model selects + 4 effort selects = 8 calls
+        assert mock_select.call_count == 8
+        assert result.easy == "haiku"
+
+    @patch("wade.services.init_service.AbstractAITool.get")
+    @patch("wade.ui.prompts.select")
+    def test_no_effort_prompts_when_tool_does_not_support(
+        self, mock_select: MagicMock, mock_get_tool: MagicMock
+    ) -> None:
+        mock_caps = MagicMock()
+        mock_caps.supports_effort = False
+        mock_get_tool.return_value.capabilities.return_value = mock_caps
+
+        mapping = ComplexityModelMapping(
+            easy="haiku", medium="haiku", complex="sonnet", very_complex="opus"
+        )
+        mock_select.side_effect = lambda title, items, default=0, **kw: default
+
+        _prompt_model_mapping("claude", mapping, non_interactive=False)
+
+        # Only 4 model selects — no effort prompts
+        assert mock_select.call_count == 4
+
+    @patch("wade.services.init_service.AbstractAITool.get")
+    @patch("wade.ui.prompts.select")
+    def test_effort_value_stored_in_mapping(
+        self, mock_select: MagicMock, mock_get_tool: MagicMock
+    ) -> None:
+        mock_caps = MagicMock()
+        mock_caps.supports_effort = True
+        mock_get_tool.return_value.capabilities.return_value = mock_caps
+
+        mapping = ComplexityModelMapping(
+            easy="haiku", medium="haiku", complex="sonnet", very_complex="opus"
+        )
+
+        from wade.models.ai import EffortLevel
+
+        effort_values = [e.value for e in EffortLevel]
+        call_count = 0
+
+        def fake_select(title: str, items: list[str], default: int = 0, **kw: object) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0 and "Effort" in title:
+                # Return index 1 = first real effort level (e.g. "low")
+                return 1
+            return default
+
+        mock_select.side_effect = fake_select
+
+        result = _prompt_model_mapping("claude", mapping, non_interactive=False)
+        # At least one tier should have an effort set
+        tier_efforts = [
+            result.easy_effort,
+            result.medium_effort,
+            result.complex_effort,
+            result.very_complex_effort,
+        ]
+        assert any(e is not None for e in tier_efforts)
+        assert all(e in effort_values or e is None for e in tier_efforts)
+
+
+# ---------------------------------------------------------------------------
+# _show_init_summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestShowInitSummary:
+    def test_renders_without_error_minimal(self) -> None:
+        _show_init_summary(
+            provider_setup={"name": "github"},
+            project_settings={
+                "main_branch": "main",
+                "merge_strategy": "PR",
+                "branch_prefix": "feat",
+                "worktrees_dir": "../.worktrees",
+            },
+            selected_tool=None,
+            default_model=None,
+            default_effort=None,
+            default_yolo=None,
+            implementation_setup={},
+            command_overrides={},
+            hooks_setup={},
+            knowledge_setup={},
+        )
+
+    def test_renders_with_full_data(self) -> None:
+        mapping = ComplexityModelMapping(
+            easy="haiku",
+            medium="sonnet",
+            complex="sonnet",
+            very_complex="opus",
+            complex_effort="high",
+        )
+        _show_init_summary(
+            provider_setup={"name": "github"},
+            project_settings={
+                "main_branch": "main",
+                "merge_strategy": "direct",
+                "branch_prefix": "fix",
+                "worktrees_dir": "../trees",
+            },
+            selected_tool="claude",
+            default_model="claude-sonnet-4-6",
+            default_effort="medium",
+            default_yolo=True,
+            implementation_setup={"tool": "claude", "model_mapping": mapping},
+            command_overrides={
+                "plan": {"tool": "gemini", "model": "gemini-2.5-pro"},
+                "deps": {"mode": "headless"},
+                "review_plan": {"enabled": "true", "mode": "prompt"},
+            },
+            hooks_setup={
+                "post_worktree_create": "scripts/setup.sh",
+                "copy_to_worktree": [".env"],
+            },
+            knowledge_setup={"enabled": True, "path": "docs/KNOWLEDGE.md"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# _write_config default_yolo tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteConfigYolo:
+    def test_default_yolo_true_written_to_ai_section(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        _write_config(config_path, "claude", ComplexityModelMapping(), default_yolo=True)
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["yolo"] is True
+
+    def test_default_yolo_false_written_to_ai_section(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        _write_config(config_path, "claude", ComplexityModelMapping(), default_yolo=False)
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["yolo"] is False
+
+    def test_default_yolo_none_omitted_from_ai_section(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        _write_config(config_path, "claude", ComplexityModelMapping(), default_yolo=None)
+        config = yaml.safe_load(config_path.read_text())
+        assert "yolo" not in config["ai"]
+
+    def test_per_command_yolo_in_overrides(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        overrides = {"plan": {"tool": "claude", "yolo": "true"}, "deps": {}}
+        _write_config(config_path, "claude", ComplexityModelMapping(), command_overrides=overrides)
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["plan"]["yolo"] is True
+
+
+# ---------------------------------------------------------------------------
+# _patch_config default_yolo tests
+# ---------------------------------------------------------------------------
+
+
+class TestPatchConfigYolo:
+    def test_force_writes_yolo_true(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\nai:\n  default_tool: claude\n")
+        _patch_config(
+            config_path, "claude", ComplexityModelMapping(), default_yolo=True, force=True
+        )
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["yolo"] is True
+
+    def test_force_overwrites_existing_yolo(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\nai:\n  default_tool: claude\n  yolo: true\n")
+        _patch_config(
+            config_path, "claude", ComplexityModelMapping(), default_yolo=False, force=True
+        )
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["yolo"] is False
+
+    def test_no_force_preserves_existing_yolo(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\nai:\n  default_tool: claude\n  yolo: true\n")
+        _patch_config(
+            config_path, "claude", ComplexityModelMapping(), default_yolo=False, force=False
+        )
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["yolo"] is True  # preserved
+
+    def test_no_force_writes_yolo_when_absent(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\nai:\n  default_tool: claude\n")
+        _patch_config(
+            config_path, "claude", ComplexityModelMapping(), default_yolo=True, force=False
+        )
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["yolo"] is True


### PR DESCRIPTION
Closes #293

<!-- wade:plan:start -->

## Complexity
complex

## Context / Problem

The `wade init` interactive wizard (`src/wade/services/init_service.py`) has
grown organically and shows several rough edges:

1. **Inconsistent section order.** The current flow goes
   `Provider → Project → Worktree hooks → Project knowledge → AI → Implementation
   → Per-command overrides → Claude Code → Gemini → Shell → Completions`.
   AI-related sections are split across the start and end of the wizard, with
   unrelated sections (hooks, knowledge) wedged in the middle. Tool-specific
   settings (Claude Code, Gemini) appear at the very end despite being part of
   the AI configuration story.
2. **Inconsistent skippability.** Some prompts offer "Skip (use default)";
   others force a choice. Re-running `wade init` on an already-inited project
   makes the user re-answer everything from scratch — there is no pre-fill from
   the existing `.wade.yml`.
3. **No per-command effort or YOLO prompts.** `AICommandConfig` already supports
   `effort` and `yolo` fields (`src/wade/models/config.py:69`), and the
   resolution chain in `services/ai_resolution.py` already reads them, but the
   init wizard never asks for either. Users have to hand-edit `.wade.yml` to
   configure them.
4. **No per-complexity-tier effort.** During Implementation setup, the user
   picks a model per complexity tier (easy/medium/complex/very_complex) but
   cannot pick a matching effort level — even though pairing is the natural use
   case (e.g. `easy` → low effort, `very_complex` → xhigh effort).
5. **No final review before write.** The wizard writes config the moment the
   last prompt is answered. A typo or accidental selection can only be fixed by
   re-running `wade init` or hand-editing.

## Proposed Solution

A coherent rework of `wade init` that standardizes the flow, adds the missing
prompts, and gives the user a chance to review before writing. All changes live
in `init_service.py`, `models/config.py`, `config/migrations.py`, and tests.

### 1. Standardize section order

New order in `init_service.py::init()`:

```
Provider              (task system: GitHub / ClickUp)
Project               (main branch, worktrees dir, branch prefix, merge strategy)
AI                    (default tool, default model, default effort, default yolo)
Implementation        (per-tier model + per-tier effort)
Per-command overrides (plan, deps, implement, review_plan, review_implementation, review_batch)
Tool-specific         (Claude Code settings, Gemini experimental)  — only when relevant tool is in use
Worktree hooks        (post_worktree_create, copy_to_worktree)
Project knowledge     (KNOWLEDGE.md)
Shell integration
Shell completions
```

Rationale: Provider + Project are non-AI plumbing first. The AI block (default
+ per-tier + per-command + tool-specific tweaks) is contiguous. Worktree hooks
and Knowledge are repo-level concerns last. Shell/completions are
host-environment integrations at the very end.

### 2. Make every prompt skippable

Every `prompts.select(...)` call gains a uniform "Skip (use default)" option
(or similar), and every `prompts.input_prompt(...)` accepts an empty value to
mean "skip". Skipping a prompt:

- On a fresh init: leaves the field absent in `.wade.yml` (loader/defaults take
  over at runtime).
- On re-init: keeps the existing value in `.wade.yml` untouched.

Add a small helper in `init_service.py` (e.g. `_select_or_skip(label, options,
current=None) -> str | None`) so every section uses the same skip semantics.

### 3. Re-init pre-selection from `.wade.yml`

When `.wade.yml` exists at init time, parse it once at the top of `init()` and
thread the parsed values into every `_prompt_*` helper as the prompt default.
The user sees their current values pre-selected and can hit Enter to keep
them. Provider already has partial pre-selection
(`init_service.py:113-124`) — extend to every section.

### 4. Add YOLO prompt to AI section (global default)

In `_prompt_ai_section`, after the effort prompt, add a yes/no prompt for
`ai.yolo` ("Enable YOLO mode by default for every session?"). Only show when
the selected tool's `caps.supports_yolo` is true. Persist to
`ai.yolo: true|false` in the config. Default offered: current value if
present, else `false`.

### 5. Add YOLO + effort prompts to per-command overrides

In `_prompt_command_overrides`, after asking for tool/model for each command
(`plan`, `deps`, `implement`, `review_plan`, `review_implementation`,
`review_batch`), add:

- An effort prompt — only when the resolved tool's `caps.supports_effort` is
  true. Options come from the tool's supported `EffortLevel` set (Claude
  includes `xhigh`; Codex does not). Offer "Skip (use default)" → inherits
  global `ai.effort`.
- A YOLO prompt — only when the resolved tool's `caps.supports_yolo` is true.
  Yes/No/Skip. Skipping inherits global `ai.yolo`.

Persist to `ai.<cmd>.effort` and `ai.<cmd>.yolo`. `AICommandConfig` already has
both fields, so no schema change is needed for this part.

### 6. Per-complexity-tier effort selection

#### Schema

Extend `ComplexityModelMapping` in `models/config.py`. Two acceptable shapes
on disk; loader normalizes to the structured form:

```yaml
# Legacy (still accepted on read; auto-migrated on next write)
models:
  claude:
    easy: claude-haiku-4.5
    medium: claude-sonnet-4.6
    complex: claude-sonnet-4.6
    very_complex: claude-opus-4.7

# New canonical form
models:
  claude:
    easy:         { model: claude-haiku-4.5, effort: low }
    medium:       { model: claude-sonnet-4.6, effort: medium }
    complex:      { model: claude-sonnet-4.6, effort: high }
    very_complex: { model: claude-opus-4.7,   effort: xhigh }
```

Implement as a Pydantic field validator that accepts both `str` and
`{model, effort}` dict forms. Store internally as a small `TierConfig` object
per tier (or as a flat pair: `easy_model` / `easy_effort` etc. — pick the
cleaner option during implementation).

#### Migration

Add a new step in `src/wade/config/migrations.py` that upgrades any
string-valued tier into `{model: <str>, effort: null}`. Idempotent.
`run_all_migrations()` already wires migrations in sequence.

#### Resolution chain

Update `services/ai_resolution.py::resolve_effort()` (or add a per-tier-aware
sibling) to honor this priority:

```
1. CLI --effort flag                         (most specific)
2. ai.<command>.effort                       (per-command)
3. models.<tool>.<tier>.effort               (per-tier — NEW)
4. ai.effort                                 (global)
5. tool default                              (least specific)
```

`wade implement` already knows the complexity tier when launching, so it can
pass the tier into the resolver.

#### Wizard

In `_prompt_model_mapping`, after the user picks a model for each tier, ask
for an effort level for that tier. Capability-gated (only when
`caps.supports_effort`). Skippable.

### 7. End-of-wizard summary panel

Before the write phase (right before the `console.rule("Initing")` block at
`init_service.py:186`), render a summary panel listing every selected value
across all sections. Then prompt: "Write these values to `.wade.yml`?" with
Yes / Modify / Cancel. "Modify" jumps back into the wizard from the start
(simple loop; no granular jump-back required for v1). "Cancel" exits without
writing.

### 8. Persistence in `_write_config` and `_patch_config`

- New per-command fields: `ai.<cmd>.effort`, `ai.<cmd>.yolo` (already in
  `AICommandConfig` — just need write-side handling). The existing
  `valid_keys` set in `services/check_service.py:418` already includes both;
  no validator change required.
- New global field: `ai.yolo` (already in `AIConfig` and `check_service.py`).
- New per-tier shape: `models.<tool>.<tier>: {model, effort}`.
- Force-mode behavior: when `force=True` and the user explicitly chose
  "(none — use tool default)" for any field, clear it from the existing
  config (current pattern uses `""` sentinel for `default_effort` — keep it
  consistent).

## Tasks

- [ ] Reorder sections in `init_service.py::init()` to the standardized order
- [ ] Move `_prompt_claude_code_settings` and
      `_prompt_configure_gemini_experimental` calls to run right after
      per-command overrides
- [ ] Add `_select_or_skip` helper for uniform skip semantics
- [ ] Audit every `prompts.select` / `prompts.input_prompt` call in
      `init_service.py` and route through the helper
- [ ] Parse `.wade.yml` once at top of `init()` and thread current values into
      every `_prompt_*` helper as defaults
- [ ] Add global `ai.yolo` prompt at the end of `_prompt_ai_section`
- [ ] Add per-command `effort` prompt in `_prompt_command_overrides`
      (capability-gated)
- [ ] Add per-command `yolo` prompt in `_prompt_command_overrides`
      (capability-gated)
- [ ] Extend `ComplexityModelMapping` to accept both `str` and
      `{model, effort}` shapes (Pydantic validator)
- [ ] Add config migration: legacy string tier → `{model, effort: null}`
- [ ] Update `services/ai_resolution.py::resolve_effort` to consult the
      per-tier value
- [ ] Update `wade implement` callers to pass the tier into the resolver
- [ ] Add per-tier effort prompt to `_prompt_model_mapping`
- [ ] Add end-of-wizard summary panel + Yes/Modify/Cancel confirmation
- [ ] Update `_write_config` to write per-command `effort`, per-command `yolo`,
      global `ai.yolo`, and the new per-tier shape
- [ ] Update `_patch_config` to merge the same fields into existing configs
      (force-mode clears explicit "(none)" selections)
- [ ] Unit tests: prompt order, skip behavior, re-init pre-fill, summary panel
- [ ] Unit tests: per-command effort/yolo persistence
- [ ] Unit tests: per-tier schema parse (both shapes), migration round-trip,
      resolution chain priority
- [ ] Update relevant fixtures under `tests/unit/test_services/` and
      `tests/unit/test_config/`
- [ ] Run `./scripts/check-all.sh` and address findings
- [ ] Update `README.md` if user-facing wizard behavior is documented there
- [ ] Update `AGENTS.md` / `docs/dev/architecture.md` only if conventions
      changed (likely no change)

## Acceptance Criteria

- [ ] `wade init` on a fresh repo runs the new section order:
      Provider → Project → AI → Implementation → Per-command overrides →
      Tool-specific → Worktree hooks → Knowledge → Shell → Completions
- [ ] Every selectable prompt offers a "Skip (use default)" option; every
      input prompt accepts an empty value as skip
- [ ] Re-running `wade init` on an already-inited repo pre-selects the
      current values from `.wade.yml` for every prompt
- [ ] AI section asks for global YOLO default when the chosen tool supports
      it; persists to `ai.yolo`
- [ ] Per-command override section asks for per-command effort and per-command
      YOLO (when the tool supports each); persists to `ai.<cmd>.effort` and
      `ai.<cmd>.yolo`
- [ ] Implementation section asks for an effort level for each complexity tier
      (when the tool supports effort); persists to
      `models.<tool>.<tier>.effort`
- [ ] Existing string-valued `models.<tool>.<tier>` configs continue to load
      without breaking, and are upgraded to `{model, effort}` form on the next
      `wade update` or `wade init`
- [ ] `resolve_effort` honors the priority chain
      `CLI → ai.<cmd>.effort → models.<tool>.<tier>.effort → ai.effort → tool
      default`
- [ ] End-of-wizard summary panel is shown before the write phase; Yes writes,
      Modify loops back to the first prompt, Cancel aborts without writing
- [ ] `./scripts/test.sh` passes
- [ ] `./scripts/check.sh` passes (lint + types)
- [ ] No regressions in non-interactive mode (`wade init --non-interactive`
      still produces a valid `.wade.yml`)

<!-- wade:plan:end -->

## Summary

## What was addressed

All 7 unresolved review comments across `.wade.yml` and `src/wade/services/init_service.py` were addressed.

## Changes

- **`.wade.yml` tier format** (copilot): Attempted update to structured `{model, effort}` form — then reverted because the installed `wade` binary uses the main checkout which lacks `_parse_tier_value`. The `migrate_string_tiers_to_tier_config` migration will auto-convert after the PR is merged. Thread resolved.

- **Renamed effort picker label** (copilot × 2): Renamed `"(none — use tool default)"` to `"Skip (inherit defaults)"` for both per-tier (`_prompt_model_mapping`) and per-command (`_ask_effort_and_yolo`) effort pickers. Omitting the override inherits `ai.effort`, not the tool's hardcoded default.

- **Per-command effort/YOLO with inherited tool** (CodeRabbit major): Fixed `_ask_effort_and_yolo` to be invoked with `effective_tool = tool_for_cmd[cmd_idx] or default_tool`, so commands that inherit `default_tool` can now configure per-command `effort`/`yolo` overrides. Tests updated to reflect the new prompt sequence.

- **parse_failed flag for corrupted config** (CodeRabbit major): Added `parse_failed` flag. When `.wade.yml` exists but fails to parse, the wizard now prompts before overwriting with `_write_config()` rather than silently calling `_patch_config()` which returns early without writing.

- **ClickUp provider re-init pre-fill** (CodeRabbit major): Added `current_api_token_env` and `current_settings` params to `_prompt_provider_setup()`. ClickUp-specific fields (`api_token_env`, `team_id`, `list_id`, `space_id`) are now pre-filled on re-init instead of forcing users to re-enter them.

- **Stale model mapping when tool changes** (CodeRabbit major): Added `current_effective_tool` param to `_prompt_implementation_setup()`. The cached `current_model_mapping` is discarded when the effective tool changes between Modify passes, preventing stale Claude mappings from being reused under Gemini/Copilot.

## Remaining

None — all 7 threads resolved.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **117,600** |
| Input tokens | **16,500** |
| Output tokens | **101,100** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Init wizard can re-run, shows configuration summary before writing.
  * Per-complexity-tier effort settings and per-command YOLO/effort overrides.

* **Configuration Updates**
  * AI model defaults updated (Claude Sonnet/Opus family) and structured per-tier model+effort format.
  * New interactive batch review pipeline and explicit knowledge file path; knowledge files copied into worktrees.

* **Migrations & Tests**
  * Migration to normalize legacy tier strings to structured tier objects; added unit and integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **69,374** |
| Input tokens | **874** |
| Output tokens | **68,500** |

### Session 2

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **46,320** |
| Input tokens | **920** |
| Output tokens | **45,400** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `9d96bebb-5fc0-4239-b4a8-6b7648ac0181` |
| Review | `claude` | `c7221daf-b86b-4757-aeaa-4add336c8f29` |
| Review | `claude` | `c05f4fd9-0bd8-46b5-a8f8-9ce3cdf9e600` |

<!-- wade:sessions:end -->
