### PR TITLE
feat: add Markdown file-backed task provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ CLI modules are thin dispatch — they parse flags via Typer, then call service 
 ### Key Design Patterns
 
 - **AI Tool Self-Registration**: `AbstractAITool.__init_subclass__` auto-registers adapters. Adding a new AI tool = one file, one class.
-- **Provider Abstraction**: `AbstractTaskProvider` ABC with pluggable backends (GitHub via `gh` CLI, ClickUp via REST API).
+- **Provider Abstraction**: `AbstractTaskProvider` ABC with pluggable backends (GitHub via `gh` CLI, ClickUp via REST API, Markdown via a single central file). Non-GitHub providers compose `GitHubPRDelegateMixin` so PR-review APIs still flow through `gh`.
 - **Prompts as .md Templates**: All AI prompts live in `templates/prompts/`, not inline strings.
 - **Synchronous Only**: No asyncio. Process-level parallelism via multiple terminals.
 - **Pydantic Everywhere**: All data structures are Pydantic `BaseModel` subclasses, not dicts.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,55 @@ Most workflow commands accept `--ai <tool>`, `--model <model>`, `--effort <level
 | [VS Code](https://github.com/features/copilot/ai-code-editor) | `code` |
 | [Antigravity](https://antigravity.google/) | `antigravity` |
 
+## Task Providers
+
+WADE can pull tasks from three backends — pick one when you run `wade init`:
+
+| Provider | Where issues live | Auth |
+|----------|-------------------|------|
+| `github` *(default)* | GitHub Issues | `gh` CLI |
+| `clickup` | ClickUp list | API token in env var |
+| `markdown` | A single committed `ISSUES.md` | None |
+
+PRs always flow through GitHub regardless of choice — `wade fetch-reviews`,
+the auto-poll loop, and review-thread resolution work identically across
+providers.
+
+### Markdown provider
+
+Useful when you want issues versioned alongside the code, with no external
+service. Each issue is one `## ` heading in the file:
+
+```markdown
+# Wade Issues
+
+## #47239185 Add login feature
+
+<!-- wade
+state: open
+labels: feature, complexity:medium
+-->
+
+Description body here. Sub-headings, code blocks, anything markdown.
+```
+
+- The file is resolved against the **main worktree**, so every linked
+  worktree reads/writes the same physical file. No textual merge conflicts
+  on `ISSUES.md`.
+- IDs are random 8-digit decimal so two parallel `wade implement` sessions
+  in different worktrees can't collide. They stay numeric so existing
+  `#NN` checklist refs in tracking-issue bodies still work.
+- Configure via `.wade.yml`:
+  ```yaml
+  provider:
+    name: markdown
+    settings:
+      path: ISSUES.md   # relative to repo root, or absolute
+  ```
+- After a PR merges, `provider.close_task` flips the section's `state` to
+  `closed` in `ISSUES.md`. Commit that change manually (or wire up an
+  `auto_commit` follow-up).
+
 ## Agent Skills
 
 `wade init` installs Skills that teach your AI agent the workflow — issue format, planning rules, implementation session rules, and dependency analysis. Skills, the `AGENTS.md` workflow pointer, and any tool-specific configuration are set up automatically for every supported tool. Nothing to configure manually.

--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ Description body here. Sub-headings, code blocks, anything markdown.
       path: ISSUES.md   # relative to repo root, or absolute
   ```
 - After a PR merges, `provider.close_task` flips the section's `state` to
-  `closed` in `ISSUES.md`. Commit that change manually (or wire up an
-  `auto_commit` follow-up).
+  `closed` in `ISSUES.md`. The file is left modified in your working tree —
+  commit it yourself, or add a hook to do it for you. (Auto-commit isn't
+  built in today.)
 
 ## Agent Skills
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,19 @@ Description body here. Sub-headings, code blocks, anything markdown.
   provider:
     name: markdown
     settings:
-      path: ISSUES.md   # relative to repo root, or absolute
+      path: ISSUES.md      # relative to repo root, or absolute
+      auto_commit: false   # if true, close_task auto-commits the change
   ```
 
 - After a PR merges, `provider.close_task` flips the section's `state` to
-  `closed` in `ISSUES.md`. The file is left modified in your working tree —
-  commit it yourself, or add a hook to do it for you. (Auto-commit isn't
-  built in today.)
+  `closed` in `ISSUES.md`. By default the file is left modified in your
+  working tree — commit it yourself. Set `auto_commit: true` to have
+  wade commit the change with a `chore: close #N` message; failures
+  (not a git repo, hook rejection, signing required) are logged and
+  swallowed so the close itself never blocks.
+- Tracking issues with `- [ ] #N` checklist bodies work the same as with
+  GitHub Issues — markdown's `find_parent_issue` scans every section's
+  body for child refs.
 
 ## Agent Skills
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ providers.
 ### Markdown provider
 
 Useful when you want issues versioned alongside the code, with no external
-service. Each issue is one `## ` heading in the file:
+service. Each issue is one `##` heading in the file:
 
 ```markdown
 # Wade Issues
@@ -196,12 +196,14 @@ Description body here. Sub-headings, code blocks, anything markdown.
   in different worktrees can't collide. They stay numeric so existing
   `#NN` checklist refs in tracking-issue bodies still work.
 - Configure via `.wade.yml`:
+
   ```yaml
   provider:
     name: markdown
     settings:
       path: ISSUES.md   # relative to repo root, or absolute
   ```
+
 - After a PR merges, `provider.close_task` flips the section's `state` to
   `closed` in `ISSUES.md`. The file is left modified in your working tree —
   commit it yourself, or add a hook to do it for you. (Auto-commit isn't

--- a/src/wade/models/config.py
+++ b/src/wade/models/config.py
@@ -18,7 +18,7 @@ Matches the v2 .wade.yml format:
         easy: claude-haiku-4.5
         ...
     provider:
-      name: github
+      name: github   # or "clickup" or "markdown"
     permissions:
       allowed_commands:
         - "wade *"
@@ -42,6 +42,7 @@ class ProviderID(StrEnum):
 
     GITHUB = "github"
     CLICKUP = "clickup"
+    MARKDOWN = "markdown"
 
 
 class ComplexityModelMapping(BaseModel):

--- a/src/wade/models/review.py
+++ b/src/wade/models/review.py
@@ -43,6 +43,17 @@ class ReviewThread(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class PRComment(BaseModel):
+    """A PR-level issue comment (not a code-review thread comment).
+
+    Used by review-bot status detection. Providers that surface PR comments
+    return these via :meth:`AbstractTaskProvider.get_pr_issue_comments`.
+    """
+
+    login: str
+    body: str
+
+
 class ReviewBotStatus(StrEnum):
     """Status of a review bot's review on a PR."""
 
@@ -66,7 +77,7 @@ RECENT_COMMIT_GRACE_SECONDS = 120
 
 
 def detect_coderabbit_review_status(
-    comments: list[dict[str, str]],
+    comments: list[PRComment],
 ) -> ReviewBotStatus | None:
     """Detect CodeRabbit review status from PR issue comments.
 
@@ -74,7 +85,7 @@ def detect_coderabbit_review_status(
     status markers embedded as HTML comments.
 
     Args:
-        comments: List of dicts with ``login`` and ``body`` keys.
+        comments: List of PR-level comments.
 
     Returns:
         A :class:`ReviewBotStatus` if CodeRabbit is mid-review, else ``None``.
@@ -82,8 +93,8 @@ def detect_coderabbit_review_status(
     # Find the latest CodeRabbit comment (last in the list = most recent)
     latest_body: str | None = None
     for c in reversed(comments):
-        if "coderabbit" in c.get("login", "").lower():
-            latest_body = c.get("body", "")
+        if "coderabbit" in c.login.lower():
+            latest_body = c.body
             break
 
     if latest_body is None:

--- a/src/wade/providers/__init__.py
+++ b/src/wade/providers/__init__.py
@@ -20,6 +20,17 @@ def _load_clickup():  # type: ignore[no-untyped-def]
 
 register_provider(ProviderID.CLICKUP, _load_clickup)
 
+
+# Markdown provider — lazy import so users who don't use it pay no cost
+# even on minimal installs.
+def _load_markdown():  # type: ignore[no-untyped-def]
+    from wade.providers.markdown import MarkdownIssueProvider
+
+    return MarkdownIssueProvider
+
+
+register_provider(ProviderID.MARKDOWN, _load_markdown)
+
 __all__ = [
     "AbstractTaskProvider",
     "get_provider",

--- a/src/wade/providers/_pr_delegate.py
+++ b/src/wade/providers/_pr_delegate.py
@@ -1,0 +1,65 @@
+"""Shared mixin: delegate PR-review APIs to a GitHub provider.
+
+Issue providers whose tasks live elsewhere (Markdown file, ClickUp, etc.)
+still flow PRs through GitHub. Without this mixin they would raise
+``NotImplementedError`` for review threads / PR comments and silently
+degrade ``wade fetch-reviews`` and the auto-poll loop. Composing the mixin
+makes those operations transparently delegate to a lazily-constructed
+:class:`wade.providers.github.GitHubProvider`.
+
+Usage::
+
+    class ClickUpProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
+        def __init__(self, config=None, github_provider=None):
+            super().__init__(config)
+            self._init_pr_delegate(github_provider)
+"""
+
+from __future__ import annotations
+
+from wade.models.review import PRReviewStatus, ReviewThread
+from wade.providers.base import AbstractTaskProvider
+
+
+class GitHubPRDelegateMixin:
+    """Forwards PR-review thread / comment / status APIs to a GitHubProvider.
+
+    Subclasses must call :meth:`_init_pr_delegate` (typically from their
+    ``__init__``) to wire up the inner provider — pass ``None`` for the
+    default lazy-constructed :class:`GitHubProvider`, or inject one for
+    tests.
+    """
+
+    _pr_github: AbstractTaskProvider | None = None
+
+    def _init_pr_delegate(
+        self,
+        github_provider: AbstractTaskProvider | None = None,
+    ) -> None:
+        """Wire the inner GitHub provider used for PR-review delegation."""
+        self._pr_github = github_provider
+
+    def _pr_gh(self) -> AbstractTaskProvider:
+        """Return the inner GitHub provider, constructing it on first use."""
+        if self._pr_github is None:
+            from wade.providers.github import GitHubProvider
+
+            self._pr_github = GitHubProvider()
+        return self._pr_github
+
+    # --- Delegated PR-review operations ---
+
+    def get_pr_review_threads(self, pr_number: int) -> list[ReviewThread]:
+        return self._pr_gh().get_pr_review_threads(pr_number)
+
+    def resolve_review_thread(self, thread_id: str) -> bool:
+        return self._pr_gh().resolve_review_thread(thread_id)
+
+    def get_pr_issue_comments(self, pr_number: int) -> list[dict[str, str]]:
+        return self._pr_gh().get_pr_issue_comments(pr_number)
+
+    def get_pr_review_status(self, pr_number: int) -> PRReviewStatus:
+        return self._pr_gh().get_pr_review_status(pr_number)
+
+    def get_repo_nwo(self) -> str:
+        return self._pr_gh().get_repo_nwo()

--- a/src/wade/providers/_pr_delegate.py
+++ b/src/wade/providers/_pr_delegate.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from wade.models.review import PRReviewStatus, ReviewThread
+from wade.models.review import PRComment, PRReviewStatus, ReviewThread
 
 if TYPE_CHECKING:
     from wade.providers.github import GitHubProvider
@@ -59,7 +59,7 @@ class GitHubPRDelegateMixin:
     def resolve_review_thread(self, thread_id: str) -> bool:
         return self._pr_gh().resolve_review_thread(thread_id)
 
-    def get_pr_issue_comments(self, pr_number: int) -> list[dict[str, str]]:
+    def get_pr_issue_comments(self, pr_number: int) -> list[PRComment]:
         return self._pr_gh().get_pr_issue_comments(pr_number)
 
     def get_pr_review_status(self, pr_number: int) -> PRReviewStatus:

--- a/src/wade/providers/_pr_delegate.py
+++ b/src/wade/providers/_pr_delegate.py
@@ -17,8 +17,12 @@ Usage::
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from wade.models.review import PRReviewStatus, ReviewThread
-from wade.providers.base import AbstractTaskProvider
+
+if TYPE_CHECKING:
+    from wade.providers.github import GitHubProvider
 
 
 class GitHubPRDelegateMixin:
@@ -30,21 +34,21 @@ class GitHubPRDelegateMixin:
     tests.
     """
 
-    _pr_github: AbstractTaskProvider | None = None
+    _pr_github: GitHubProvider | None = None
 
     def _init_pr_delegate(
         self,
-        github_provider: AbstractTaskProvider | None = None,
+        github_provider: GitHubProvider | None = None,
     ) -> None:
         """Wire the inner GitHub provider used for PR-review delegation."""
         self._pr_github = github_provider
 
-    def _pr_gh(self) -> AbstractTaskProvider:
+    def _pr_gh(self) -> GitHubProvider:
         """Return the inner GitHub provider, constructing it on first use."""
         if self._pr_github is None:
-            from wade.providers.github import GitHubProvider
+            from wade.providers.github import GitHubProvider as _GitHubProvider
 
-            self._pr_github = GitHubProvider()
+            self._pr_github = _GitHubProvider()
         return self._pr_github
 
     # --- Delegated PR-review operations ---

--- a/src/wade/providers/base.py
+++ b/src/wade/providers/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from wade.models.config import ProviderConfig
-from wade.models.review import PRReviewStatus, ReviewThread
+from wade.models.review import PRComment, PRReviewStatus, ReviewThread
 from wade.models.task import Label, Task, TaskState
 
 
@@ -122,8 +122,13 @@ class AbstractTaskProvider(ABC):
     def get_pr_issue_comments(
         self,
         pr_number: int,
-    ) -> list[dict[str, str]]:
-        """Fetch PR issue comments. Returns list of dicts with login/body keys."""
+    ) -> list[PRComment]:
+        """Fetch PR-level issue comments (not inline review comments).
+
+        Returns an empty list by default. Concrete providers override this
+        to surface PR comments — used downstream by review-bot status
+        detection (``detect_coderabbit_review_status``).
+        """
         return []
 
     def get_pr_review_status(

--- a/src/wade/providers/clickup.py
+++ b/src/wade/providers/clickup.py
@@ -20,6 +20,7 @@ from wade.models.task import (
     parse_complexity_from_body,
     parse_complexity_from_labels,
 )
+from wade.providers._pr_delegate import GitHubPRDelegateMixin
 from wade.providers.base import AbstractTaskProvider
 from wade.utils.http import APIError, HTTPClient
 
@@ -65,10 +66,18 @@ def _parse_clickup_task(raw: dict[str, Any]) -> Task:
     )
 
 
-class ClickUpProvider(AbstractTaskProvider):
-    """ClickUp tasks + tags via REST API v2."""
+class ClickUpProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
+    """ClickUp tasks + tags via REST API v2.
 
-    def __init__(self, config: ProviderConfig | None = None) -> None:
+    PRs continue to flow through GitHub, so PR-review thread / comment APIs
+    are delegated to an inner GitHubProvider via :class:`GitHubPRDelegateMixin`.
+    """
+
+    def __init__(
+        self,
+        config: ProviderConfig | None = None,
+        github_provider: AbstractTaskProvider | None = None,
+    ) -> None:
         super().__init__(config)
 
         token_env = self._config.api_token_env or "CLICKUP_API_TOKEN"
@@ -93,6 +102,7 @@ class ClickUpProvider(AbstractTaskProvider):
             },
         )
         self._space_id: str | None = None
+        self._init_pr_delegate(github_provider)
 
     # --- Issue CRUD ---
 

--- a/src/wade/providers/clickup.py
+++ b/src/wade/providers/clickup.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -23,6 +23,9 @@ from wade.models.task import (
 from wade.providers._pr_delegate import GitHubPRDelegateMixin
 from wade.providers.base import AbstractTaskProvider
 from wade.utils.http import APIError, HTTPClient
+
+if TYPE_CHECKING:
+    from wade.providers.github import GitHubProvider
 
 logger = structlog.get_logger()
 
@@ -76,7 +79,7 @@ class ClickUpProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
     def __init__(
         self,
         config: ProviderConfig | None = None,
-        github_provider: AbstractTaskProvider | None = None,
+        github_provider: GitHubProvider | None = None,
     ) -> None:
         super().__init__(config)
 

--- a/src/wade/providers/github.py
+++ b/src/wade/providers/github.py
@@ -19,6 +19,7 @@ import structlog
 from wade.models.config import ProviderConfig
 from wade.models.review import (
     PendingReviewer,
+    PRComment,
     PRReview,
     PRReviewStatus,
     ReviewBotStatus,
@@ -523,11 +524,8 @@ mutation($threadId: ID!) {
     def get_pr_issue_comments(
         self,
         pr_number: int,
-    ) -> list[dict[str, str]]:
-        """Fetch PR issue comments via gh API.
-
-        Returns list of dicts with ``login`` and ``body`` keys.
-        """
+    ) -> list[PRComment]:
+        """Fetch PR-level issue comments via the gh API."""
         try:
             nwo = self.get_repo_nwo()
         except CommandError:
@@ -546,7 +544,8 @@ mutation($threadId: ID!) {
                 check=True,
                 retries=3,
             )
-            return json.loads(result.stdout)  # type: ignore[no-any-return]
+            raw: list[dict[str, str]] = json.loads(result.stdout)
+            return [PRComment(login=c.get("login", ""), body=c.get("body", "")) for c in raw]
         except (CommandError, json.JSONDecodeError) as e:
             logger.warning(
                 "github.get_pr_issue_comments_failed",

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -3,7 +3,9 @@
 The provider treats one markdown file as the source of truth for issues.
 Each issue is a ``## #<id> <title>`` heading followed by an optional metadata
 HTML comment and a body. PRs continue to be managed by the regular GitHub
-flow (``git/pr.py``) — this provider only owns the issue lifecycle.
+flow (``git/pr.py``); PR-review thread / comment APIs are delegated to an
+internal :class:`GitHubProvider` so review automation works the same as it
+does for the GitHub Issues provider.
 
 File format::
 
@@ -39,6 +41,7 @@ from pathlib import Path
 import structlog
 
 from wade.models.config import ProviderConfig
+from wade.models.review import PRReviewStatus, ReviewThread
 from wade.models.task import (
     Label,
     Task,
@@ -225,10 +228,23 @@ class MarkdownIssueProvider(AbstractTaskProvider):
         self,
         config: ProviderConfig | None = None,
         project_root: Path | None = None,
+        github_provider: AbstractTaskProvider | None = None,
     ) -> None:
         super().__init__(config)
         self._project_root = project_root or Path.cwd()
         self._path = self._resolve_path()
+        # PRs are still managed via GitHub even when issues live in markdown,
+        # so delegate review-thread / PR-comment ops to a GitHubProvider.
+        # Lazily constructed on first use to avoid loading gh wiring when
+        # the user only ever lists/closes issues.
+        self._github: AbstractTaskProvider | None = github_provider
+
+    def _gh(self) -> AbstractTaskProvider:
+        if self._github is None:
+            from wade.providers.github import GitHubProvider
+
+            self._github = GitHubProvider()
+        return self._github
 
     # --- Path resolution ---
 
@@ -443,3 +459,24 @@ class MarkdownIssueProvider(AbstractTaskProvider):
             return True
         except TaskNotFoundError:
             return False
+
+    # --- PR review operations (delegated to GitHub) ---
+    #
+    # The markdown file lives in a GitHub repo and PRs continue to flow
+    # through `gh`, so review-thread and PR-comment APIs delegate to an
+    # internal GitHubProvider rather than raising NotImplementedError.
+
+    def get_pr_review_threads(self, pr_number: int) -> list[ReviewThread]:
+        return self._gh().get_pr_review_threads(pr_number)
+
+    def resolve_review_thread(self, thread_id: str) -> bool:
+        return self._gh().resolve_review_thread(thread_id)
+
+    def get_pr_issue_comments(self, pr_number: int) -> list[dict[str, str]]:
+        return self._gh().get_pr_issue_comments(pr_number)
+
+    def get_pr_review_status(self, pr_number: int) -> PRReviewStatus:
+        return self._gh().get_pr_review_status(pr_number)
+
+    def get_repo_nwo(self) -> str:
+        return self._gh().get_repo_nwo()

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -261,9 +261,11 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
               different branches can't produce ID collisions or merge
               conflicts on ``ISSUES.md``. Defaults to ``ISSUES.md``.
 
-    Task IDs are random 8-character hex strings (e.g. ``a3f2b8e1``)
-    rather than sequential integers, again to avoid collisions when
-    multiple worktrees create issues independently.
+    Task IDs are random 8-digit decimal strings (e.g. ``47239185``)
+    rather than sequential integers, to avoid collisions when multiple
+    worktrees create issues independently. They stay numeric (not hex)
+    so wade's existing ``#\\d+`` parsing — checklist refs, dependency
+    sections, branch names — keeps working unchanged.
     """
 
     def __init__(
@@ -335,16 +337,20 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         raise TaskNotFoundError(f"Task #{task_id} not found in {self._path}")
 
     def _generate_id(self, sections: list[_Section]) -> str:
-        """Generate a fresh random 8-hex-char ID, avoiding existing ones.
+        """Generate a fresh random 8-digit decimal ID, avoiding existing ones.
 
         Random IDs (vs. sequential integers) prevent collisions when
-        multiple worktrees create issues in parallel. With 4 random bytes
-        the ID space is ~4 billion; collisions inside a single project are
-        astronomically unlikely, but we retry on the off chance.
+        multiple worktrees create issues in parallel. We use decimal
+        rather than hex so wade's ``#\\d+`` parsing — checklist child
+        refs, dependency sections, ``int(issue_number)`` casts in the
+        merge flow — keeps working unchanged. The ID space is ~90M
+        (10^7 .. 10^8 - 1, always exactly 8 digits); collisions inside
+        a single project are astronomically unlikely, but we retry on
+        the off chance.
         """
         existing = {section.id for section in sections}
         for _ in range(50):
-            candidate = secrets.token_hex(4)
+            candidate = str(secrets.randbelow(9 * 10**7) + 10**7)
             if candidate not in existing:
                 return candidate
         raise RuntimeError("Could not generate a unique markdown task ID")

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import os
 import re
+import secrets
 import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -50,6 +51,7 @@ from wade.models.task import (
 )
 from wade.providers._pr_delegate import GitHubPRDelegateMixin
 from wade.providers.base import AbstractTaskProvider
+from wade.utils.process import run
 
 logger = structlog.get_logger()
 
@@ -207,6 +209,29 @@ def _section_to_task(section: _Section) -> Task:
     )
 
 
+def _resolve_main_worktree(start: Path) -> Path | None:
+    """Return the main worktree path for the git repo containing ``start``.
+
+    From a linked worktree, returns the primary checkout (so all worktrees
+    point to the same ``ISSUES.md``). From the main checkout, returns its
+    own root. Returns ``None`` if ``start`` isn't in a git repo (rare:
+    user is running wade outside a checkout) — callers fall back to
+    ``project_root``.
+    """
+    common = run(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=start,
+        check=False,
+    )
+    if common.returncode != 0:
+        return None
+    common_dir = Path(common.stdout.strip())
+    if not common_dir.is_absolute():
+        common_dir = (start / common_dir).resolve()
+    # The main worktree is the parent of the canonical .git directory.
+    return common_dir.parent
+
+
 def _atomic_write(path: Path, content: str) -> None:
     """Write ``content`` to ``path`` atomically (write tmp + rename)."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -229,9 +254,16 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
 
     Configuration (``provider.settings`` in ``.wade.yml``):
         path: Relative or absolute path to the markdown file.
-              Relative paths resolve against ``project_root`` (the directory
-              containing ``.wade.yml``) or CWD if no project root is set.
-              Defaults to ``ISSUES.md``.
+              Relative paths resolve against the **main worktree** (the
+              repo's primary checkout) — not whatever worktree wade was
+              invoked from. This gives every worktree a single source of
+              truth for issues, so parallel ``create_task`` calls from
+              different branches can't produce ID collisions or merge
+              conflicts on ``ISSUES.md``. Defaults to ``ISSUES.md``.
+
+    Task IDs are random 8-character hex strings (e.g. ``a3f2b8e1``)
+    rather than sequential integers, again to avoid collisions when
+    multiple worktrees create issues independently.
     """
 
     def __init__(
@@ -252,7 +284,8 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         candidate = Path(raw).expanduser()
         if candidate.is_absolute():
             return candidate
-        return (self._project_root / candidate).resolve()
+        anchor = _resolve_main_worktree(self._project_root) or self._project_root
+        return (anchor / candidate).resolve()
 
     # --- File I/O ---
 
@@ -301,14 +334,20 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
                 return section
         raise TaskNotFoundError(f"Task #{task_id} not found in {self._path}")
 
-    def _next_id(self, sections: list[_Section]) -> str:
-        existing = []
-        for section in sections:
-            try:
-                existing.append(int(section.id))
-            except ValueError:
-                continue
-        return str(max(existing) + 1) if existing else "1"
+    def _generate_id(self, sections: list[_Section]) -> str:
+        """Generate a fresh random 8-hex-char ID, avoiding existing ones.
+
+        Random IDs (vs. sequential integers) prevent collisions when
+        multiple worktrees create issues in parallel. With 4 random bytes
+        the ID space is ~4 billion; collisions inside a single project are
+        astronomically unlikely, but we retry on the off chance.
+        """
+        existing = {section.id for section in sections}
+        for _ in range(50):
+            candidate = secrets.token_hex(4)
+            if candidate not in existing:
+                return candidate
+        raise RuntimeError("Could not generate a unique markdown task ID")
 
     # --- Issue CRUD ---
 
@@ -350,7 +389,7 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
     ) -> Task:
         """Append a new task as a ``## `` section to the file."""
         prelude, sections = self._load_sections()
-        new_id = self._next_id(sections)
+        new_id = self._generate_id(sections)
         meta: dict[str, str] = {"state": TaskState.OPEN.value}
         if labels:
             meta["labels"] = _join_labels(labels)

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -41,7 +41,6 @@ from pathlib import Path
 import structlog
 
 from wade.models.config import ProviderConfig
-from wade.models.review import PRReviewStatus, ReviewThread
 from wade.models.task import (
     Label,
     Task,
@@ -49,6 +48,7 @@ from wade.models.task import (
     parse_complexity_from_body,
     parse_complexity_from_labels,
 )
+from wade.providers._pr_delegate import GitHubPRDelegateMixin
 from wade.providers.base import AbstractTaskProvider
 
 logger = structlog.get_logger()
@@ -214,7 +214,7 @@ def _atomic_write(path: Path, content: str) -> None:
         raise
 
 
-class MarkdownIssueProvider(AbstractTaskProvider):
+class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
     """Task provider backed by a single central markdown file.
 
     Configuration (``provider.settings`` in ``.wade.yml``):
@@ -233,18 +233,7 @@ class MarkdownIssueProvider(AbstractTaskProvider):
         super().__init__(config)
         self._project_root = project_root or Path.cwd()
         self._path = self._resolve_path()
-        # PRs are still managed via GitHub even when issues live in markdown,
-        # so delegate review-thread / PR-comment ops to a GitHubProvider.
-        # Lazily constructed on first use to avoid loading gh wiring when
-        # the user only ever lists/closes issues.
-        self._github: AbstractTaskProvider | None = github_provider
-
-    def _gh(self) -> AbstractTaskProvider:
-        if self._github is None:
-            from wade.providers.github import GitHubProvider
-
-            self._github = GitHubProvider()
-        return self._github
+        self._init_pr_delegate(github_provider)
 
     # --- Path resolution ---
 
@@ -460,23 +449,4 @@ class MarkdownIssueProvider(AbstractTaskProvider):
         except TaskNotFoundError:
             return False
 
-    # --- PR review operations (delegated to GitHub) ---
-    #
-    # The markdown file lives in a GitHub repo and PRs continue to flow
-    # through `gh`, so review-thread and PR-comment APIs delegate to an
-    # internal GitHubProvider rather than raising NotImplementedError.
-
-    def get_pr_review_threads(self, pr_number: int) -> list[ReviewThread]:
-        return self._gh().get_pr_review_threads(pr_number)
-
-    def resolve_review_thread(self, thread_id: str) -> bool:
-        return self._gh().resolve_review_thread(thread_id)
-
-    def get_pr_issue_comments(self, pr_number: int) -> list[dict[str, str]]:
-        return self._gh().get_pr_issue_comments(pr_number)
-
-    def get_pr_review_status(self, pr_number: int) -> PRReviewStatus:
-        return self._gh().get_pr_review_status(pr_number)
-
-    def get_repo_nwo(self) -> str:
-        return self._gh().get_repo_nwo()
+    # PR-review operations are inherited from GitHubPRDelegateMixin.

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -1,0 +1,445 @@
+"""Markdown provider — read/write tasks from a single central markdown file.
+
+The provider treats one markdown file as the source of truth for issues.
+Each issue is a ``## #<id> <title>`` heading followed by an optional metadata
+HTML comment and a body. PRs continue to be managed by the regular GitHub
+flow (``git/pr.py``) — this provider only owns the issue lifecycle.
+
+File format::
+
+    # Wade Issues
+
+    ## #1 Add login feature
+
+    <!-- wade
+    state: open
+    labels: feature, complexity:medium
+    -->
+
+    Body goes here. Sub-headings (### ...) are part of the body.
+
+    ## #2 Fix parser bug
+
+    <!-- wade
+    state: closed
+    -->
+
+    Another body.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import structlog
+
+from wade.models.config import ProviderConfig
+from wade.models.task import (
+    Label,
+    Task,
+    TaskState,
+    parse_complexity_from_body,
+    parse_complexity_from_labels,
+)
+from wade.providers.base import AbstractTaskProvider
+
+logger = structlog.get_logger()
+
+DEFAULT_FILE_NAME = "ISSUES.md"
+DEFAULT_FILE_HEADER = "# Wade Issues\n\n<!-- Managed by the Wade markdown issue provider. -->\n"
+
+# Heading like "## #42 Title", "## #42: Title", or "## #42 - Title".
+# Em (U+2014) and en (U+2013) dashes are accepted via explicit escapes.
+_HEADING_RE = re.compile(
+    "^##\\s+#(?P<id>[A-Za-z0-9_-]+)\\s*(?:[:\\-–—]\\s*)?(?P<title>.*?)\\s*$",  # noqa: RUF001
+    re.MULTILINE,
+)
+
+# Metadata HTML comment block: <!-- wade ... -->
+_META_RE = re.compile(r"<!--\s*wade\s*\n(?P<body>.*?)\n\s*-->", re.DOTALL)
+
+_VALID_STATES = frozenset(s.value for s in TaskState)
+
+
+class MarkdownProviderError(Exception):
+    """Errors raised by MarkdownIssueProvider for non-recoverable conditions."""
+
+
+class TaskNotFoundError(MarkdownProviderError):
+    """Raised when a task ID does not exist in the markdown file."""
+
+
+@dataclass
+class _Section:
+    """A parsed issue section from the markdown file.
+
+    ``meta`` and ``body`` are kept separate so we can rewrite metadata
+    without touching the user-authored body.
+    """
+
+    id: str
+    title: str
+    meta: dict[str, str]
+    body: str
+    # Raw spans (start, end) into the source text, for in-place rewrites.
+    span: tuple[int, int]
+
+
+def _parse_meta_block(text: str) -> dict[str, str]:
+    """Parse ``key: value`` lines from a wade metadata block."""
+    meta: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        meta[key.strip().lower()] = value.strip()
+    return meta
+
+
+def _format_meta_block(meta: dict[str, str]) -> str:
+    """Format a metadata dict as a ``<!-- wade ... -->`` HTML comment."""
+    lines = ["<!-- wade"]
+    for key in ("state", "labels"):
+        value = meta.get(key, "")
+        # Always emit ``state`` (default "open"); only emit ``labels`` if non-empty.
+        if key == "state":
+            lines.append(f"state: {value or TaskState.OPEN.value}")
+        elif value:
+            lines.append(f"labels: {value}")
+    lines.append("-->")
+    return "\n".join(lines)
+
+
+def _split_labels(value: str) -> list[str]:
+    """Split a comma-separated labels string into a clean list."""
+    return [name.strip() for name in value.split(",") if name.strip()]
+
+
+def _join_labels(names: list[str]) -> str:
+    """Join label names into a comma-separated string."""
+    return ", ".join(name for name in names if name)
+
+
+def _parse_sections(text: str) -> list[_Section]:
+    """Split a markdown file into issue sections.
+
+    Returns sections in document order. Anything before the first ``## ``
+    heading is preserved in the file as a prelude (handled by the writer).
+    """
+    headings = list(_HEADING_RE.finditer(text))
+    if not headings:
+        return []
+
+    sections: list[_Section] = []
+    for i, match in enumerate(headings):
+        start = match.start()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
+        chunk = text[start:end]
+
+        # Body is everything after the heading line.
+        after_heading = chunk[match.end() - start :].lstrip("\n")
+
+        meta_match = _META_RE.match(after_heading)
+        if meta_match:
+            meta = _parse_meta_block(meta_match.group("body"))
+            body = after_heading[meta_match.end() :].lstrip("\n").rstrip()
+        else:
+            meta = {}
+            body = after_heading.rstrip()
+
+        sections.append(
+            _Section(
+                id=match.group("id"),
+                title=match.group("title").strip(),
+                meta=meta,
+                body=body,
+                span=(start, end),
+            )
+        )
+    return sections
+
+
+def _format_section(section: _Section) -> str:
+    """Format a parsed section back to canonical markdown."""
+    parts = [f"## #{section.id} {section.title}".rstrip(), ""]
+    parts.append(_format_meta_block(section.meta))
+    if section.body:
+        parts.extend(["", section.body.rstrip()])
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _section_to_task(section: _Section) -> Task:
+    """Convert a parsed _Section to a Task model."""
+    state_str = (section.meta.get("state") or "open").lower()
+    state = TaskState(state_str) if state_str in _VALID_STATES else TaskState.OPEN
+
+    label_names = _split_labels(section.meta.get("labels", ""))
+    labels = [Label(name=name) for name in label_names]
+
+    return Task(
+        id=section.id,
+        title=section.title,
+        body=section.body,
+        state=state,
+        complexity=parse_complexity_from_labels(labels) or parse_complexity_from_body(section.body),
+        labels=labels,
+        url=None,
+    )
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically (write tmp + rename)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_name, path)
+    except Exception:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
+
+
+class MarkdownIssueProvider(AbstractTaskProvider):
+    """Task provider backed by a single central markdown file.
+
+    Configuration (``provider.settings`` in ``.wade.yml``):
+        path: Relative or absolute path to the markdown file.
+              Relative paths resolve against ``project_root`` (the directory
+              containing ``.wade.yml``) or CWD if no project root is set.
+              Defaults to ``ISSUES.md``.
+    """
+
+    def __init__(
+        self,
+        config: ProviderConfig | None = None,
+        project_root: Path | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._project_root = project_root or Path.cwd()
+        self._path = self._resolve_path()
+
+    # --- Path resolution ---
+
+    def _resolve_path(self) -> Path:
+        raw = self._config.settings.get("path", DEFAULT_FILE_NAME)
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        return (self._project_root / candidate).resolve()
+
+    # --- File I/O ---
+
+    def _read_text(self) -> str:
+        if not self._path.exists():
+            return ""
+        return self._path.read_text(encoding="utf-8")
+
+    def _write_text(self, content: str) -> None:
+        if not content.endswith("\n"):
+            content += "\n"
+        _atomic_write(self._path, content)
+
+    def _load_sections(self) -> tuple[str, list[_Section]]:
+        """Return (prelude, sections) where prelude is everything before
+        the first ``## `` heading.
+        """
+        text = self._read_text()
+        sections = _parse_sections(text)
+        prelude = text[: sections[0].span[0]] if sections else text
+        return prelude, sections
+
+    def _persist(self, prelude: str, sections: list[_Section]) -> None:
+        """Reassemble the file from prelude + sections and write atomically."""
+        if not prelude and not sections:
+            self._write_text(DEFAULT_FILE_HEADER)
+            return
+
+        body_parts: list[str] = []
+        if prelude.strip():
+            body_parts.append(prelude.rstrip() + "\n")
+        elif sections:
+            # Ensure file always has at least the default header.
+            body_parts.append(DEFAULT_FILE_HEADER.rstrip() + "\n")
+
+        for section in sections:
+            body_parts.append("\n" + _format_section(section))
+
+        self._write_text("".join(body_parts))
+
+    # --- Section helpers ---
+
+    def _find_section(self, sections: list[_Section], task_id: str) -> _Section:
+        for section in sections:
+            if section.id == task_id:
+                return section
+        raise TaskNotFoundError(f"Task #{task_id} not found in {self._path}")
+
+    def _next_id(self, sections: list[_Section]) -> str:
+        existing = []
+        for section in sections:
+            try:
+                existing.append(int(section.id))
+            except ValueError:
+                continue
+        return str(max(existing) + 1) if existing else "1"
+
+    # --- Issue CRUD ---
+
+    def list_tasks(
+        self,
+        label: str | None = None,
+        state: TaskState | None = TaskState.OPEN,
+        limit: int = 50,
+        exclude_labels: list[str] | None = None,
+    ) -> list[Task]:
+        """List tasks from the markdown file with optional filtering."""
+        _, sections = self._load_sections()
+        tasks: list[Task] = []
+        exclude_set = set(exclude_labels or [])
+
+        for section in sections:
+            task = _section_to_task(section)
+
+            if state is not None and task.state != state:
+                continue
+
+            label_names = {lbl.name for lbl in task.labels}
+            if label and label not in label_names:
+                continue
+            if exclude_set and label_names & exclude_set:
+                continue
+
+            tasks.append(task)
+            if len(tasks) >= limit:
+                break
+
+        return tasks
+
+    def create_task(
+        self,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+    ) -> Task:
+        """Append a new task as a ``## `` section to the file."""
+        prelude, sections = self._load_sections()
+        new_id = self._next_id(sections)
+        meta: dict[str, str] = {"state": TaskState.OPEN.value}
+        if labels:
+            meta["labels"] = _join_labels(labels)
+
+        section = _Section(
+            id=new_id,
+            title=title.strip(),
+            meta=meta,
+            body=body.rstrip(),
+            span=(0, 0),
+        )
+        sections.append(section)
+        self._persist(prelude, sections)
+
+        logger.info("markdown.task_created", task_id=new_id, title=title, path=str(self._path))
+        return _section_to_task(section)
+
+    def read_task(self, task_id: str) -> Task:
+        _, sections = self._load_sections()
+        return _section_to_task(self._find_section(sections, task_id))
+
+    def _is_not_found_error(self, error: Exception) -> bool:
+        return isinstance(error, TaskNotFoundError)
+
+    def update_task(
+        self,
+        task_id: str,
+        body: str | None = None,
+        title: str | None = None,
+    ) -> Task:
+        prelude, sections = self._load_sections()
+        section = self._find_section(sections, task_id)
+        if title is not None:
+            section.title = title.strip()
+        if body is not None:
+            section.body = body.rstrip()
+        self._persist(prelude, sections)
+        return _section_to_task(section)
+
+    def close_task(self, task_id: str) -> Task:
+        prelude, sections = self._load_sections()
+        section = self._find_section(sections, task_id)
+        section.meta["state"] = TaskState.CLOSED.value
+        # Closing implies leaving in-progress.
+        labels = _split_labels(section.meta.get("labels", ""))
+        labels = [name for name in labels if name != "in-progress"]
+        if labels:
+            section.meta["labels"] = _join_labels(labels)
+        else:
+            section.meta.pop("labels", None)
+        self._persist(prelude, sections)
+        logger.info("markdown.task_closed", task_id=task_id, path=str(self._path))
+        return _section_to_task(section)
+
+    def comment_on_task(self, task_id: str, body: str) -> None:
+        prelude, sections = self._load_sections()
+        section = self._find_section(sections, task_id)
+        timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M UTC")
+        comment_block = f"\n\n### Comment — {timestamp}\n\n{body.rstrip()}"
+        section.body = (section.body.rstrip() + comment_block).strip()
+        self._persist(prelude, sections)
+
+    # --- Label management ---
+
+    def ensure_label(self, label: Label) -> None:
+        """Markdown labels are inline strings — nothing to pre-create."""
+        return None
+
+    def add_label(self, task_id: str, label_name: str) -> None:
+        try:
+            prelude, sections = self._load_sections()
+            section = self._find_section(sections, task_id)
+            labels = _split_labels(section.meta.get("labels", ""))
+            if label_name not in labels:
+                labels.append(label_name)
+                section.meta["labels"] = _join_labels(labels)
+                self._persist(prelude, sections)
+        except TaskNotFoundError:
+            logger.warning("markdown.label_add_failed", task_id=task_id, label=label_name)
+
+    def remove_label(self, task_id: str, label_name: str) -> None:
+        try:
+            prelude, sections = self._load_sections()
+            section = self._find_section(sections, task_id)
+            labels = _split_labels(section.meta.get("labels", ""))
+            if label_name in labels:
+                labels = [name for name in labels if name != label_name]
+                if labels:
+                    section.meta["labels"] = _join_labels(labels)
+                else:
+                    section.meta.pop("labels", None)
+                self._persist(prelude, sections)
+        except TaskNotFoundError:
+            logger.warning("markdown.label_remove_failed", task_id=task_id, label=label_name)
+
+    # --- Project board operations ---
+
+    def move_to_in_progress(self, task_id: str) -> bool:
+        try:
+            prelude, sections = self._load_sections()
+            section = self._find_section(sections, task_id)
+            section.meta["state"] = TaskState.IN_PROGRESS.value
+            self._persist(prelude, sections)
+            logger.info("markdown.moved_to_in_progress", task_id=task_id)
+            return True
+        except TaskNotFoundError:
+            return False

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -106,15 +106,25 @@ def _parse_meta_block(text: str) -> dict[str, str]:
 
 
 def _format_meta_block(meta: dict[str, str]) -> str:
-    """Format a metadata dict as a ``<!-- wade ... -->`` HTML comment."""
+    """Format a metadata dict as a ``<!-- wade ... -->`` HTML comment.
+
+    Wade-managed keys (``state``, ``labels``) are emitted first in canonical
+    order. Any additional keys present in ``meta`` are passed through after
+    them, preserving user-added metadata like ``priority`` or ``owner`` that
+    wade doesn't interpret but shouldn't silently drop on write.
+    """
     lines = ["<!-- wade"]
-    for key in ("state", "labels"):
-        value = meta.get(key, "")
-        # Always emit ``state`` (default "open"); only emit ``labels`` if non-empty.
-        if key == "state":
-            lines.append(f"state: {value or TaskState.OPEN.value}")
-        elif value:
-            lines.append(f"labels: {value}")
+    # Always emit state with a sensible default.
+    lines.append(f"state: {meta.get('state') or TaskState.OPEN.value}")
+    labels = meta.get("labels", "")
+    if labels:
+        lines.append(f"labels: {labels}")
+    # Pass through anything else the user added.
+    for key, value in meta.items():
+        if key in ("state", "labels"):
+            continue
+        if value:
+            lines.append(f"{key}: {value}")
     lines.append("-->")
     return "\n".join(lines)
 

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -48,7 +48,11 @@ from pydantic import BaseModel, ConfigDict
 
 if sys.platform != "win32":
     import fcntl
+
+    msvcrt = None
 else:  # pragma: no cover -- exercised only on Windows
+    import msvcrt
+
     fcntl = None  # type: ignore[assignment]
 
 from wade.models.config import ProviderConfig
@@ -58,6 +62,7 @@ from wade.models.task import (
     TaskState,
     parse_complexity_from_body,
     parse_complexity_from_labels,
+    parse_tracking_child_ids,
 )
 from wade.providers._pr_delegate import GitHubPRDelegateMixin
 from wade.providers.base import AbstractTaskProvider
@@ -313,14 +318,26 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         project_root: Path | None = None,
         github_provider: GitHubProvider | None = None,
     ) -> None:
+        """Build a provider rooted at ``project_root`` with PR delegation wired."""
         super().__init__(config)
         self._project_root = project_root or Path.cwd()
         self._path = self._resolve_path()
+        self._auto_commit = self._config.settings.get("auto_commit", "").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
         self._init_pr_delegate(github_provider)
 
     # --- Path resolution ---
 
     def _resolve_path(self) -> Path:
+        """Resolve the configured ``path`` setting to an absolute file path.
+
+        Relative paths anchor at the main worktree (so every linked
+        worktree converges on the same physical ``ISSUES.md``); absolute
+        paths are honored verbatim.
+        """
         raw = self._config.settings.get("path", DEFAULT_FILE_NAME)
         candidate = Path(raw).expanduser()
         if candidate.is_absolute():
@@ -331,11 +348,13 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
     # --- File I/O ---
 
     def _read_text(self) -> str:
+        """Read the markdown file, returning ``""`` if it doesn't exist yet."""
         if not self._path.exists():
             return ""
         return self._path.read_text(encoding="utf-8")
 
     def _write_text(self, content: str) -> None:
+        """Atomically write ``content`` to the markdown file with a trailing newline."""
         if not content.endswith("\n"):
             content += "\n"
         _atomic_write(self._path, content)
@@ -360,22 +379,32 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         updates). We block on a sibling ``.lock`` file so the load and
         persist are observed as one atomic unit.
 
-        On Windows ``fcntl`` is unavailable, so this is a no-op there —
-        wade's primary platform is POSIX and locking gracefully degrades.
+        Implementation differs by platform but the contract is identical:
+        ``fcntl.flock`` (POSIX) blocks on the open file description;
+        ``msvcrt.locking`` (Windows) byte-locks the first byte of the
+        lock file in blocking-exclusive mode.
         """
-        if fcntl is None:  # pragma: no cover -- Windows path
-            yield
-            return
         self._path.parent.mkdir(parents=True, exist_ok=True)
         lock_path = self._path.with_name(f".{self._path.name}.lock")
         # Open with O_RDWR | O_CREAT so we can both create and lock the file.
         fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            else:  # pragma: no cover -- Windows path
+                # msvcrt locks a byte range; ensure the file has at least 1 byte.
+                if os.fstat(fd).st_size == 0:
+                    os.write(fd, b"\0")
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
             yield
         finally:
             with contextlib.suppress(OSError):
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                if fcntl is not None:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                else:  # pragma: no cover -- Windows path
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
             os.close(fd)
 
     def _persist(self, prelude: str, sections: list[_Section]) -> None:
@@ -399,6 +428,7 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
     # --- Section helpers ---
 
     def _find_section(self, sections: list[_Section], task_id: str) -> _Section:
+        """Return the section matching ``task_id`` or raise ``TaskNotFoundError``."""
         for section in sections:
             if section.id == task_id:
                 return section
@@ -483,10 +513,12 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         return _section_to_task(section)
 
     def read_task(self, task_id: str) -> Task:
+        """Return the task with the given ID. Raises ``TaskNotFoundError`` if absent."""
         _, sections = self._load_sections()
         return _section_to_task(self._find_section(sections, task_id))
 
     def _is_not_found_error(self, error: Exception) -> bool:
+        """Tell ``read_task_or_none`` that ``TaskNotFoundError`` means "not found"."""
         return isinstance(error, TaskNotFoundError)
 
     def update_task(
@@ -495,6 +527,7 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         body: str | None = None,
         title: str | None = None,
     ) -> Task:
+        """Rewrite the section's title and/or body, preserving everything else."""
         with self._lock():
             prelude, sections = self._load_sections()
             section = self._find_section(sections, task_id)
@@ -506,6 +539,11 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         return _section_to_task(section)
 
     def close_task(self, task_id: str) -> Task:
+        """Mark a task ``closed`` and strip the in-progress label.
+
+        If ``auto_commit`` is set in provider settings, commits the change
+        to git so the merge flow doesn't leave the working tree dirty.
+        """
         with self._lock():
             prelude, sections = self._load_sections()
             section = self._find_section(sections, task_id)
@@ -519,9 +557,53 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
                 section.meta.pop("labels", None)
             self._persist(prelude, sections)
         logger.info("markdown.task_closed", task_id=task_id, path=str(self._path))
+        if self._auto_commit:
+            self._git_commit_close(task_id)
         return _section_to_task(section)
 
+    def _git_commit_close(self, task_id: str) -> None:
+        """Stage and commit the ISSUES.md change announcing a task close.
+
+        Non-fatal: any failure (not a git repo, file untracked, hook
+        rejection, signing failure) is logged at WARNING and swallowed —
+        the close itself already succeeded on disk.
+        """
+        repo_root = self._path.parent
+        try:
+            add = run(
+                ["git", "add", str(self._path)],
+                cwd=repo_root,
+                check=False,
+            )
+            if add.returncode != 0:
+                logger.warning(
+                    "markdown.auto_commit_add_failed",
+                    task_id=task_id,
+                    stderr=add.stderr.strip() if add.stderr else "",
+                )
+                return
+            commit = run(
+                ["git", "commit", "-m", f"chore: close #{task_id}"],
+                cwd=repo_root,
+                check=False,
+            )
+            if commit.returncode != 0:
+                logger.warning(
+                    "markdown.auto_commit_failed",
+                    task_id=task_id,
+                    stderr=commit.stderr.strip() if commit.stderr else "",
+                )
+                return
+            logger.info("markdown.auto_committed", task_id=task_id)
+        except Exception as exc:  # log + continue; close already succeeded on disk
+            logger.warning(
+                "markdown.auto_commit_exception",
+                task_id=task_id,
+                error=str(exc),
+            )
+
     def comment_on_task(self, task_id: str, body: str) -> None:
+        """Append a timestamped ``### Comment`` block to the task body."""
         with self._lock():
             prelude, sections = self._load_sections()
             section = self._find_section(sections, task_id)
@@ -537,6 +619,7 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         return None
 
     def add_label(self, task_id: str, label_name: str) -> None:
+        """Add ``label_name`` to the task's labels list. Idempotent; non-fatal on missing task."""
         try:
             with self._lock():
                 prelude, sections = self._load_sections()
@@ -550,6 +633,7 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
             logger.warning("markdown.label_add_failed", task_id=task_id, label=label_name)
 
     def remove_label(self, task_id: str, label_name: str) -> None:
+        """Remove ``label_name`` from the task's labels list. Non-fatal on missing task."""
         try:
             with self._lock():
                 prelude, sections = self._load_sections()
@@ -565,9 +649,34 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         except TaskNotFoundError:
             logger.warning("markdown.label_remove_failed", task_id=task_id, label=label_name)
 
+    # --- Parent / tracking-issue detection ---
+
+    def find_parent_issue(self, task_id: str, label: str | None = None) -> str | None:
+        """Locate the tracking issue that lists ``task_id`` as a child.
+
+        Scans every section's body for checklist refs of the form
+        ``- [ ] #<id>`` (checked or unchecked) and returns the first
+        matching section's id. Optionally filter to sections carrying
+        ``label`` (e.g., ``feature-plan``) to avoid spurious matches
+        from unrelated issues that happen to reference ``task_id``.
+        """
+        _, sections = self._load_sections()
+        for section in sections:
+            if label:
+                labels = _split_labels(section.meta.get("labels", ""))
+                if label not in labels:
+                    continue
+            if section.id == task_id:
+                continue
+            children = parse_tracking_child_ids(section.body, include_checked=True)
+            if task_id in children:
+                return section.id
+        return None
+
     # --- Project board operations ---
 
     def move_to_in_progress(self, task_id: str) -> bool:
+        """Flip the task's state to ``in_progress``. Returns ``False`` if missing."""
         try:
             with self._lock():
                 prelude, sections = self._load_sections()

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -31,6 +31,7 @@ File format::
 
 from __future__ import annotations
 
+import functools
 import os
 import re
 import secrets
@@ -59,9 +60,12 @@ DEFAULT_FILE_NAME = "ISSUES.md"
 DEFAULT_FILE_HEADER = "# Wade Issues\n\n<!-- Managed by the Wade markdown issue provider. -->\n"
 
 # Heading like "## #42 Title", "## #42: Title", or "## #42 - Title".
-# Em (U+2014) and en (U+2013) dashes are accepted via explicit escapes.
+# The ID is restricted to digits so the regex doesn't accidentally match
+# regular markdown anchor headings like ``## #disclaimer Some text``, and
+# so IDs round-trip through ``int()`` / wade's ``#\d+`` parsing.
+# Em (U+2014) and en (U+2013) dashes are accepted as title separators.
 _HEADING_RE = re.compile(
-    "^##\\s+#(?P<id>[A-Za-z0-9_-]+)\\s*(?:[:\\-–—]\\s*)?(?P<title>.*?)\\s*$",  # noqa: RUF001
+    "^##\\s+#(?P<id>\\d+)\\s*(?:[:\\-–—]\\s*)?(?P<title>.*?)\\s*$",  # noqa: RUF001
     re.MULTILINE,
 )
 
@@ -209,14 +213,19 @@ def _section_to_task(section: _Section) -> Task:
     )
 
 
+@functools.cache
 def _resolve_main_worktree(start: Path) -> Path | None:
     """Return the main worktree path for the git repo containing ``start``.
 
     From a linked worktree, returns the primary checkout (so all worktrees
     point to the same ``ISSUES.md``). From the main checkout, returns its
-    own root. Returns ``None`` if ``start`` isn't in a git repo (rare:
-    user is running wade outside a checkout) — callers fall back to
-    ``project_root``.
+    own root. Returns ``None`` if ``start`` isn't in a working-tree git repo
+    (not in a repo, in a bare repo, or in a submodule's .git/modules tree)
+    — callers fall back to ``project_root``.
+
+    Cached because the result is stable per-path within a process and
+    ``get_provider(config)`` is hot. The cache is keyed by the absolute,
+    resolved ``start`` path; callers should pass already-resolved paths.
     """
     common = run(
         ["git", "rev-parse", "--git-common-dir"],
@@ -228,13 +237,27 @@ def _resolve_main_worktree(start: Path) -> Path | None:
     common_dir = Path(common.stdout.strip())
     if not common_dir.is_absolute():
         common_dir = (start / common_dir).resolve()
-    # The main worktree is the parent of the canonical .git directory.
-    return common_dir.parent
+    candidate = common_dir.parent
+    # Submodules report `.git/modules/<sub>` as the common dir, whose parent
+    # is `.git/modules/` — not a working tree. Heuristic: only accept the
+    # candidate if it looks like a checkout (has a .git entry of its own).
+    if not (candidate / ".git").exists():
+        return None
+    return candidate
 
 
 def _atomic_write(path: Path, content: str) -> None:
-    """Write ``content`` to ``path`` atomically (write tmp + rename)."""
+    """Write ``content`` to ``path`` atomically (write tmp + rename).
+
+    Preserves the destination's existing permission bits across writes —
+    ``tempfile.mkstemp`` defaults to ``0600``, which would otherwise leak
+    through ``os.replace`` and silently strip group/other read on every
+    ``ISSUES.md`` mutation (showing up as spurious permission churn in
+    ``git status``). For brand-new files we use ``0644`` to match the
+    convention for tracked text files.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
+    target_mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
     fd, tmp_name = tempfile.mkstemp(
         prefix=f".{path.name}.",
         suffix=".tmp",
@@ -243,6 +266,7 @@ def _atomic_write(path: Path, content: str) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
+        os.chmod(tmp_name, target_mode)
         os.replace(tmp_name, path)
     except Exception:
         Path(tmp_name).unlink(missing_ok=True)

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -473,6 +473,8 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         exclude_labels: list[str] | None = None,
     ) -> list[Task]:
         """List tasks from the markdown file with optional filtering."""
+        if limit <= 0:
+            return []
         _, sections = self._load_sections()
         tasks: list[Task] = []
         exclude_set = set(exclude_labels or [])

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -155,6 +155,20 @@ def _format_meta_block(meta: dict[str, str]) -> str:
     return "\n".join(lines)
 
 
+def _coerce_bool(value: object) -> bool:
+    """Coerce a settings value (string or bool) to a Python bool.
+
+    ``ProviderConfig.settings`` is typed ``dict[str, str]``, so YAML
+    booleans usually arrive as strings like ``"true"`` after Pydantic
+    coercion. But upstream callers (tests, programmatic config) may pass
+    real ``bool``s — accept either form to avoid an ``AttributeError`` on
+    ``.lower()``.
+    """
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("true", "1", "yes", "on")
+
+
 def _split_labels(value: str) -> list[str]:
     """Split a comma-separated labels string into a clean list."""
     return [name.strip() for name in value.split(",") if name.strip()]
@@ -322,11 +336,7 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         super().__init__(config)
         self._project_root = project_root or Path.cwd()
         self._path = self._resolve_path()
-        self._auto_commit = self._config.settings.get("auto_commit", "").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
+        self._auto_commit = _coerce_bool(self._config.settings.get("auto_commit", False))
         self._init_pr_delegate(github_provider)
 
     # --- Path resolution ---

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -31,16 +31,25 @@ File format::
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import os
 import re
 import secrets
+import sys
 import tempfile
-from dataclasses import dataclass
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import structlog
+from pydantic import BaseModel, ConfigDict
+
+if sys.platform != "win32":
+    import fcntl
+else:  # pragma: no cover -- exercised only on Windows
+    fcntl = None  # type: ignore[assignment]
 
 from wade.models.config import ProviderConfig
 from wade.models.task import (
@@ -53,6 +62,9 @@ from wade.models.task import (
 from wade.providers._pr_delegate import GitHubPRDelegateMixin
 from wade.providers.base import AbstractTaskProvider
 from wade.utils.process import run
+
+if TYPE_CHECKING:
+    from wade.providers.github import GitHubProvider
 
 logger = structlog.get_logger()
 
@@ -83,13 +95,16 @@ class TaskNotFoundError(MarkdownProviderError):
     """Raised when a task ID does not exist in the markdown file."""
 
 
-@dataclass
-class _Section:
+class _Section(BaseModel):
     """A parsed issue section from the markdown file.
 
     ``meta`` and ``body`` are kept separate so we can rewrite metadata
     without touching the user-authored body.
     """
+
+    # Section is mutated in place during read-modify-write (title, body,
+    # meta), and the schema is internal — keep validation light.
+    model_config = ConfigDict(validate_assignment=False, frozen=False)
 
     id: str
     title: str
@@ -296,7 +311,7 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         self,
         config: ProviderConfig | None = None,
         project_root: Path | None = None,
-        github_provider: AbstractTaskProvider | None = None,
+        github_provider: GitHubProvider | None = None,
     ) -> None:
         super().__init__(config)
         self._project_root = project_root or Path.cwd()
@@ -333,6 +348,35 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         sections = _parse_sections(text)
         prelude = text[: sections[0].span[0]] if sections else text
         return prelude, sections
+
+    @contextlib.contextmanager
+    def _lock(self) -> Iterator[None]:
+        """Acquire an exclusive cross-process lock for the duration of a
+        read-modify-write cycle.
+
+        Two worktrees writing concurrently to the same ``ISSUES.md`` could
+        each load a snapshot, mutate in memory, and have the second writer
+        clobber the first (atomic write protects torn writes, not lost
+        updates). We block on a sibling ``.lock`` file so the load and
+        persist are observed as one atomic unit.
+
+        On Windows ``fcntl`` is unavailable, so this is a no-op there —
+        wade's primary platform is POSIX and locking gracefully degrades.
+        """
+        if fcntl is None:  # pragma: no cover -- Windows path
+            yield
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self._path.with_name(f".{self._path.name}.lock")
+        # Open with O_RDWR | O_CREAT so we can both create and lock the file.
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
 
     def _persist(self, prelude: str, sections: list[_Section]) -> None:
         """Reassemble the file from prelude + sections and write atomically."""
@@ -418,21 +462,22 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         labels: list[str] | None = None,
     ) -> Task:
         """Append a new task as a ``## `` section to the file."""
-        prelude, sections = self._load_sections()
-        new_id = self._generate_id(sections)
-        meta: dict[str, str] = {"state": TaskState.OPEN.value}
-        if labels:
-            meta["labels"] = _join_labels(labels)
+        with self._lock():
+            prelude, sections = self._load_sections()
+            new_id = self._generate_id(sections)
+            meta: dict[str, str] = {"state": TaskState.OPEN.value}
+            if labels:
+                meta["labels"] = _join_labels(labels)
 
-        section = _Section(
-            id=new_id,
-            title=title.strip(),
-            meta=meta,
-            body=body.rstrip(),
-            span=(0, 0),
-        )
-        sections.append(section)
-        self._persist(prelude, sections)
+            section = _Section(
+                id=new_id,
+                title=title.strip(),
+                meta=meta,
+                body=body.rstrip(),
+                span=(0, 0),
+            )
+            sections.append(section)
+            self._persist(prelude, sections)
 
         logger.info("markdown.task_created", task_id=new_id, title=title, path=str(self._path))
         return _section_to_task(section)
@@ -450,37 +495,40 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         body: str | None = None,
         title: str | None = None,
     ) -> Task:
-        prelude, sections = self._load_sections()
-        section = self._find_section(sections, task_id)
-        if title is not None:
-            section.title = title.strip()
-        if body is not None:
-            section.body = body.rstrip()
-        self._persist(prelude, sections)
+        with self._lock():
+            prelude, sections = self._load_sections()
+            section = self._find_section(sections, task_id)
+            if title is not None:
+                section.title = title.strip()
+            if body is not None:
+                section.body = body.rstrip()
+            self._persist(prelude, sections)
         return _section_to_task(section)
 
     def close_task(self, task_id: str) -> Task:
-        prelude, sections = self._load_sections()
-        section = self._find_section(sections, task_id)
-        section.meta["state"] = TaskState.CLOSED.value
-        # Closing implies leaving in-progress.
-        labels = _split_labels(section.meta.get("labels", ""))
-        labels = [name for name in labels if name != "in-progress"]
-        if labels:
-            section.meta["labels"] = _join_labels(labels)
-        else:
-            section.meta.pop("labels", None)
-        self._persist(prelude, sections)
+        with self._lock():
+            prelude, sections = self._load_sections()
+            section = self._find_section(sections, task_id)
+            section.meta["state"] = TaskState.CLOSED.value
+            # Closing implies leaving in-progress.
+            labels = _split_labels(section.meta.get("labels", ""))
+            labels = [name for name in labels if name != "in-progress"]
+            if labels:
+                section.meta["labels"] = _join_labels(labels)
+            else:
+                section.meta.pop("labels", None)
+            self._persist(prelude, sections)
         logger.info("markdown.task_closed", task_id=task_id, path=str(self._path))
         return _section_to_task(section)
 
     def comment_on_task(self, task_id: str, body: str) -> None:
-        prelude, sections = self._load_sections()
-        section = self._find_section(sections, task_id)
-        timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M UTC")
-        comment_block = f"\n\n### Comment — {timestamp}\n\n{body.rstrip()}"
-        section.body = (section.body.rstrip() + comment_block).strip()
-        self._persist(prelude, sections)
+        with self._lock():
+            prelude, sections = self._load_sections()
+            section = self._find_section(sections, task_id)
+            timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M UTC")
+            comment_block = f"\n\n### Comment — {timestamp}\n\n{body.rstrip()}"
+            section.body = (section.body.rstrip() + comment_block).strip()
+            self._persist(prelude, sections)
 
     # --- Label management ---
 
@@ -490,28 +538,30 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
 
     def add_label(self, task_id: str, label_name: str) -> None:
         try:
-            prelude, sections = self._load_sections()
-            section = self._find_section(sections, task_id)
-            labels = _split_labels(section.meta.get("labels", ""))
-            if label_name not in labels:
-                labels.append(label_name)
-                section.meta["labels"] = _join_labels(labels)
-                self._persist(prelude, sections)
+            with self._lock():
+                prelude, sections = self._load_sections()
+                section = self._find_section(sections, task_id)
+                labels = _split_labels(section.meta.get("labels", ""))
+                if label_name not in labels:
+                    labels.append(label_name)
+                    section.meta["labels"] = _join_labels(labels)
+                    self._persist(prelude, sections)
         except TaskNotFoundError:
             logger.warning("markdown.label_add_failed", task_id=task_id, label=label_name)
 
     def remove_label(self, task_id: str, label_name: str) -> None:
         try:
-            prelude, sections = self._load_sections()
-            section = self._find_section(sections, task_id)
-            labels = _split_labels(section.meta.get("labels", ""))
-            if label_name in labels:
-                labels = [name for name in labels if name != label_name]
-                if labels:
-                    section.meta["labels"] = _join_labels(labels)
-                else:
-                    section.meta.pop("labels", None)
-                self._persist(prelude, sections)
+            with self._lock():
+                prelude, sections = self._load_sections()
+                section = self._find_section(sections, task_id)
+                labels = _split_labels(section.meta.get("labels", ""))
+                if label_name in labels:
+                    labels = [name for name in labels if name != label_name]
+                    if labels:
+                        section.meta["labels"] = _join_labels(labels)
+                    else:
+                        section.meta.pop("labels", None)
+                    self._persist(prelude, sections)
         except TaskNotFoundError:
             logger.warning("markdown.label_remove_failed", task_id=task_id, label=label_name)
 
@@ -519,10 +569,11 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
 
     def move_to_in_progress(self, task_id: str) -> bool:
         try:
-            prelude, sections = self._load_sections()
-            section = self._find_section(sections, task_id)
-            section.meta["state"] = TaskState.IN_PROGRESS.value
-            self._persist(prelude, sections)
+            with self._lock():
+                prelude, sections = self._load_sections()
+                section = self._find_section(sections, task_id)
+                section.meta["state"] = TaskState.IN_PROGRESS.value
+                self._persist(prelude, sections)
             logger.info("markdown.moved_to_in_progress", task_id=task_id)
             return True
         except TaskNotFoundError:

--- a/src/wade/providers/registry.py
+++ b/src/wade/providers/registry.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
-from typing import cast
+from pathlib import Path
+from typing import Any, cast
 
 from wade.models.config import ProjectConfig, ProviderID
 from wade.providers.base import AbstractTaskProvider
@@ -56,4 +58,13 @@ def get_provider(config: ProjectConfig | None = None) -> AbstractTaskProvider:
         raise ValueError(f"Unknown provider: {provider_id}. Supported: {supported}")
 
     cls = _resolve(_PROVIDER_FACTORIES[provider_id])
-    return cls(config.provider)
+
+    # Some providers (e.g. markdown) want the project root to resolve
+    # relative paths. Pass it iff the constructor accepts the kwarg —
+    # keeping older providers untouched.
+    kwargs: dict[str, Any] = {}
+    sig = inspect.signature(cls.__init__)
+    if "project_root" in sig.parameters and config.project_root:
+        kwargs["project_root"] = Path(config.project_root)
+
+    return cls(config.provider, **kwargs)

--- a/src/wade/providers/registry.py
+++ b/src/wade/providers/registry.py
@@ -61,9 +61,11 @@ def get_provider(config: ProjectConfig | None = None) -> AbstractTaskProvider:
 
     # Some providers (e.g. markdown) want the project root to resolve
     # relative paths. Pass it iff the constructor accepts the kwarg —
-    # keeping older providers untouched.
+    # keeping older providers untouched. ``inspect.signature(cls)``
+    # returns the user-facing constructor signature (self stripped,
+    # respects ``__init_subclass__`` / ``__new__``).
     kwargs: dict[str, Any] = {}
-    sig = inspect.signature(cls.__init__)
+    sig = inspect.signature(cls)
     if "project_root" in sig.parameters and config.project_root:
         kwargs["project_root"] = Path(config.project_root)
 

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -1483,6 +1483,23 @@ def _prompt_provider_setup(
             ).strip()
             or "ISSUES.md"
         )
+        # Pre-create the file with the default header so the user can see
+        # where it lives and `wade list` doesn't silently report an empty
+        # phantom file. Anchored at project_root because init runs in
+        # the main checkout (worktree-aware resolution kicks in later
+        # at runtime).
+        path_obj = Path(path).expanduser()
+        md_path = path_obj if path_obj.is_absolute() else project_root / path_obj
+        if not md_path.exists():
+            from wade.providers.markdown import DEFAULT_FILE_HEADER
+
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text(DEFAULT_FILE_HEADER, encoding="utf-8")
+            try:
+                shown = md_path.relative_to(project_root)
+            except ValueError:
+                shown = md_path
+            console.success(f"Created {shown}")
         return {"name": "markdown", "settings": {"path": path}}
 
     # --- GitHub path ---

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -1463,13 +1463,27 @@ def _prompt_provider_setup(
 
     console.rule("Provider")
 
-    providers = ["GitHub Issues", "ClickUp"]
-    hints = ["gh CLI", "API token"]
+    providers = ["GitHub Issues", "ClickUp", "Markdown file"]
+    hints = ["gh CLI", "API token", "Local .md file"]
     default_idx = 0
     if current_provider == "clickup":
         default_idx = 1
+    elif current_provider == "markdown":
+        default_idx = 2
 
     idx = prompts.select("Task management provider", providers, default=default_idx, hints=hints)
+
+    # --- Markdown path ---
+    if idx == 2:
+        current_settings = current_settings or {}
+        path = (
+            prompts.input_prompt(
+                "Path to issues markdown file",
+                default=current_settings.get("path", "ISSUES.md"),
+            ).strip()
+            or "ISSUES.md"
+        )
+        return {"name": "markdown", "settings": {"path": path}}
 
     # --- GitHub path ---
     if idx == 0:

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -490,6 +490,10 @@ def init(
         )
         console.success(f"Created {config_path.name}")
 
+    # Create the markdown issues file if that's the chosen provider.
+    if provider_setup.get("name") == "markdown":
+        _ensure_markdown_file(root, provider_setup.get("settings") or {})
+
     # Create knowledge file if enabled
     if knowledge_setup.get("enabled"):
         from wade.services.knowledge_service import ensure_knowledge_file
@@ -1483,23 +1487,9 @@ def _prompt_provider_setup(
             ).strip()
             or "ISSUES.md"
         )
-        # Pre-create the file with the default header so the user can see
-        # where it lives and `wade list` doesn't silently report an empty
-        # phantom file. Anchored at project_root because init runs in
-        # the main checkout (worktree-aware resolution kicks in later
-        # at runtime).
-        path_obj = Path(path).expanduser()
-        md_path = path_obj if path_obj.is_absolute() else project_root / path_obj
-        if not md_path.exists():
-            from wade.providers.markdown import DEFAULT_FILE_HEADER
-
-            md_path.parent.mkdir(parents=True, exist_ok=True)
-            md_path.write_text(DEFAULT_FILE_HEADER, encoding="utf-8")
-            try:
-                shown = md_path.relative_to(project_root)
-            except ValueError:
-                shown = md_path
-            console.success(f"Created {shown}")
+        # File creation is deferred to the post-wizard write phase so
+        # "Modify" / "Cancel" doesn't leave stray files behind. See
+        # _ensure_markdown_file() invoked alongside the config write.
         return {"name": "markdown", "settings": {"path": path}}
 
     # --- GitHub path ---
@@ -1753,6 +1743,28 @@ def _prompt_knowledge_setup(
         defaults["path"] = path.strip()
 
     return defaults
+
+
+def _ensure_markdown_file(project_root: Path, settings: dict[str, Any]) -> None:
+    """Create the markdown issues file with the default header if missing.
+
+    Called from the init write phase (alongside the config write) so the
+    wizard's "Modify" / "Cancel" paths don't leave stray files behind.
+    """
+    raw = settings.get("path") or "ISSUES.md"
+    path_obj = Path(str(raw)).expanduser()
+    md_path = path_obj if path_obj.is_absolute() else project_root / path_obj
+    if md_path.exists():
+        return
+    from wade.providers.markdown import DEFAULT_FILE_HEADER
+
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.write_text(DEFAULT_FILE_HEADER, encoding="utf-8")
+    try:
+        shown: Path | str = md_path.relative_to(project_root)
+    except ValueError:
+        shown = md_path
+    console.success(f"Created {shown}")
 
 
 def _normalize_knowledge_setup(

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -1748,15 +1748,32 @@ def _prompt_knowledge_setup(
 def _ensure_markdown_file(project_root: Path, settings: dict[str, Any]) -> None:
     """Create the markdown issues file with the default header if missing.
 
+    Resolves the path through the same main-worktree resolver the provider
+    uses at runtime, so running ``wade init`` from a linked worktree writes
+    the file at the location the provider will later read from. Rejects
+    paths that already exist as directories.
+
     Called from the init write phase (alongside the config write) so the
     wizard's "Modify" / "Cancel" paths don't leave stray files behind.
     """
-    raw = settings.get("path") or "ISSUES.md"
+    from wade.providers.markdown import (
+        DEFAULT_FILE_HEADER,
+        DEFAULT_FILE_NAME,
+        _resolve_main_worktree,
+    )
+
+    raw = settings.get("path") or DEFAULT_FILE_NAME
     path_obj = Path(str(raw)).expanduser()
-    md_path = path_obj if path_obj.is_absolute() else project_root / path_obj
+    if path_obj.is_absolute():
+        md_path = path_obj
+    else:
+        anchor = _resolve_main_worktree(project_root) or project_root
+        md_path = (anchor / path_obj).resolve()
+
     if md_path.exists():
+        if not md_path.is_file():
+            raise ValueError(f"Markdown issues path is not a regular file: {md_path}")
         return
-    from wade.providers.markdown import DEFAULT_FILE_HEADER
 
     md_path.parent.mkdir(parents=True, exist_ok=True)
     md_path.write_text(DEFAULT_FILE_HEADER, encoding="utf-8")

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -491,8 +491,18 @@ def init(
         console.success(f"Created {config_path.name}")
 
     # Create the markdown issues file if that's the chosen provider.
+    # Failures (existing dir at path, write permission, etc.) shouldn't
+    # take down the whole init — surface a fix hint and return False.
     if provider_setup.get("name") == "markdown":
-        _ensure_markdown_file(root, provider_setup.get("settings") or {})
+        try:
+            _ensure_markdown_file(root, provider_setup.get("settings") or {})
+        except (ValueError, OSError) as exc:
+            console.error_with_fix(
+                str(exc),
+                "Set provider.settings.path to a writable file path "
+                "(default: ISSUES.md at the repo root).",
+            )
+            return False
 
     # Create knowledge file if enabled
     if knowledge_setup.get("enabled"):

--- a/tests/integration/test_markdown_provider.py
+++ b/tests/integration/test_markdown_provider.py
@@ -1,0 +1,160 @@
+"""Integration tests for the markdown task provider.
+
+Exercises the full config → registry → provider path with a real ``.wade.yml``,
+a real ``ISSUES.md``, and a real linked git worktree. Proves that the merge
+flow's single ``provider.close_task(id)`` call lands in main's file even
+when wade is invoked from a sibling worktree.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from wade.config.loader import parse_config_file
+from wade.models.task import TaskState
+from wade.providers.markdown import MarkdownIssueProvider, _resolve_main_worktree
+from wade.providers.registry import get_provider
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "PATH": os.environ.get("PATH", ""),
+    }
+
+
+def _init_repo(path: Path) -> None:
+    env = _git_env()
+    subprocess.run(["git", "init", "-b", "main"], cwd=path, check=True, env=env)
+    (path / "README").write_text("seed")
+    subprocess.run(["git", "add", "."], cwd=path, check=True, env=env)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, env=env)
+
+
+@pytest.fixture
+def md_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a main repo + linked worktree, both configured for the markdown provider.
+
+    Returns ``(main_root, worktree_root)``. ``ISSUES.md`` is seeded with one
+    open task #42 and committed to main so the worktree sees the same file.
+    """
+    # Clear the LRU on _resolve_main_worktree so different tmp_paths in the
+    # same test session don't collide.
+    _resolve_main_worktree.cache_clear()
+
+    main = tmp_path / "main"
+    main.mkdir()
+    _init_repo(main)
+
+    config = {
+        "version": 2,
+        "project": {"main_branch": "main"},
+        "provider": {"name": "markdown", "settings": {"path": "ISSUES.md"}},
+    }
+    (main / ".wade.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    (main / "ISSUES.md").write_text(
+        "# Wade Issues\n\n## #42 Seed task\n\n<!-- wade\nstate: open\n-->\n\nSeed body.\n",
+        encoding="utf-8",
+    )
+    env = _git_env()
+    subprocess.run(["git", "add", "."], cwd=main, check=True, env=env)
+    subprocess.run(["git", "commit", "-m", "seed"], cwd=main, check=True, env=env)
+
+    wt = tmp_path / "wt"
+    subprocess.run(
+        ["git", "worktree", "add", str(wt), "-b", "feat/x"],
+        cwd=main,
+        check=True,
+        env=env,
+    )
+    # Copy .wade.yml into the worktree (wade does this via the
+    # copy_to_worktree hook; we replicate the steady state).
+    (wt / ".wade.yml").write_text((main / ".wade.yml").read_text(), encoding="utf-8")
+
+    return main, wt
+
+
+class TestProviderViaRegistry:
+    """Registry + config-loader hand off cleanly to MarkdownIssueProvider."""
+
+    def test_load_config_returns_markdown_provider(self, md_repo) -> None:
+        main, _ = md_repo
+        config = parse_config_file(main / ".wade.yml")
+        provider = get_provider(config)
+        assert isinstance(provider, MarkdownIssueProvider)
+        assert provider._path == (main / "ISSUES.md").resolve()
+
+
+class TestMergeFlowEndsClosed:
+    """Simulate what _merge_pr does post-merge: call provider.close_task."""
+
+    def test_close_from_main_updates_main_file(self, md_repo) -> None:
+        main, _ = md_repo
+        config = parse_config_file(main / ".wade.yml")
+        provider = get_provider(config)
+
+        provider.close_task("42")
+
+        # The actual file on disk now reflects closed state.
+        text = (main / "ISSUES.md").read_text(encoding="utf-8")
+        assert "state: closed" in text
+
+        # And re-reading via a fresh provider sees the same.
+        fresh = get_provider(parse_config_file(main / ".wade.yml"))
+        assert fresh.read_task("42").state == TaskState.CLOSED
+
+    def test_close_from_worktree_updates_main_file(self, md_repo) -> None:
+        """The point of main-worktree resolution: close from a worktree,
+        and main's ISSUES.md is what changes.
+        """
+        main, wt = md_repo
+        config = parse_config_file(wt / ".wade.yml")
+        provider = get_provider(config)
+
+        # Resolved path must point at main's file, not the worktree's copy.
+        assert provider._path == (main / "ISSUES.md").resolve()
+
+        provider.close_task("42")
+
+        # Main's file was updated.
+        text = (main / "ISSUES.md").read_text(encoding="utf-8")
+        assert "state: closed" in text
+
+    def test_parallel_creates_from_two_worktrees_do_not_collide(self, md_repo) -> None:
+        """Two providers (one rooted in main, one in worktree) both create
+        tasks. Because they target the same file, IDs are distinct and the
+        file is internally consistent — no duplicate sections.
+        """
+        main, wt = md_repo
+        p_main = get_provider(parse_config_file(main / ".wade.yml"))
+        p_wt = get_provider(parse_config_file(wt / ".wade.yml"))
+
+        a = p_main.create_task("From main", "body A")
+        b = p_wt.create_task("From worktree", "body B")
+
+        assert a.id != b.id
+
+        # Both providers see all three tasks (#42 seed + 2 new).
+        for provider in (p_main, p_wt):
+            ids = {t.id for t in provider.list_tasks(state=None)}
+            assert {"42", a.id, b.id}.issubset(ids)
+
+
+class TestFilePermissionsArePreserved:
+    def test_close_does_not_strip_permissions(self, md_repo) -> None:
+        main, _ = md_repo
+        os.chmod(main / "ISSUES.md", 0o644)
+        config = parse_config_file(main / ".wade.yml")
+        provider = get_provider(config)
+
+        provider.close_task("42")
+
+        assert os.stat(main / "ISSUES.md").st_mode & 0o777 == 0o644

--- a/tests/integration/test_markdown_provider.py
+++ b/tests/integration/test_markdown_provider.py
@@ -129,23 +129,62 @@ class TestMergeFlowEndsClosed:
         assert "state: closed" in text
 
     def test_parallel_creates_from_two_worktrees_do_not_collide(self, md_repo) -> None:
-        """Two providers (one rooted in main, one in worktree) both create
-        tasks. Because they target the same file, IDs are distinct and the
-        file is internally consistent — no duplicate sections.
+        """Two providers (one rooted in main, one in worktree) create tasks
+        concurrently. The cross-process file lock must serialize the
+        read-modify-write cycles so neither create is lost and both IDs
+        are distinct.
         """
+        from concurrent.futures import ThreadPoolExecutor
+
         main, wt = md_repo
         p_main = get_provider(parse_config_file(main / ".wade.yml"))
         p_wt = get_provider(parse_config_file(wt / ".wade.yml"))
 
-        a = p_main.create_task("From main", "body A")
-        b = p_wt.create_task("From worktree", "body B")
+        with ThreadPoolExecutor(max_workers=2) as ex:
+            fa = ex.submit(p_main.create_task, "From main", "body A")
+            fb = ex.submit(p_wt.create_task, "From worktree", "body B")
+            a = fa.result()
+            b = fb.result()
 
         assert a.id != b.id
 
-        # Both providers see all three tasks (#42 seed + 2 new).
+        # Both providers see all three tasks (#42 seed + 2 new), and the
+        # underlying file has exactly one section per id (no clobbered writes).
+        text = (main / "ISSUES.md").read_text(encoding="utf-8")
+        assert text.count(f"## #{a.id} ") == 1
+        assert text.count(f"## #{b.id} ") == 1
         for provider in (p_main, p_wt):
             ids = {t.id for t in provider.list_tasks(state=None)}
             assert {"42", a.id, b.id}.issubset(ids)
+
+    def test_many_concurrent_creates_all_persist(self, md_repo) -> None:
+        """Sanity: hammer the lock with N concurrent creates. Every task
+        must survive the read-modify-write cycle (no lost updates) and
+        every ID must be distinct.
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        main, wt = md_repo
+        providers = [
+            get_provider(parse_config_file(main / ".wade.yml")),
+            get_provider(parse_config_file(wt / ".wade.yml")),
+        ]
+        n = 12
+
+        def _create(i: int):
+            return providers[i % 2].create_task(f"Task {i}", f"body {i}")
+
+        with ThreadPoolExecutor(max_workers=4) as ex:
+            futures = [ex.submit(_create, i) for i in range(n)]
+            tasks = [f.result() for f in as_completed(futures)]
+
+        ids = [t.id for t in tasks]
+        assert len(ids) == n
+        assert len(set(ids)) == n  # All distinct.
+
+        text = (main / "ISSUES.md").read_text(encoding="utf-8")
+        for task_id in ids:
+            assert text.count(f"## #{task_id} ") == 1
 
 
 class TestFilePermissionsArePreserved:

--- a/tests/unit/test_cli/test_knowledge_cli.py
+++ b/tests/unit/test_cli/test_knowledge_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -380,7 +381,9 @@ class TestKnowledgeEnableCommand:
         updated_config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         assert updated_config["knowledge"]["enabled"] is True
 
-    def test_enables_knowledge_with_custom_path(self, tmp_path: Path) -> None:
+    def test_enables_knowledge_with_custom_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         config_path = tmp_path / ".wade.yml"
         config_path.write_text("version: 2\n", encoding="utf-8")
 
@@ -389,6 +392,9 @@ class TestKnowledgeEnableCommand:
             knowledge=KnowledgeConfig(enabled=False, path="KNOWLEDGE.md"),
             config_path=str(config_path),
         )
+        # The CLI handler reads Path.cwd() to derive project_root, so chdir
+        # into tmp_path to keep the created knowledge file out of the real repo.
+        monkeypatch.chdir(tmp_path)
         with (
             patch("wade.config.loader.load_config", return_value=config),
             patch("wade.config.loader.find_config_file", return_value=config_path),

--- a/tests/unit/test_models/test_review.py
+++ b/tests/unit/test_models/test_review.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from wade.models.review import (
     PendingReviewer,
+    PRComment,
     PRReviewStatus,
     ReviewBotStatus,
     ReviewComment,
@@ -82,44 +83,44 @@ class TestReviewThread:
 class TestDetectCoderabbitReviewStatus:
     def test_paused_review(self) -> None:
         comments = [
-            {
-                "login": "coderabbitai[bot]",
-                "body": (
+            PRComment(
+                login="coderabbitai[bot]",
+                body=(
                     "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
                     "<!-- This is an auto-generated comment: review paused by coderabbit.ai -->\n"
                     "\n> [!NOTE]\n> ## Reviews paused\n"
                 ),
-            }
+            )
         ]
         assert detect_coderabbit_review_status(comments) == ReviewBotStatus.PAUSED
 
     def test_in_progress_review(self) -> None:
         comments = [
-            {
-                "login": "coderabbitai[bot]",
-                "body": (
+            PRComment(
+                login="coderabbitai[bot]",
+                body=(
                     "<!-- This is an auto-generated comment:"
                     " review in progress by coderabbit.ai -->"
                 ),
-            }
+            )
         ]
         assert detect_coderabbit_review_status(comments) == ReviewBotStatus.IN_PROGRESS
 
     def test_completed_review_returns_completed(self) -> None:
         comments = [
-            {
-                "login": "coderabbitai[bot]",
-                "body": (
+            PRComment(
+                login="coderabbitai[bot]",
+                body=(
                     "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
                     "## Walkthrough\nSome summary here."
                 ),
-            }
+            )
         ]
         assert detect_coderabbit_review_status(comments) == ReviewBotStatus.COMPLETED
 
     def test_no_coderabbit_comments(self) -> None:
         comments = [
-            {"login": "octocat", "body": "Looks good to me!"},
+            PRComment(login="octocat", body="Looks good to me!"),
         ]
         assert detect_coderabbit_review_status(comments) is None
 
@@ -129,18 +130,16 @@ class TestDetectCoderabbitReviewStatus:
     def test_uses_latest_comment(self) -> None:
         """When multiple CodeRabbit comments exist, the latest (last) wins."""
         comments = [
-            {
-                "login": "coderabbitai[bot]",
-                "body": (
-                    "<!-- This is an auto-generated comment: review paused by coderabbit.ai -->"
-                ),
-            },
-            {
-                "login": "coderabbitai[bot]",
-                "body": (
+            PRComment(
+                login="coderabbitai[bot]",
+                body=("<!-- This is an auto-generated comment: review paused by coderabbit.ai -->"),
+            ),
+            PRComment(
+                login="coderabbitai[bot]",
+                body=(
                     "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\nDone."
                 ),
-            },
+            ),
         ]
         # Latest comment has no paused/in-progress marker -> COMPLETED
         assert detect_coderabbit_review_status(comments) == ReviewBotStatus.COMPLETED
@@ -148,30 +147,28 @@ class TestDetectCoderabbitReviewStatus:
     def test_paused_overrides_earlier_completed(self) -> None:
         """A newer paused comment takes precedence over an older completed one."""
         comments = [
-            {
-                "login": "coderabbitai[bot]",
-                "body": (
+            PRComment(
+                login="coderabbitai[bot]",
+                body=(
                     "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\nDone."
                 ),
-            },
-            {
-                "login": "coderabbitai[bot]",
-                "body": (
-                    "<!-- This is an auto-generated comment: review paused by coderabbit.ai -->"
-                ),
-            },
+            ),
+            PRComment(
+                login="coderabbitai[bot]",
+                body=("<!-- This is an auto-generated comment: review paused by coderabbit.ai -->"),
+            ),
         ]
         assert detect_coderabbit_review_status(comments) == ReviewBotStatus.PAUSED
 
     def test_detection_is_case_insensitive(self) -> None:
         comments = [
-            {
-                "login": "coderabbitai[bot]",
-                "body": (
+            PRComment(
+                login="coderabbitai[bot]",
+                body=(
                     "<!-- This is an auto-generated comment:"
                     " Review In Progress by CodeRabbit.ai -->"
                 ),
-            }
+            )
         ]
         assert detect_coderabbit_review_status(comments) == ReviewBotStatus.IN_PROGRESS
 

--- a/tests/unit/test_providers/test_clickup.py
+++ b/tests/unit/test_providers/test_clickup.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from wade.models.config import ProviderConfig, ProviderID
+from wade.models.review import PRReviewStatus
 from wade.models.task import Complexity, Label, TaskState
 from wade.providers.clickup import ClickUpProvider, _parse_clickup_task
 from wade.utils.http import APIError
@@ -484,3 +485,56 @@ class TestResolveSpaceId:
 
         with pytest.raises(ValueError, match="Could not resolve space_id"):
             provider._resolve_space_id()
+
+
+# ---------------------------------------------------------------------------
+# PR-review delegation to GitHub
+# ---------------------------------------------------------------------------
+
+
+class TestPRReviewDelegation:
+    """ClickUp tasks live in ClickUp; PRs flow through GitHub."""
+
+    def _build(self) -> tuple[ClickUpProvider, MagicMock]:
+        gh = MagicMock()
+        with patch.dict("os.environ", {"CLICKUP_API_TOKEN": "pk_test"}):
+            provider = ClickUpProvider(CLICKUP_CONFIG, github_provider=gh)
+        return provider, gh
+
+    def test_get_pr_review_threads_delegates(self) -> None:
+        provider, gh = self._build()
+        gh.get_pr_review_threads.return_value = ["t1"]
+        assert provider.get_pr_review_threads(42) == ["t1"]
+        gh.get_pr_review_threads.assert_called_once_with(42)
+
+    def test_resolve_review_thread_delegates(self) -> None:
+        provider, gh = self._build()
+        gh.resolve_review_thread.return_value = True
+        assert provider.resolve_review_thread("THREAD_ID") is True
+        gh.resolve_review_thread.assert_called_once_with("THREAD_ID")
+
+    def test_get_pr_issue_comments_delegates(self) -> None:
+        provider, gh = self._build()
+        gh.get_pr_issue_comments.return_value = [{"login": "u", "body": "hi"}]
+        assert provider.get_pr_issue_comments(7) == [{"login": "u", "body": "hi"}]
+        gh.get_pr_issue_comments.assert_called_once_with(7)
+
+    def test_get_pr_review_status_delegates(self) -> None:
+        provider, gh = self._build()
+        status = PRReviewStatus()
+        gh.get_pr_review_status.return_value = status
+        assert provider.get_pr_review_status(99) is status
+        gh.get_pr_review_status.assert_called_once_with(99)
+
+    def test_get_repo_nwo_delegates(self) -> None:
+        provider, gh = self._build()
+        gh.get_repo_nwo.return_value = "owner/repo"
+        assert provider.get_repo_nwo() == "owner/repo"
+
+    def test_inner_github_provider_lazy_init(self) -> None:
+        with patch.dict("os.environ", {"CLICKUP_API_TOKEN": "pk_test"}):
+            provider = ClickUpProvider(CLICKUP_CONFIG)
+        assert provider._pr_github is None
+        gh = provider._pr_gh()
+        assert gh is not None
+        assert provider._pr_gh() is gh

--- a/tests/unit/test_providers/test_clickup.py
+++ b/tests/unit/test_providers/test_clickup.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from wade.models.config import ProviderConfig, ProviderID
-from wade.models.review import PRReviewStatus
+from wade.models.review import PRComment, PRReviewStatus
 from wade.models.task import Complexity, Label, TaskState
 from wade.providers.clickup import ClickUpProvider, _parse_clickup_task
 from wade.utils.http import APIError
@@ -515,8 +515,9 @@ class TestPRReviewDelegation:
 
     def test_get_pr_issue_comments_delegates(self) -> None:
         provider, gh = self._build()
-        gh.get_pr_issue_comments.return_value = [{"login": "u", "body": "hi"}]
-        assert provider.get_pr_issue_comments(7) == [{"login": "u", "body": "hi"}]
+        expected = [PRComment(login="u", body="hi")]
+        gh.get_pr_issue_comments.return_value = expected
+        assert provider.get_pr_issue_comments(7) == expected
         gh.get_pr_issue_comments.assert_called_once_with(7)
 
     def test_get_pr_review_status_delegates(self) -> None:

--- a/tests/unit/test_providers/test_clickup.py
+++ b/tests/unit/test_providers/test_clickup.py
@@ -531,6 +531,7 @@ class TestPRReviewDelegation:
         provider, gh = self._build()
         gh.get_repo_nwo.return_value = "owner/repo"
         assert provider.get_repo_nwo() == "owner/repo"
+        gh.get_repo_nwo.assert_called_once_with()
 
     def test_inner_github_provider_lazy_init(self) -> None:
         with patch.dict("os.environ", {"CLICKUP_API_TOKEN": "pk_test"}):

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -278,7 +278,7 @@ class TestCreateTask:
         provider = config_factory(None)
         task = provider.create_task("New task", "Body here", labels=["feature"])
         # IDs are random 8-hex-char strings.
-        assert re.fullmatch(r"[0-9a-f]{8}", task.id)
+        assert re.fullmatch(r"[1-9][0-9]{7}", task.id)
         assert task.title == "New task"
         assert task.state == TaskState.OPEN
         assert any(lbl.name == "feature" for lbl in task.labels)
@@ -289,7 +289,7 @@ class TestCreateTask:
     def test_appends_to_existing_file(self, config_factory) -> None:
         provider = config_factory(SAMPLE_FILE)
         task = provider.create_task("Another", "Body", labels=["x"])
-        assert re.fullmatch(r"[0-9a-f]{8}", task.id)
+        assert re.fullmatch(r"[1-9][0-9]{7}", task.id)
         assert task.id not in {"1", "2", "3"}  # Distinct from existing IDs.
         # Original tasks still readable.
         assert provider.read_task("1").title == "Add login feature"
@@ -466,7 +466,10 @@ class TestRoundTrip:
         a = provider.create_task("Task A", "Body A", labels=["feature"])
         b = provider.create_task("Task B", "Body B")
         assert a.id != b.id
-        assert re.fullmatch(r"[0-9a-f]{8}", a.id)
+        assert re.fullmatch(r"[1-9][0-9]{7}", a.id)
+        # Decimal IDs survive int() — needed by wade's branch naming and
+        # merge-flow paths that cast issue_number to int.
+        assert str(int(a.id)) == a.id
 
         provider.add_label(a.id, "complexity:complex")
         provider.update_task(b.id, body="Updated body for B")

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -491,9 +491,9 @@ class TestPRReviewDelegation:
             ProviderConfig(name=ProviderID.MARKDOWN),
             project_root=tmp_path,
         )
-        assert provider._github is None
-        # Calling _gh() should construct one lazily.
-        gh = provider._gh()
+        assert provider._pr_github is None
+        # Calling _pr_gh() should construct one lazily.
+        gh = provider._pr_gh()
         assert gh is not None
         # And cache it.
-        assert provider._gh() is gh
+        assert provider._pr_gh() is gh

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -105,6 +105,22 @@ class TestFormatMetaBlock:
         block = _format_meta_block({"state": "open", "labels": "a, b"})
         assert "labels: a, b" in block
 
+    def test_custom_keys_passed_through(self) -> None:
+        block = _format_meta_block(
+            {"state": "open", "labels": "x", "priority": "high", "owner": "alice"}
+        )
+        assert "priority: high" in block
+        assert "owner: alice" in block
+
+    def test_custom_keys_emitted_after_canonical_keys(self) -> None:
+        block = _format_meta_block({"state": "open", "priority": "high", "labels": "x"})
+        # Canonical (state, labels) come before pass-through keys.
+        assert block.index("state:") < block.index("labels:") < block.index("priority:")
+
+    def test_empty_custom_value_is_skipped(self) -> None:
+        block = _format_meta_block({"state": "open", "priority": ""})
+        assert "priority" not in block
+
 
 class TestParseSections:
     def test_basic_sections(self) -> None:
@@ -417,6 +433,26 @@ class TestRoundTrip:
         assert provider.read_task("2").state == TaskState.CLOSED
         assert provider.read_task("1").complexity == Complexity.COMPLEX
         assert provider.read_task("2").body == "Updated body for B"
+
+    def test_custom_metadata_keys_survive_writes(self, config_factory) -> None:
+        # User has hand-added metadata keys wade doesn't manage.
+        content = (
+            "## #1 Title\n\n"
+            "<!-- wade\nstate: open\npriority: high\nowner: alice\n-->\n\n"
+            "body\n"
+        )
+        provider = config_factory(content)
+        # Trigger writes that don't touch the custom keys.
+        provider.add_label("1", "feature")
+        provider.move_to_in_progress("1")
+        provider.update_task("1", body="updated body")
+
+        text = provider._path.read_text(encoding="utf-8")
+        assert "priority: high" in text
+        assert "owner: alice" in text
+        # And the wade-managed fields still work.
+        assert provider.read_task("1").state == TaskState.IN_PROGRESS
+        assert {lbl.name for lbl in provider.read_task("1").labels} == {"feature"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from wade.models.config import ProjectConfig, ProviderConfig, ProviderID
+from wade.models.review import PRReviewStatus
 from wade.models.task import Complexity, TaskState
 from wade.providers.markdown import (
     DEFAULT_FILE_HEADER,
@@ -434,3 +436,64 @@ class TestRegistryIntegration:
         provider = get_provider(config)
         assert isinstance(provider, MarkdownIssueProvider)
         assert provider._path == (tmp_path / "ISSUES.md").resolve()
+
+
+# ---------------------------------------------------------------------------
+# PR-review delegation to GitHub
+# ---------------------------------------------------------------------------
+
+
+class TestPRReviewDelegation:
+    """Markdown issues live in a GitHub repo; PR-review ops delegate to gh."""
+
+    def _build(self, tmp_path: Path) -> tuple[MarkdownIssueProvider, MagicMock]:
+        gh = MagicMock()
+        provider = MarkdownIssueProvider(
+            ProviderConfig(name=ProviderID.MARKDOWN),
+            project_root=tmp_path,
+            github_provider=gh,
+        )
+        return provider, gh
+
+    def test_get_pr_review_threads_delegates(self, tmp_path: Path) -> None:
+        provider, gh = self._build(tmp_path)
+        gh.get_pr_review_threads.return_value = ["t1", "t2"]
+        assert provider.get_pr_review_threads(42) == ["t1", "t2"]
+        gh.get_pr_review_threads.assert_called_once_with(42)
+
+    def test_resolve_review_thread_delegates(self, tmp_path: Path) -> None:
+        provider, gh = self._build(tmp_path)
+        gh.resolve_review_thread.return_value = True
+        assert provider.resolve_review_thread("THREAD_ID") is True
+        gh.resolve_review_thread.assert_called_once_with("THREAD_ID")
+
+    def test_get_pr_issue_comments_delegates(self, tmp_path: Path) -> None:
+        provider, gh = self._build(tmp_path)
+        gh.get_pr_issue_comments.return_value = [{"login": "u", "body": "hi"}]
+        assert provider.get_pr_issue_comments(7) == [{"login": "u", "body": "hi"}]
+        gh.get_pr_issue_comments.assert_called_once_with(7)
+
+    def test_get_pr_review_status_delegates(self, tmp_path: Path) -> None:
+        provider, gh = self._build(tmp_path)
+        status = PRReviewStatus()
+        gh.get_pr_review_status.return_value = status
+        assert provider.get_pr_review_status(99) is status
+        gh.get_pr_review_status.assert_called_once_with(99)
+
+    def test_get_repo_nwo_delegates(self, tmp_path: Path) -> None:
+        provider, gh = self._build(tmp_path)
+        gh.get_repo_nwo.return_value = "owner/repo"
+        assert provider.get_repo_nwo() == "owner/repo"
+
+    def test_inner_github_provider_lazy_init(self, tmp_path: Path) -> None:
+        # No github_provider injected — should not construct one until needed.
+        provider = MarkdownIssueProvider(
+            ProviderConfig(name=ProviderID.MARKDOWN),
+            project_root=tmp_path,
+        )
+        assert provider._github is None
+        # Calling _gh() should construct one lazily.
+        gh = provider._gh()
+        assert gh is not None
+        # And cache it.
+        assert provider._gh() is gh

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -1,0 +1,436 @@
+"""Tests for the Markdown provider — file-backed task storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wade.models.config import ProjectConfig, ProviderConfig, ProviderID
+from wade.models.task import Complexity, TaskState
+from wade.providers.markdown import (
+    DEFAULT_FILE_HEADER,
+    MarkdownIssueProvider,
+    TaskNotFoundError,
+    _format_meta_block,
+    _parse_meta_block,
+    _parse_sections,
+)
+from wade.providers.registry import get_provider
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_FILE = """# Wade Issues
+
+<!-- Managed by the Wade markdown issue provider. -->
+
+## #1 Add login feature
+
+<!-- wade
+state: open
+labels: feature, complexity:medium
+-->
+
+Body for issue 1.
+
+Multiple paragraphs ok.
+
+## #2 Fix parser bug
+
+<!-- wade
+state: closed
+labels: bug
+-->
+
+Body for issue 2.
+
+## #3 Refactor
+
+Body without metadata block.
+"""
+
+
+@pytest.fixture
+def config_factory(tmp_path: Path):
+    """Build a MarkdownIssueProvider with a temp file."""
+
+    def _make(content: str | None = None, filename: str = "ISSUES.md") -> MarkdownIssueProvider:
+        path = tmp_path / filename
+        if content is not None:
+            path.write_text(content, encoding="utf-8")
+        provider_config = ProviderConfig(
+            name=ProviderID.MARKDOWN,
+            settings={"path": filename},
+        )
+        return MarkdownIssueProvider(provider_config, project_root=tmp_path)
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Pure parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseMetaBlock:
+    def test_simple_pairs(self) -> None:
+        meta = _parse_meta_block("state: open\nlabels: feature, bug")
+        assert meta == {"state": "open", "labels": "feature, bug"}
+
+    def test_skips_blank_and_invalid(self) -> None:
+        meta = _parse_meta_block("\nstate: closed\nno-colon\n")
+        assert meta == {"state": "closed"}
+
+    def test_keys_normalized_to_lowercase(self) -> None:
+        meta = _parse_meta_block("STATE: open\nLabels: x")
+        assert meta == {"state": "open", "labels": "x"}
+
+
+class TestFormatMetaBlock:
+    def test_state_always_emitted(self) -> None:
+        block = _format_meta_block({})
+        assert "state: open" in block
+        assert block.startswith("<!-- wade")
+        assert block.endswith("-->")
+
+    def test_labels_omitted_when_empty(self) -> None:
+        block = _format_meta_block({"state": "closed", "labels": ""})
+        assert "labels" not in block
+
+    def test_labels_emitted_when_set(self) -> None:
+        block = _format_meta_block({"state": "open", "labels": "a, b"})
+        assert "labels: a, b" in block
+
+
+class TestParseSections:
+    def test_basic_sections(self) -> None:
+        sections = _parse_sections(SAMPLE_FILE)
+        assert len(sections) == 3
+        assert sections[0].id == "1"
+        assert sections[0].title == "Add login feature"
+        assert sections[0].meta["state"] == "open"
+        assert "Body for issue 1" in sections[0].body
+
+    def test_section_without_meta_block(self) -> None:
+        sections = _parse_sections(SAMPLE_FILE)
+        section = next(s for s in sections if s.id == "3")
+        assert section.meta == {}
+        assert "Body without metadata" in section.body
+
+    def test_handles_separator_chars_in_heading(self) -> None:
+        text = "## #5: Title with colon\n\nbody"
+        sections = _parse_sections(text)
+        assert sections[0].id == "5"
+        assert sections[0].title == "Title with colon"
+
+    def test_handles_em_dash(self) -> None:
+        text = "## #6 — Title with dash\n\nbody"
+        sections = _parse_sections(text)
+        assert sections[0].id == "6"
+        assert sections[0].title == "Title with dash"
+
+    def test_subheadings_are_part_of_body(self) -> None:
+        text = "## #1 Title\n\n<!-- wade\nstate: open\n-->\n\nbody\n\n### Sub\n\nmore body\n"
+        sections = _parse_sections(text)
+        assert "### Sub" in sections[0].body
+
+    def test_no_sections_returns_empty(self) -> None:
+        assert _parse_sections("# No issues here yet\n") == []
+
+
+# ---------------------------------------------------------------------------
+# Constructor / path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPathResolution:
+    def test_relative_path_resolves_to_project_root(self, tmp_path: Path) -> None:
+        config = ProviderConfig(name=ProviderID.MARKDOWN, settings={"path": "docs/ISSUES.md"})
+        provider = MarkdownIssueProvider(config, project_root=tmp_path)
+        assert provider._path == (tmp_path / "docs/ISSUES.md").resolve()
+
+    def test_absolute_path_honored(self, tmp_path: Path) -> None:
+        abs_path = tmp_path / "absolute.md"
+        config = ProviderConfig(name=ProviderID.MARKDOWN, settings={"path": str(abs_path)})
+        provider = MarkdownIssueProvider(config, project_root=Path("/wherever"))
+        assert provider._path == abs_path
+
+    def test_default_filename(self, tmp_path: Path) -> None:
+        cfg = ProviderConfig(name=ProviderID.MARKDOWN)
+        provider = MarkdownIssueProvider(cfg, project_root=tmp_path)
+        assert provider._path.name == "ISSUES.md"
+
+
+# ---------------------------------------------------------------------------
+# CRUD tests
+# ---------------------------------------------------------------------------
+
+
+class TestListTasks:
+    def test_lists_open_tasks_only_by_default(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        tasks = provider.list_tasks()
+        ids = [t.id for t in tasks]
+        # #2 is closed, #3 has no metadata (defaults to open).
+        assert "1" in ids
+        assert "3" in ids
+        assert "2" not in ids
+
+    def test_filters_by_label(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        tasks = provider.list_tasks(label="feature")
+        assert [t.id for t in tasks] == ["1"]
+
+    def test_excludes_labels(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        tasks = provider.list_tasks(state=None, exclude_labels=["bug"])
+        ids = [t.id for t in tasks]
+        assert "2" not in ids
+        assert "1" in ids
+
+    def test_lists_closed_state(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        tasks = provider.list_tasks(state=TaskState.CLOSED)
+        assert [t.id for t in tasks] == ["2"]
+
+    def test_lists_all_states(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        tasks = provider.list_tasks(state=None)
+        assert {t.id for t in tasks} == {"1", "2", "3"}
+
+    def test_respects_limit(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        tasks = provider.list_tasks(state=None, limit=2)
+        assert len(tasks) == 2
+
+    def test_complexity_parsed_from_label(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        task = next(t for t in provider.list_tasks() if t.id == "1")
+        assert task.complexity == Complexity.MEDIUM
+
+    def test_empty_file(self, config_factory) -> None:
+        provider = config_factory("# Wade Issues\n\n")
+        assert provider.list_tasks() == []
+
+    def test_missing_file(self, config_factory) -> None:
+        provider = config_factory(None)  # No file written
+        assert provider.list_tasks() == []
+
+
+class TestCreateTask:
+    def test_creates_first_task(self, config_factory) -> None:
+        provider = config_factory(None)
+        task = provider.create_task("New task", "Body here", labels=["feature"])
+        assert task.id == "1"
+        assert task.title == "New task"
+        assert task.state == TaskState.OPEN
+        assert any(lbl.name == "feature" for lbl in task.labels)
+        # Round-trip: read it back.
+        reread = provider.read_task("1")
+        assert reread.title == "New task"
+
+    def test_appends_to_existing_file(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        task = provider.create_task("Another", "Body", labels=["x"])
+        assert task.id == "4"
+        # Original tasks still readable.
+        assert provider.read_task("1").title == "Add login feature"
+        assert provider.read_task("4").title == "Another"
+
+    def test_no_labels(self, config_factory) -> None:
+        provider = config_factory(None)
+        task = provider.create_task("No labels", "Body")
+        assert task.labels == []
+
+    def test_writes_default_header_when_creating_in_empty_file(self, config_factory) -> None:
+        provider = config_factory(None)
+        provider.create_task("First", "Body")
+        text = provider._path.read_text(encoding="utf-8")
+        assert DEFAULT_FILE_HEADER.strip() in text
+
+
+class TestReadTask:
+    def test_reads_existing(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        task = provider.read_task("2")
+        assert task.title == "Fix parser bug"
+        assert task.state == TaskState.CLOSED
+
+    def test_raises_when_not_found(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        with pytest.raises(TaskNotFoundError):
+            provider.read_task("999")
+
+    def test_read_or_none_returns_none_when_missing(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        assert provider.read_task_or_none("999") is None
+
+    def test_read_or_none_returns_task_when_present(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        task = provider.read_task_or_none("1")
+        assert task is not None
+        assert task.id == "1"
+
+
+class TestUpdateTask:
+    def test_update_title(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        task = provider.update_task("1", title="Renamed")
+        assert task.title == "Renamed"
+        assert provider.read_task("1").title == "Renamed"
+
+    def test_update_body(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        provider.update_task("1", body="New body content")
+        assert provider.read_task("1").body == "New body content"
+
+    def test_update_preserves_other_sections(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        provider.update_task("1", title="Renamed")
+        assert provider.read_task("2").title == "Fix parser bug"
+        assert provider.read_task("3").title == "Refactor"
+
+
+class TestCloseTask:
+    def test_close_marks_closed(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        task = provider.close_task("1")
+        assert task.state == TaskState.CLOSED
+        # Persisted.
+        assert provider.read_task("1").state == TaskState.CLOSED
+
+    def test_close_strips_in_progress_label(self, config_factory) -> None:
+        content = (
+            "## #1 Title\n\n"
+            "<!-- wade\nstate: in_progress\nlabels: in-progress, feature\n-->\n\n"
+            "body\n"
+        )
+        provider = config_factory(content)
+        provider.close_task("1")
+        task = provider.read_task("1")
+        names = {lbl.name for lbl in task.labels}
+        assert "in-progress" not in names
+        assert "feature" in names
+
+    def test_close_unknown_raises(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        with pytest.raises(TaskNotFoundError):
+            provider.close_task("999")
+
+
+class TestCommentOnTask:
+    def test_comment_appended_to_body(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        provider.comment_on_task("1", "Hello world")
+        body = provider.read_task("1").body
+        assert "Hello world" in body
+        assert "### Comment" in body
+
+
+# ---------------------------------------------------------------------------
+# Label management
+# ---------------------------------------------------------------------------
+
+
+class TestAddLabel:
+    def test_adds_when_missing(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        provider.add_label("3", "new-label")
+        names = {lbl.name for lbl in provider.read_task("3").labels}
+        assert "new-label" in names
+
+    def test_idempotent(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        provider.add_label("1", "feature")  # Already present.
+        names = [lbl.name for lbl in provider.read_task("1").labels]
+        assert names.count("feature") == 1
+
+    def test_unknown_task_is_non_fatal(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        # Should not raise.
+        provider.add_label("999", "anything")
+
+
+class TestRemoveLabel:
+    def test_removes_existing(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        provider.remove_label("1", "feature")
+        names = {lbl.name for lbl in provider.read_task("1").labels}
+        assert "feature" not in names
+
+    def test_unknown_task_is_non_fatal(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        provider.remove_label("999", "anything")
+
+
+class TestEnsureLabel:
+    def test_noop(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        # Should not raise — markdown labels are inline.
+        from wade.models.task import Label
+
+        provider.ensure_label(Label(name="anything"))
+
+
+# ---------------------------------------------------------------------------
+# Project board ops
+# ---------------------------------------------------------------------------
+
+
+class TestMoveToInProgress:
+    def test_marks_in_progress(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        assert provider.move_to_in_progress("1") is True
+        assert provider.read_task("1").state == TaskState.IN_PROGRESS
+
+    def test_unknown_returns_false(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        assert provider.move_to_in_progress("999") is False
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: file remains parseable after multiple operations.
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_full_lifecycle(self, config_factory) -> None:
+        provider = config_factory(None)
+        a = provider.create_task("Task A", "Body A", labels=["feature"])
+        b = provider.create_task("Task B", "Body B")
+        assert a.id == "1"
+        assert b.id == "2"
+
+        provider.add_label("1", "complexity:complex")
+        provider.update_task("2", body="Updated body for B")
+        provider.move_to_in_progress("1")
+        provider.close_task("2")
+
+        # Re-read the whole file via a fresh provider instance.
+        fresh = config_factory.__self__ if hasattr(config_factory, "__self__") else None  # noqa
+        # Same provider instance; reload from disk.
+        assert provider.read_task("1").state == TaskState.IN_PROGRESS
+        assert provider.read_task("2").state == TaskState.CLOSED
+        assert provider.read_task("1").complexity == Complexity.COMPLEX
+        assert provider.read_task("2").body == "Updated body for B"
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    def test_registry_returns_markdown_provider(self, tmp_path: Path) -> None:
+        config = ProjectConfig(
+            provider=ProviderConfig(
+                name=ProviderID.MARKDOWN,
+                settings={"path": "ISSUES.md"},
+            ),
+            project_root=str(tmp_path),
+        )
+        provider = get_provider(config)
+        assert isinstance(provider, MarkdownIssueProvider)
+        assert provider._path == (tmp_path / "ISSUES.md").resolve()

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -180,6 +181,41 @@ class TestPathResolution:
         provider = MarkdownIssueProvider(cfg, project_root=tmp_path)
         assert provider._path.name == "ISSUES.md"
 
+    def test_resolves_to_main_worktree_from_linked_worktree(self, tmp_path: Path) -> None:
+        """Issuing wade from a linked worktree must read/write main's ISSUES.md.
+
+        Creates a real git repo + a linked worktree. The provider must
+        resolve the relative path against main's checkout, not the worktree.
+        """
+        import subprocess
+
+        main = tmp_path / "main"
+        main.mkdir()
+        env = {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": __import__("os").environ.get("PATH", ""),
+        }
+        subprocess.run(["git", "init", "-b", "main"], cwd=main, check=True, env=env)
+        (main / "README").write_text("seed")
+        subprocess.run(["git", "add", "."], cwd=main, check=True, env=env)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=main, check=True, env=env)
+        wt = tmp_path / "wt"
+        subprocess.run(
+            ["git", "worktree", "add", str(wt), "-b", "feat/x"],
+            cwd=main,
+            check=True,
+            env=env,
+        )
+
+        cfg = ProviderConfig(name=ProviderID.MARKDOWN, settings={"path": "ISSUES.md"})
+        # Construct from inside the linked worktree.
+        provider = MarkdownIssueProvider(cfg, project_root=wt)
+        # Path must point at MAIN's ISSUES.md, not wt's.
+        assert provider._path == (main / "ISSUES.md").resolve()
+
 
 # ---------------------------------------------------------------------------
 # CRUD tests
@@ -241,21 +277,32 @@ class TestCreateTask:
     def test_creates_first_task(self, config_factory) -> None:
         provider = config_factory(None)
         task = provider.create_task("New task", "Body here", labels=["feature"])
-        assert task.id == "1"
+        # IDs are random 8-hex-char strings.
+        assert re.fullmatch(r"[0-9a-f]{8}", task.id)
         assert task.title == "New task"
         assert task.state == TaskState.OPEN
         assert any(lbl.name == "feature" for lbl in task.labels)
-        # Round-trip: read it back.
-        reread = provider.read_task("1")
+        # Round-trip: read it back via the returned id.
+        reread = provider.read_task(task.id)
         assert reread.title == "New task"
 
     def test_appends_to_existing_file(self, config_factory) -> None:
         provider = config_factory(SAMPLE_FILE)
         task = provider.create_task("Another", "Body", labels=["x"])
-        assert task.id == "4"
+        assert re.fullmatch(r"[0-9a-f]{8}", task.id)
+        assert task.id not in {"1", "2", "3"}  # Distinct from existing IDs.
         # Original tasks still readable.
         assert provider.read_task("1").title == "Add login feature"
-        assert provider.read_task("4").title == "Another"
+        assert provider.read_task(task.id).title == "Another"
+
+    def test_id_does_not_collide_with_existing(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        ids_seen: set[str] = {"1", "2", "3"}
+        # Create a handful and confirm uniqueness within the file.
+        for _ in range(10):
+            t = provider.create_task("X", "body")
+            assert t.id not in ids_seen
+            ids_seen.add(t.id)
 
     def test_no_labels(self, config_factory) -> None:
         provider = config_factory(None)
@@ -418,21 +465,19 @@ class TestRoundTrip:
         provider = config_factory(None)
         a = provider.create_task("Task A", "Body A", labels=["feature"])
         b = provider.create_task("Task B", "Body B")
-        assert a.id == "1"
-        assert b.id == "2"
+        assert a.id != b.id
+        assert re.fullmatch(r"[0-9a-f]{8}", a.id)
 
-        provider.add_label("1", "complexity:complex")
-        provider.update_task("2", body="Updated body for B")
-        provider.move_to_in_progress("1")
-        provider.close_task("2")
+        provider.add_label(a.id, "complexity:complex")
+        provider.update_task(b.id, body="Updated body for B")
+        provider.move_to_in_progress(a.id)
+        provider.close_task(b.id)
 
-        # Re-read the whole file via a fresh provider instance.
-        fresh = config_factory.__self__ if hasattr(config_factory, "__self__") else None  # noqa
-        # Same provider instance; reload from disk.
-        assert provider.read_task("1").state == TaskState.IN_PROGRESS
-        assert provider.read_task("2").state == TaskState.CLOSED
-        assert provider.read_task("1").complexity == Complexity.COMPLEX
-        assert provider.read_task("2").body == "Updated body for B"
+        # Reload from disk via the same provider instance.
+        assert provider.read_task(a.id).state == TaskState.IN_PROGRESS
+        assert provider.read_task(b.id).state == TaskState.CLOSED
+        assert provider.read_task(a.id).complexity == Complexity.COMPLEX
+        assert provider.read_task(b.id).body == "Updated body for B"
 
     def test_custom_metadata_keys_survive_writes(self, config_factory) -> None:
         # User has hand-added metadata keys wade doesn't manage.

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -204,7 +205,7 @@ class TestPathResolution:
             "GIT_AUTHOR_EMAIL": "t@t",
             "GIT_COMMITTER_NAME": "test",
             "GIT_COMMITTER_EMAIL": "t@t",
-            "PATH": __import__("os").environ.get("PATH", ""),
+            "PATH": os.environ.get("PATH", ""),
         }
         subprocess.run(["git", "init", "-b", "main"], cwd=main, check=True, env=env)
         (main / "README").write_text("seed")
@@ -285,7 +286,7 @@ class TestCreateTask:
     def test_creates_first_task(self, config_factory) -> None:
         provider = config_factory(None)
         task = provider.create_task("New task", "Body here", labels=["feature"])
-        # IDs are random 8-hex-char strings.
+        # IDs are random 8-digit decimal strings (no leading zero).
         assert re.fullmatch(r"[1-9][0-9]{7}", task.id)
         assert task.title == "New task"
         assert task.state == TaskState.OPEN
@@ -395,11 +396,9 @@ class TestCloseTask:
     def test_preserves_existing_file_mode(self, config_factory) -> None:
         # Atomic write must not silently strip group/other perms.
         provider = config_factory(SAMPLE_FILE)
-        import os as _os
-
-        _os.chmod(provider._path, 0o644)
+        os.chmod(provider._path, 0o644)
         provider.close_task("1")
-        assert _os.stat(provider._path).st_mode & 0o777 == 0o644
+        assert os.stat(provider._path).st_mode & 0o777 == 0o644
 
 
 class TestCommentOnTask:

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -158,6 +158,14 @@ class TestParseSections:
     def test_no_sections_returns_empty(self) -> None:
         assert _parse_sections("# No issues here yet\n") == []
 
+    def test_non_numeric_id_is_not_parsed_as_section(self) -> None:
+        # A regular markdown anchor heading shouldn't accidentally become
+        # an issue section just because it starts with "## #".
+        text = "## #disclaimer Some text\n\nbody\n\n## #42 Real issue\n\nreal body"
+        sections = _parse_sections(text)
+        assert [s.id for s in sections] == ["42"]
+        assert sections[0].title == "Real issue"
+
 
 # ---------------------------------------------------------------------------
 # Constructor / path resolution
@@ -383,6 +391,15 @@ class TestCloseTask:
         provider = config_factory(SAMPLE_FILE)
         with pytest.raises(TaskNotFoundError):
             provider.close_task("999")
+
+    def test_preserves_existing_file_mode(self, config_factory) -> None:
+        # Atomic write must not silently strip group/other perms.
+        provider = config_factory(SAMPLE_FILE)
+        import os as _os
+
+        _os.chmod(provider._path, 0o644)
+        provider.close_task("1")
+        assert _os.stat(provider._path).st_mode & 0o777 == 0o644
 
 
 class TestCommentOnTask:

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -501,9 +501,7 @@ class TestRoundTrip:
     def test_custom_metadata_keys_survive_writes(self, config_factory) -> None:
         # User has hand-added metadata keys wade doesn't manage.
         content = (
-            "## #1 Title\n\n"
-            "<!-- wade\nstate: open\npriority: high\nowner: alice\n-->\n\n"
-            "body\n"
+            "## #1 Title\n\n<!-- wade\nstate: open\npriority: high\nowner: alice\n-->\n\nbody\n"
         )
         provider = config_factory(content)
         # Trigger writes that don't touch the custom keys.

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -268,6 +268,14 @@ class TestListTasks:
         tasks = provider.list_tasks(state=None, limit=2)
         assert len(tasks) == 2
 
+    def test_zero_limit_returns_empty(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        assert provider.list_tasks(state=None, limit=0) == []
+
+    def test_negative_limit_returns_empty(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        assert provider.list_tasks(state=None, limit=-3) == []
+
     def test_complexity_parsed_from_label(self, config_factory) -> None:
         provider = config_factory(SAMPLE_FILE)
         task = next(t for t in provider.list_tasks() if t.id == "1")
@@ -676,6 +684,7 @@ class TestPRReviewDelegation:
         provider, gh = self._build(tmp_path)
         gh.get_repo_nwo.return_value = "owner/repo"
         assert provider.get_repo_nwo() == "owner/repo"
+        gh.get_repo_nwo.assert_called_once_with()
 
     def test_inner_github_provider_lazy_init(self, tmp_path: Path) -> None:
         # No github_provider injected — should not construct one until needed.

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -411,6 +411,84 @@ class TestCommentOnTask:
 
 
 # ---------------------------------------------------------------------------
+# Tracking-issue / parent detection
+# ---------------------------------------------------------------------------
+
+
+class TestFindParentIssue:
+    def test_finds_parent_with_checked_or_unchecked_ref(self, config_factory) -> None:
+        content = (
+            "## #100 Tracking: feature umbrella\n\n"
+            "<!-- wade\nstate: open\nlabels: feature-plan\n-->\n\n"
+            "- [ ] #1 sub one\n"
+            "- [x] #2 sub two (done)\n\n"
+            "## #1 Sub one\n\n<!-- wade\nstate: open\n-->\n\nbody\n\n"
+            "## #2 Sub two\n\n<!-- wade\nstate: closed\n-->\n\nbody\n"
+        )
+        provider = config_factory(content)
+        assert provider.find_parent_issue("1") == "100"
+        assert provider.find_parent_issue("2") == "100"
+
+    def test_returns_none_when_no_parent(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        assert provider.find_parent_issue("1") is None
+
+    def test_label_filter_excludes_non_matching_parents(self, config_factory) -> None:
+        content = (
+            "## #100 Tracking umbrella\n\n<!-- wade\nstate: open\nlabels: other\n-->\n\n"
+            "- [ ] #5 child\n\n"
+            "## #5 Child\n\n<!-- wade\nstate: open\n-->\n\nbody\n"
+        )
+        provider = config_factory(content)
+        assert provider.find_parent_issue("5", label="feature-plan") is None
+        assert provider.find_parent_issue("5") == "100"
+
+
+# ---------------------------------------------------------------------------
+# Auto-commit setting
+# ---------------------------------------------------------------------------
+
+
+class TestAutoCommit:
+    def test_disabled_by_default(self, config_factory) -> None:
+        provider = config_factory(SAMPLE_FILE)
+        assert provider._auto_commit is False
+
+    def test_enabled_via_settings(self, tmp_path: Path) -> None:
+        cfg = ProviderConfig(
+            name=ProviderID.MARKDOWN,
+            settings={"path": "ISSUES.md", "auto_commit": "true"},
+        )
+        provider = MarkdownIssueProvider(cfg, project_root=tmp_path)
+        assert provider._auto_commit is True
+
+    def test_close_invokes_git_commit_when_enabled(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        cfg = ProviderConfig(
+            name=ProviderID.MARKDOWN,
+            settings={"path": "ISSUES.md", "auto_commit": "yes"},
+        )
+        (tmp_path / "ISSUES.md").write_text(SAMPLE_FILE, encoding="utf-8")
+        provider = MarkdownIssueProvider(cfg, project_root=tmp_path)
+
+        with patch.object(provider, "_git_commit_close") as mock_commit:
+            provider.close_task("1")
+            mock_commit.assert_called_once_with("1")
+
+    def test_close_skips_git_commit_when_disabled(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        (tmp_path / "ISSUES.md").write_text(SAMPLE_FILE, encoding="utf-8")
+        cfg = ProviderConfig(name=ProviderID.MARKDOWN, settings={"path": "ISSUES.md"})
+        provider = MarkdownIssueProvider(cfg, project_root=tmp_path)
+
+        with patch.object(provider, "_git_commit_close") as mock_commit:
+            provider.close_task("1")
+            mock_commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Label management
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from wade.models.config import ProjectConfig, ProviderConfig, ProviderID
-from wade.models.review import PRReviewStatus
+from wade.models.review import PRComment, PRReviewStatus
 from wade.models.task import Complexity, TaskState
 from wade.providers.markdown import (
     DEFAULT_FILE_HEADER,
@@ -462,6 +462,21 @@ class TestAutoCommit:
         provider = MarkdownIssueProvider(cfg, project_root=tmp_path)
         assert provider._auto_commit is True
 
+    def test_enabled_with_native_bool_value(self, tmp_path: Path) -> None:
+        # ProviderConfig.settings is typed dict[str, str] but bool values
+        # can leak in via programmatic config or non-strict YAML loaders.
+        # The coercion helper must not crash on .lower().
+        cfg = ProviderConfig(name=ProviderID.MARKDOWN, settings={"path": "ISSUES.md"})
+        cfg.settings = {"path": "ISSUES.md", "auto_commit": True}  # type: ignore[dict-item]
+        provider = MarkdownIssueProvider(cfg, project_root=tmp_path)
+        assert provider._auto_commit is True
+
+    def test_disabled_with_native_bool_false(self, tmp_path: Path) -> None:
+        cfg = ProviderConfig(name=ProviderID.MARKDOWN, settings={"path": "ISSUES.md"})
+        cfg.settings = {"path": "ISSUES.md", "auto_commit": False}  # type: ignore[dict-item]
+        provider = MarkdownIssueProvider(cfg, project_root=tmp_path)
+        assert provider._auto_commit is False
+
     def test_close_invokes_git_commit_when_enabled(self, tmp_path: Path) -> None:
         from unittest.mock import patch
 
@@ -645,8 +660,9 @@ class TestPRReviewDelegation:
 
     def test_get_pr_issue_comments_delegates(self, tmp_path: Path) -> None:
         provider, gh = self._build(tmp_path)
-        gh.get_pr_issue_comments.return_value = [{"login": "u", "body": "hi"}]
-        assert provider.get_pr_issue_comments(7) == [{"login": "u", "body": "hi"}]
+        expected = [PRComment(login="u", body="hi")]
+        gh.get_pr_issue_comments.return_value = expected
+        assert provider.get_pr_issue_comments(7) == expected
         gh.get_pr_issue_comments.assert_called_once_with(7)
 
     def test_get_pr_review_status_delegates(self, tmp_path: Path) -> None:

--- a/tests/unit/test_services/test_implementation_done_sync.py
+++ b/tests/unit/test_services/test_implementation_done_sync.py
@@ -757,7 +757,7 @@ class TestSyncAutoStash:
         }
         mock_bootstrap_repo.get_dirty_file_paths.return_value = dirty_paths
         mock_stash.detect_untracked_collisions.return_value = []
-        mock_stash.create_named_stash.return_value = stash_ref
+        mock_stash.create_named_stash.return_value = (stash_ref, "wade-autostash/test")
         mock_stash.pop_stash.return_value = MagicMock(returncode=0)
         mock_branch.commits_ahead.return_value = behind
         if behind > 0:
@@ -1128,7 +1128,7 @@ class TestCatchupAutoStash:
         mock_repo.get_dirty_status.return_value = {"staged": 1, "unstaged": 0, "untracked": 0}
         mock_bootstrap_repo.get_dirty_file_paths.return_value = ["src/app.py"]
         mock_stash.detect_untracked_collisions.return_value = []
-        mock_stash.create_named_stash.return_value = "stash@{0}"
+        mock_stash.create_named_stash.return_value = ("stash@{0}", "wade-autostash/test")
         mock_stash.pop_stash.return_value = MagicMock(returncode=0)
         mock_branch.commits_ahead.return_value = 1
         mock_sync_mod.merge_branch.return_value = SyncResult(

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -2474,6 +2474,33 @@ class TestWriteConfigYolo:
 # ---------------------------------------------------------------------------
 
 
+class TestEnsureMarkdownFile:
+    """Init's markdown-file write phase."""
+
+    def test_creates_default_when_missing(self, tmp_path: Path) -> None:
+        from wade.services.init_service import _ensure_markdown_file
+
+        _ensure_markdown_file(tmp_path, {"path": "ISSUES.md"})
+        assert (tmp_path / "ISSUES.md").is_file()
+        assert "# Wade Issues" in (tmp_path / "ISSUES.md").read_text(encoding="utf-8")
+
+    def test_no_op_when_file_already_exists(self, tmp_path: Path) -> None:
+        from wade.services.init_service import _ensure_markdown_file
+
+        existing = tmp_path / "ISSUES.md"
+        existing.write_text("existing content\n", encoding="utf-8")
+        _ensure_markdown_file(tmp_path, {"path": "ISSUES.md"})
+        assert existing.read_text(encoding="utf-8") == "existing content\n"
+
+    def test_rejects_directory_at_path(self, tmp_path: Path) -> None:
+        from wade.services.init_service import _ensure_markdown_file
+
+        # A directory exists where the file should go.
+        (tmp_path / "ISSUES.md").mkdir()
+        with pytest.raises(ValueError, match="not a regular file"):
+            _ensure_markdown_file(tmp_path, {"path": "ISSUES.md"})
+
+
 class TestPatchConfigYolo:
     def test_force_writes_yolo_true(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"


### PR DESCRIPTION
## Summary

Introduces a new `MarkdownIssueProvider` that stores tasks in a single committed markdown file (`ISSUES.md`), complementing the existing GitHub Issues and ClickUp providers. PRs continue to flow through GitHub regardless of task provider choice.

## Key Changes

- **New Markdown Provider** (`src/wade/providers/markdown.py`): reads/writes tasks as `## #<id> <title>` sections with a wade-managed `<!-- wade -->` metadata block per issue. Random 8-digit decimal IDs (collision-free across worktrees, compatible with the codebase's `#\d+` parsing). Resolves the file path against the main worktree so every linked worktree edits the same physical file. fcntl-/msvcrt-locked read-modify-write cycle so concurrent writers don't lose updates. Atomic writes that preserve existing file mode. Optional `auto_commit` setting commits the close-task change automatically. `find_parent_issue` scans checklist refs in section bodies so tracking-issue features work.
- **PR-review delegation** (`src/wade/providers/_pr_delegate.py`): new `GitHubPRDelegateMixin` so non-GitHub providers (Markdown, ClickUp) keep working `wade fetch-reviews` and the auto-poll loop by delegating PR-review APIs to a lazily-constructed `GitHubProvider`.
- **`PRComment` Pydantic model**: replaces `list[dict[str, str]]` on `AbstractTaskProvider.get_pr_issue_comments`, applied to GitHub, mixin consumers, and `detect_coderabbit_review_status`.
- **`wade init`** prompts for a Markdown path alongside GitHub/ClickUp and pre-creates `ISSUES.md` with the default header.
- **Docs**: new "Task Providers" section in README; `GitHubPRDelegateMixin` mention in AGENTS.md.

## Test plan

- 70 markdown-provider unit tests (parsing, CRUD, labels, locking, PR delegation, find_parent_issue, auto_commit) + 6 integration tests (real git repo + linked worktree, concurrent creates under load).
- ClickUp / GitHub regression suites pass (mixin and `PRComment` refactor verified).
- ruff + ruff format + mypy --strict clean.

## Drive-by fix (not part of this feature)

- `c6af3a9 fix(tests): align auto-stash mocks with create_named_stash's tuple return` — PR #306 mocked `git_stash.create_named_stash` with a bare string, but the real function returns `tuple[str, str]`; `core.py:1920` unpacks it into `stash_ref, stash_name` and raised `ValueError: too many values to unpack`, which has been failing CI on `main` since #306 merged. Bundled here so this PR's CI could go green. Happy to split into a separate PR if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Markdown-backed task provider (ISSUES.md) with CRUD, comments, labels, concurrency-safe atomic persistence, optional auto-commit, and GitHub PR-review delegation; ClickUp now delegates PR-review APIs to GitHub.
  * CLI init/registry now support selecting a "markdown" task provider and lazy provider loading.

* **Documentation**
  * Added "Task Providers" docs with examples and Markdown provider configuration.

* **Tests**
  * Extensive unit and integration tests for the Markdown provider, worktree resolution, concurrency, and PR-review delegation; updated tests for PR comment typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->