### PR TITLE
fix: ensure_label produces spurious subprocess.failed error when label exists

### DIFF
--- a/.wade.yml
+++ b/.wade.yml
@@ -13,27 +13,39 @@ ai:
     tool: claude
     model: claude-opus-4.7
   deps:
-    tool: gemini
-    model: gemini-3-pro-preview
+    tool: copilot
+    model: claude-sonnet-4.6
     mode: headless
   review_plan:
-    mode: prompt
+    tool: copilot
+    model: claude-sonnet-4.6
+    mode: headless
     enabled: true
   review_implementation:
-    mode: prompt
+    tool: copilot
+    model: claude-sonnet-4.6
+    mode: headless
+    enabled: true
+  review_batch:
+    tool: copilot
+    model: claude-sonnet-4.6
+    mode: interactive
     enabled: true
 models:
   claude:
-    easy: claude-haiku-4.5
+    easy: claude-sonnet-4.6
     medium: claude-sonnet-4.6
-    complex: claude-sonnet-4.6
+    complex: claude-opus-4.7
     very_complex: claude-opus-4.7
 provider:
   name: github
 knowledge:
   enabled: true
+  path: KNOWLEDGE.md
 hooks:
   post_worktree_create: scripts/setup-worktree.sh
   copy_to_worktree:
   - .env
   - .wade.yml
+  - KNOWLEDGE.md
+  - KNOWLEDGE.ratings.yml

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -78,3 +78,9 @@ When writing instructions for AI tools, "ask the user X" is not sufficient to pr
 When editing agent session rules, check BOTH templates/skills/<name>/SKILL.md AND templates/prompts/<name>.md — skills are symlinked into .claude/skills/ while prompts are read directly by service code. Changes to one without the other can leave contradictory instructions.
 
 ---
+
+## 6264c1a6 | 2026-04-27 | plan | tags: github, gh-cli, labels
+
+`gh label list --search <name>` is unreliable for label-existence checks — it returns empty for label names that exist (verified for `bug`, `complexity:medium`, `review-addressed-by:claude`). Use `gh api repos/{slug}/labels/{url-encoded-name}` with `check=False` instead; it returns 200 if the label exists and 404 if not.
+
+---

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -1,0 +1,18 @@
+164c355e:
+  down: 0
+  up: 1
+3463fbd4:
+  down: 0
+  up: 1
+b61e247e:
+  down: 0
+  up: 2
+b6a3a637:
+  down: 0
+  up: 1
+cedeaad0:
+  down: 0
+  up: 1
+e2a49ac1:
+  down: 0
+  up: 2

--- a/src/wade/providers/github.py
+++ b/src/wade/providers/github.py
@@ -12,6 +12,7 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import structlog
 
@@ -89,6 +90,7 @@ class GitHubProvider(AbstractTaskProvider):
 
     def __init__(self, config: ProviderConfig | None = None) -> None:
         super().__init__(config)
+        self._repo_nwo: str | None = None
 
     def list_tasks(
         self,
@@ -284,21 +286,25 @@ class GitHubProvider(AbstractTaskProvider):
     def ensure_label(self, label: Label) -> None:
         """Ensure a label exists, creating it if needed.
 
-        1. Search for the label name
+        1. Probe existence via GitHub API (reliable, unlike gh label list --search)
         2. If not found, create it (handling "already exists" race condition)
         """
-        # Check if label already exists
-        try:
-            result = run(
-                ["gh", "label", "list", "--search", label.name, "--json", "name", "-q", ".[].name"],
-                check=True,
-                retries=3,
+        nwo = self.get_repo_nwo()
+        encoded_name = quote(label.name, safe="")
+        probe = run(
+            ["gh", "api", f"repos/{nwo}/labels/{encoded_name}"],
+            check=False,
+        )
+        if probe.returncode == 0:
+            return  # Label already exists
+        stderr_lower = (probe.stderr or "").lower()
+        if "not found" not in stderr_lower and "404" not in stderr_lower:
+            logger.warning(
+                "github.label_probe_failed",
+                name=label.name,
+                returncode=probe.returncode,
+                stderr=probe.stderr,
             )
-            existing = result.stdout.strip().splitlines()
-            if label.name in existing:
-                return
-        except CommandError:
-            pass  # Search failed — try creating anyway
 
         # Create the label
         cmd = [
@@ -796,12 +802,14 @@ query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
 
     def get_repo_nwo(self) -> str:
         """Get the repo name-with-owner via gh repo view."""
-        result = run(
-            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-            check=True,
-            retries=3,
-        )
-        return result.stdout.strip()
+        if self._repo_nwo is None:
+            result = run(
+                ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+                check=True,
+                retries=3,
+            )
+            self._repo_nwo = result.stdout.strip()
+        return self._repo_nwo
 
     # --- Parent issue detection ---
 

--- a/tests/unit/test_providers/test_github.py
+++ b/tests/unit/test_providers/test_github.py
@@ -413,6 +413,26 @@ class TestEnsureLabel:
         probe_cmd = mock_run.call_args[0][0]
         assert probe_cmd == ["gh", "api", "repos/owner/repo/labels/review-addressed-by%3Aclaude"]
 
+    @patch("wade.providers.github.run")
+    def test_probe_unexpected_error_falls_through_to_create(
+        self, mock_run: MagicMock, provider: GitHubProvider
+    ) -> None:
+        """Non-404 probe failure (e.g. auth error) still attempts creation."""
+        provider._repo_nwo = "owner/repo"
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="authentication required"
+            ),
+            _make_completed(""),
+        ]
+
+        label = Label(name="new-label", color="FBCA04")
+        provider.ensure_label(label)
+
+        assert mock_run.call_count == 2
+        create_cmd = mock_run.call_args_list[1][0][0]
+        assert "create" in create_cmd
+
 
 class TestAddLabel:
     @patch("wade.providers.github.run")

--- a/tests/unit/test_providers/test_github.py
+++ b/tests/unit/test_providers/test_github.py
@@ -354,19 +354,24 @@ class TestCommentOnTask:
 class TestEnsureLabel:
     @patch("wade.providers.github.run")
     def test_label_already_exists(self, mock_run: MagicMock, provider: GitHubProvider) -> None:
-        mock_run.return_value = _make_completed("feature-plan\n")
+        provider._repo_nwo = "owner/repo"
+        # Probe returns 0 — label exists
+        mock_run.return_value = _make_completed("", returncode=0)
 
         label = Label(name="feature-plan", color="0E8A16", description="Plan issue")
         provider.ensure_label(label)
 
-        # Should only call list, not create
+        # Only the gh api probe — no create call
         assert mock_run.call_count == 1
+        probe_cmd = mock_run.call_args[0][0]
+        assert probe_cmd == ["gh", "api", "repos/owner/repo/labels/feature-plan"]
 
     @patch("wade.providers.github.run")
     def test_label_created(self, mock_run: MagicMock, provider: GitHubProvider) -> None:
-        # First call: list (no match), second call: create
+        provider._repo_nwo = "owner/repo"
+        # First call: probe returns 404 (not found), second call: create succeeds
         mock_run.side_effect = [
-            _make_completed("other-label\n"),
+            subprocess.CompletedProcess(args=["gh"], returncode=1, stdout="", stderr="not found"),
             _make_completed(""),
         ]
 
@@ -374,6 +379,8 @@ class TestEnsureLabel:
         provider.ensure_label(label)
 
         assert mock_run.call_count == 2
+        probe_cmd = mock_run.call_args_list[0][0][0]
+        assert probe_cmd == ["gh", "api", "repos/owner/repo/labels/new-label"]
         create_cmd = mock_run.call_args_list[1][0][0]
         assert "create" in create_cmd
         assert "new-label" in create_cmd
@@ -382,14 +389,29 @@ class TestEnsureLabel:
     @patch("wade.providers.github.run")
     def test_label_race_condition(self, mock_run: MagicMock, provider: GitHubProvider) -> None:
         """Test that "already exists" error during creation is non-fatal."""
+        provider._repo_nwo = "owner/repo"
         mock_run.side_effect = [
-            _make_completed(""),  # list: empty
+            subprocess.CompletedProcess(args=["gh"], returncode=1, stdout="", stderr="not found"),
             CommandError(["gh"], 1, "label already exists"),
         ]
 
         label = Label(name="race-label", color="000000")
         # Should not raise
         provider.ensure_label(label)
+
+    @patch("wade.providers.github.run")
+    def test_label_name_with_colon_is_url_encoded(
+        self, mock_run: MagicMock, provider: GitHubProvider
+    ) -> None:
+        """Label names containing ':' must be percent-encoded in the API path."""
+        provider._repo_nwo = "owner/repo"
+        mock_run.return_value = _make_completed("", returncode=0)
+
+        label = Label(name="review-addressed-by:claude", color="0075ca")
+        provider.ensure_label(label)
+
+        probe_cmd = mock_run.call_args[0][0]
+        assert probe_cmd == ["gh", "api", "repos/owner/repo/labels/review-addressed-by%3Aclaude"]
 
 
 class TestAddLabel:


### PR DESCRIPTION
Closes #298

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

After every `wade review` (and any flow that applies labels), a noisy ERROR
log appears:

```
[error] subprocess.failed [wade.utils.process]
  command=['gh', 'label', 'create', 'review-addressed-by:claude', ...]
  returncode=1
  stderr='label with name "review-addressed-by:claude" already exists; use `--force` to update its color and description'
```

The user-visible flow is unaffected — `ensure_label` in
`src/wade/providers/github.py` swallows the `CommandError` when the message
contains "already exists" — but the ERROR-level log is misleading and
suggests something is broken.

Root cause: `ensure_label` pre-checks existence with
`gh label list --search <name>`, but the `--search` flag is unreliable.
Verified locally:

- `gh label list --search "review-addressed-by:claude"` → empty
- `gh label list --search "complexity:medium"` → empty
- `gh label list --search "bug"` → empty

…even though all three labels exist in the repo. When the pre-check returns
empty, wade falls through to `gh label create`, which fails with
"already exists". `run()` in `src/wade/utils/process.py` logs
`subprocess.failed` at ERROR before raising the `CommandError` that
`ensure_label` then swallows.

This affects every label-applying operation
(`add_planned_by_labels`, `add_implemented_by_labels`,
`add_review_addressed_by_labels`, complexity labels, etc.), and produces
log noise on essentially every wade run.

## Proposed Solution

Replace the unreliable `gh label list --search <name>` pre-check with a
direct existence check via the GitHub API:

```
gh api repos/{owner}/{repo}/labels/{url-encoded-name}
```

This returns 200 if the label exists, 404 if not. Implementation notes:

- Call `run()` with `check=False` so a 404 returns a non-zero `returncode`
  without going through the ERROR-logging branch in `process.py`. Do **not**
  pass `retries=...` here — retries are gated on `check=True` and would be
  dead code that confuses intent.
- URL-encode the label name when building the path. Label names can include
  characters that are special in URL paths — most importantly the colon used
  in `review-addressed-by:claude`, `complexity:medium`, etc. Use
  `urllib.parse.quote(label.name, safe="")`.
- A non-zero return code from the probe should be treated as "label not
  found, proceed to create" only when stderr clearly indicates 404 / Not
  Found. For other failures (auth errors, network, etc.), log a warning
  and still fall through to create — that preserves current behavior
  (create may still succeed) without burying real problems.
- Reuse the existing `get_repo_nwo()` helper (line 797 of
  `src/wade/providers/github.py`). Add a `_repo_nwo: str | None = None`
  cache field on the provider instance (initialised in `__init__`) and
  return the cached value on subsequent calls. `ensure_label` is invoked
  many times per session; one `gh repo view` per process is plenty.
- Keep the existing "already exists" race-condition swallow on the create
  path — concurrent processes may still both reach create.

No changes to `run()` / `process.py` are needed.

## Tasks
- [ ] Add `_repo_nwo: str | None = None` to `GitHubProvider.__init__`
  and update `get_repo_nwo()` to populate / return the cache
- [ ] Rewrite the pre-check block in `ensure_label`
  (`src/wade/providers/github.py`) to call
  `gh api repos/{slug}/labels/{urllib.parse.quote(name, safe="")}`
  with `check=False` and **no** `retries` argument
- [ ] Treat probe `returncode == 0` as "exists, return early";
  treat non-zero with "not found" / "404" in stderr as "proceed to
  create"; for any other non-zero, emit a `logger.warning` and still
  fall through to create
- [ ] Keep the `gh label create` block and the existing "already exists"
  swallow on the create path as-is
- [ ] Update the three existing tests in
  `tests/unit/test_providers/test_github.py`
  (`test_label_already_exists`, `test_label_created`,
  `test_label_race_condition`) to reflect the new call sequence — the
  cleanest approach is to set `provider._repo_nwo = "owner/repo"` in the
  test (or a fixture) so the probe is the only mocked call, then assert on
  the `gh api` invocation in the "exists" path and on `gh api` + `gh label
  create` in the create / race paths
- [ ] Add a new test for the URL-encoded path: ensure a label name
  containing `:` produces an API path with `%3A` (or whatever
  `urllib.parse.quote` produces)
- [ ] One-time local smoke check: run a wade flow that hits
  `ensure_label` for an existing label and confirm no `subprocess.failed`
  ERROR log appears (no permanent automation needed)
- [ ] Run `./scripts/check-all.sh` and ensure it passes

## Acceptance Criteria
- [ ] Running `wade review pr-comments` (or any flow that applies labels) on
  a repo where the labels already exist produces no `subprocess.failed`
  ERROR log line
- [ ] Creating a label that does not yet exist still works end-to-end
- [ ] Concurrent label creation race is still handled gracefully (the
  "already exists" swallow on create remains)
- [ ] Label names containing `:` are correctly URL-encoded in the probe
  path (covered by a new unit test)
- [ ] `./scripts/test.sh` and `./scripts/check.sh` both pass

<!-- wade:plan:end -->

## Summary

## What was done

Eliminated the spurious `subprocess.failed` ERROR log that appeared after every
`wade review` (and any flow that applies labels). The root cause was that
`gh label list --search <name>` silently returns empty results for labels that
already exist, causing `ensure_label` to always fall through to `gh label create`,
which then fails with "already exists". The `run()` call logs `subprocess.failed`
at ERROR before raising the `CommandError` that `ensure_label` swallowed.

## Changes

- Replaced the unreliable `gh label list --search` pre-check with a direct
  GitHub API probe: `gh api repos/{nwo}/labels/{url-encoded-name}` with
  `check=False` — returns 200 if the label exists, 404 if not, with no
  ERROR-level logging on 404.
- Added `urllib.parse.quote(name, safe="")` encoding so label names with `:`
  (e.g. `review-addressed-by:claude`, `complexity:medium`) are correctly
  percent-encoded in the API path.
- Added `_repo_nwo` instance cache on `GitHubProvider` so `get_repo_nwo()` only
  invokes `gh repo view` once per process, not once per `ensure_label` call.
- Kept the existing "already exists" race-condition swallow on the create path.
- Non-404 probe failures (auth error, network, etc.) emit a `logger.warning` and
  still fall through to create, preserving current behaviour.

## Testing

- Updated all three existing `TestEnsureLabel` tests to reflect the new call
  sequence (pre-seeding `provider._repo_nwo` so `get_repo_nwo()` needs no mock).
- Added `test_label_name_with_colon_is_url_encoded`: asserts `review-addressed-by:claude`
  produces `review-addressed-by%3Aclaude` in the API path.
- Added `test_probe_unexpected_error_falls_through_to_create`: verifies that a
  non-404 probe failure still attempts creation.
- All 2370 tests pass; ruff and mypy are clean.

## Notes for reviewers

The `.wade.yml` changes visible in the diff are pre-existing branch scaffolding
from `wade implement` and are unrelated to this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub label operations by updating the label existence check mechanism. The system now uses a more reliable approach that correctly handles special characters (such as `:`) in label names, ensuring accurate label detection and creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | **16,888** |
| Input tokens | **688** |
| Output tokens | **16,200** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `b354b5ff-cf18-4027-9cf4-d02ef009f61a` |

<!-- wade:sessions:end -->
