### PR TITLE
feat: auto-stash dirty worktree during sync/catchup with safe recovery

### DIFF
--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -1,6 +1,9 @@
 164c355e:
   down: 0
   up: 1
+1c18f1d4:
+  down: 0
+  up: 1
 3463fbd4:
   down: 0
   up: 1
@@ -15,7 +18,7 @@ b6a3a637:
   up: 1
 cc91cd11:
   down: 0
-  up: 2
+  up: 3
 cedeaad0:
   down: 1
   up: 1

--- a/src/wade/cli/implementation_session.py
+++ b/src/wade/cli/implementation_session.py
@@ -32,6 +32,11 @@ def catchup(
     main_branch: str | None = typer.Option(
         None, "--main-branch", help="Override main branch name."
     ),
+    no_stash: bool = typer.Option(
+        False,
+        "--no-stash",
+        help="Disable auto-stash: fail immediately on any uncommitted changes.",
+    ),
 ) -> None:
     """Sync current branch with base branch (early catchup at session startup)."""
     from wade.cli.session_shared import handle_sync_result
@@ -42,6 +47,7 @@ def catchup(
         dry_run=dry_run,
         main_branch=main_branch,
         json_output=json_output,
+        no_stash=no_stash,
     )
     # Catchup has custom success messages for dry-run vs real merge
     if result.success:
@@ -77,6 +83,11 @@ def sync(
     main_branch: str | None = typer.Option(
         None, "--main-branch", help="Override main branch name."
     ),
+    no_stash: bool = typer.Option(
+        False,
+        "--no-stash",
+        help="Disable auto-stash: fail immediately on any uncommitted changes.",
+    ),
 ) -> None:
     """Sync current branch with main."""
     from wade.cli.session_shared import handle_sync_result
@@ -87,6 +98,7 @@ def sync(
         main_branch=main_branch,
         json_output=json_output,
         session_type="implementation",
+        no_stash=no_stash,
     )
     handle_sync_result(
         result, json_output=json_output, next_step_hint="wade implementation-session done"

--- a/src/wade/git/stash.py
+++ b/src/wade/git/stash.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import structlog
+from pydantic import BaseModel
 
 from wade.git.repo import GitError, _run_git
 
@@ -15,14 +16,21 @@ log = structlog.get_logger(__name__)
 AUTOSTASH_PREFIX = "wade-autostash"
 
 
+class AutoStashEntry(BaseModel):
+    """A single wade autostash entry from the git stash list."""
+
+    ref: str
+    message: str
+
+
 def _stash_message(session_type: str, branch: str) -> str:
     ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     safe_branch = branch.replace("/", "_")
     return f"{AUTOSTASH_PREFIX}/{session_type}/{safe_branch}/{ts}"
 
 
-def create_named_stash(session_type: str, branch: str, cwd: Path) -> str:
-    """Stash staged+unstaged tracked-file changes and return the stash ref.
+def create_named_stash(session_type: str, branch: str, cwd: Path) -> tuple[str, str]:
+    """Stash staged+unstaged tracked-file changes and return (ref, message).
 
     Untracked files are intentionally left in place — call
     detect_untracked_collisions() before this to ensure they won't conflict.
@@ -33,7 +41,7 @@ def create_named_stash(session_type: str, branch: str, cwd: Path) -> str:
         cwd: Working directory inside the git repo.
 
     Returns:
-        The stash ref string (e.g. ``stash@{0}``).
+        Tuple of (stash_ref, stash_message), e.g. (``stash@{0}``, ``wade-autostash/...``).
 
     Raises:
         GitError: If the stash command fails or nothing was stashed.
@@ -49,7 +57,7 @@ def create_named_stash(session_type: str, branch: str, cwd: Path) -> str:
     if ref is None:
         raise GitError(f"Stash created but ref not found for: {message!r}")
     log.debug("git.stash.created", ref=ref, message=message)
-    return ref
+    return ref, message
 
 
 def _find_stash_ref(message: str, cwd: Path) -> str | None:
@@ -84,12 +92,12 @@ def drop_stash(stash_ref: str, cwd: Path) -> subprocess.CompletedProcess[str]:
     return _run_git("stash", "drop", stash_ref, cwd=cwd, check=False)
 
 
-def list_wade_autostashes(cwd: Path) -> list[dict[str, str]]:
-    """Return all wade autostash entries as ``{'ref': ..., 'message': ...}`` dicts."""
+def list_wade_autostashes(cwd: Path) -> list[AutoStashEntry]:
+    """Return all wade autostash entries."""
     result = _run_git("stash", "list", "--format=%gd %gs", cwd=cwd, check=False)
     if result.returncode != 0:
         return []
-    entries: list[dict[str, str]] = []
+    entries: list[AutoStashEntry] = []
     for line in result.stdout.splitlines():
         if not line.strip():
             continue
@@ -98,7 +106,7 @@ def list_wade_autostashes(cwd: Path) -> list[dict[str, str]]:
             continue
         ref, subject = parts[0], parts[1]
         if AUTOSTASH_PREFIX in subject:
-            entries.append({"ref": ref, "message": subject})
+            entries.append(AutoStashEntry(ref=ref, message=subject))
     return entries
 
 

--- a/src/wade/git/stash.py
+++ b/src/wade/git/stash.py
@@ -1,0 +1,150 @@
+"""Git stash helpers for wade auto-stash operations."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import structlog
+
+from wade.git.repo import GitError, _run_git
+
+log = structlog.get_logger(__name__)
+
+AUTOSTASH_PREFIX = "wade-autostash"
+
+
+def _stash_message(session_type: str, branch: str) -> str:
+    ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    safe_branch = branch.replace("/", "_")
+    return f"{AUTOSTASH_PREFIX}/{session_type}/{safe_branch}/{ts}"
+
+
+def create_named_stash(session_type: str, branch: str, cwd: Path) -> str:
+    """Stash staged+unstaged tracked-file changes and return the stash ref.
+
+    Untracked files are intentionally left in place — call
+    detect_untracked_collisions() before this to ensure they won't conflict.
+
+    Args:
+        session_type: Session type label (e.g. "implementation").
+        branch: Current branch name (embedded in the stash message).
+        cwd: Working directory inside the git repo.
+
+    Returns:
+        The stash ref string (e.g. ``stash@{0}``).
+
+    Raises:
+        GitError: If the stash command fails or nothing was stashed.
+    """
+    message = _stash_message(session_type, branch)
+    result = _run_git("stash", "push", "-m", message, cwd=cwd, check=False)
+    if result.returncode != 0:
+        raise GitError(f"git stash push failed: {result.stderr.strip()}")
+    stdout = result.stdout.strip()
+    if stdout == "No local changes to save":
+        raise GitError("No local changes to save")
+    ref = _find_stash_ref(message, cwd)
+    if ref is None:
+        raise GitError(f"Stash created but ref not found for: {message!r}")
+    log.debug("git.stash.created", ref=ref, message=message)
+    return ref
+
+
+def _find_stash_ref(message: str, cwd: Path) -> str | None:
+    """Return the stash ref (e.g. ``stash@{0}``) whose subject contains *message*."""
+    result = _run_git("stash", "list", "--format=%gd %gs", cwd=cwd, check=False)
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(" ", 1)
+        if len(parts) < 2:
+            continue
+        ref, subject = parts[0], parts[1]
+        if message in subject:
+            return ref
+    return None
+
+
+def pop_stash(stash_ref: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Apply and remove *stash_ref*. Returns CompletedProcess (never raises)."""
+    return _run_git("stash", "pop", stash_ref, cwd=cwd, check=False)
+
+
+def apply_stash(stash_ref: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Apply *stash_ref* without removing it. Returns CompletedProcess."""
+    return _run_git("stash", "apply", stash_ref, cwd=cwd, check=False)
+
+
+def drop_stash(stash_ref: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Remove *stash_ref* from the stash list. Returns CompletedProcess."""
+    return _run_git("stash", "drop", stash_ref, cwd=cwd, check=False)
+
+
+def list_wade_autostashes(cwd: Path) -> list[dict[str, str]]:
+    """Return all wade autostash entries as ``{'ref': ..., 'message': ...}`` dicts."""
+    result = _run_git("stash", "list", "--format=%gd %gs", cwd=cwd, check=False)
+    if result.returncode != 0:
+        return []
+    entries: list[dict[str, str]] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(" ", 1)
+        if len(parts) < 2:
+            continue
+        ref, subject = parts[0], parts[1]
+        if AUTOSTASH_PREFIX in subject:
+            entries.append({"ref": ref, "message": subject})
+    return entries
+
+
+def detect_untracked_collisions(cwd: Path, merge_ref: str) -> list[str]:
+    """Return untracked file paths that would be overwritten by merging *merge_ref*.
+
+    Uses ``git diff --name-only --diff-filter=A HEAD...<merge_ref>`` to find
+    files newly introduced by the incoming commits, then intersects with the
+    untracked files in the working directory.
+
+    The collision check is conservative: it reports paths that appear in both
+    sets, which is a superset of what git would actually reject (some cases are
+    fine if the file content matches). This avoids any mutation before the check.
+
+    Args:
+        cwd: Working directory inside the git repo.
+        merge_ref: The ref to merge (e.g. ``origin/main``).
+
+    Returns:
+        Sorted list of colliding paths relative to the repo root (may be empty).
+    """
+    diff_result = _run_git(
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        f"HEAD...{merge_ref}",
+        cwd=cwd,
+        check=False,
+    )
+    if diff_result.returncode != 0:
+        return []
+    added_files = {line for line in diff_result.stdout.splitlines() if line.strip()}
+    if not added_files:
+        return []
+
+    status_result = _run_git("status", "--porcelain", cwd=cwd, check=False)
+    if status_result.returncode != 0:
+        return []
+    untracked: set[str] = set()
+    for line in status_result.stdout.splitlines():
+        if not line.startswith("?? "):
+            continue
+        path = line[3:]
+        if path.startswith('"') and path.endswith('"'):
+            path = path[1:-1]
+        if not path.endswith("/"):
+            untracked.add(path)
+
+    return sorted(added_files & untracked)

--- a/src/wade/models/session.py
+++ b/src/wade/models/session.py
@@ -63,6 +63,10 @@ class SyncEventType(StrEnum):
     MERGED = "merged"
     CONFLICT = "conflict"
     CONFLICT_DIFF = "conflict_diff"
+    AUTOSTASHED = "autostashed"
+    STASH_RESTORED = "stash_restored"
+    STASH_LEFT_BEHIND = "stash_left_behind"
+    UNTRACKED_CONFLICT = "untracked_conflict"
 
 
 class SyncEvent(BaseModel):

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -12,13 +12,12 @@ import os
 import re
 import tempfile
 import webbrowser
-from dataclasses import dataclass
-from dataclasses import field as _field
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import structlog
+from pydantic import BaseModel, Field
 
 from wade.ai_tools.base import AbstractAITool
 from wade.config.loader import load_config
@@ -1542,16 +1541,16 @@ class _DirtyCategory(StrEnum):
     USER_DIRTY = "user_dirty"
 
 
-@dataclass
-class _PreflightOK:
+class _PreflightOK(BaseModel):
     """Successful pre-flight result — git repo and branch checks passed."""
 
     repo_root: Path
+    cwd: Path
     current_branch: str
     resolved_main: str
     dirty_category: _DirtyCategory
-    session_files: list[str] = _field(default_factory=list)
-    dirty_paths: list[str] = _field(default_factory=list)
+    session_files: list[str] = Field(default_factory=list)
+    dirty_paths: list[str] = Field(default_factory=list)
     has_tracked_changes: bool = False
 
 
@@ -1611,6 +1610,7 @@ def _sync_preflight(
     if git_repo.is_clean(cwd):
         return _PreflightOK(
             repo_root=repo_root,
+            cwd=cwd,
             current_branch=current,
             resolved_main=resolved_main,
             dirty_category=_DirtyCategory.CLEAN,
@@ -1623,6 +1623,7 @@ def _sync_preflight(
     if not non_session_paths:
         return _PreflightOK(
             repo_root=repo_root,
+            cwd=cwd,
             current_branch=current,
             resolved_main=resolved_main,
             dirty_category=_DirtyCategory.ARTIFACTS_ONLY,
@@ -1635,6 +1636,7 @@ def _sync_preflight(
     has_tracked_changes = dirty_status["staged"] > 0 or dirty_status["unstaged"] > 0
     return _PreflightOK(
         repo_root=repo_root,
+        cwd=cwd,
         current_branch=current,
         resolved_main=resolved_main,
         dirty_category=_DirtyCategory.USER_DIRTY,
@@ -1650,7 +1652,7 @@ def _emit_dirty_worktree_error(
     json_output: bool,
 ) -> None:
     """Emit ERROR dirty_worktree event and console output (--no-stash path)."""
-    detail_str = _format_uncommitted_summary(preflight.repo_root)
+    detail_str = _format_uncommitted_summary(preflight.cwd)
     if preflight.session_files:
         emit(
             SyncEventType.ERROR,
@@ -1915,8 +1917,8 @@ def sync(
 
         if preflight.has_tracked_changes:
             try:
-                stash_ref = git_stash.create_named_stash(session_type, current, cwd)
-                emit(SyncEventType.AUTOSTASHED, stash_ref=stash_ref)
+                stash_ref, stash_name = git_stash.create_named_stash(session_type, current, cwd)
+                emit(SyncEventType.AUTOSTASHED, stash_ref=stash_ref, stash_name=stash_name)
                 if not json_output:
                     console.info(f"Stashed local changes: {stash_ref}")
             except GitError as exc:
@@ -2062,8 +2064,8 @@ def catchup(
 
         if preflight.has_tracked_changes:
             try:
-                stash_ref = git_stash.create_named_stash("catchup", current, cwd)
-                emit(SyncEventType.AUTOSTASHED, stash_ref=stash_ref)
+                stash_ref, stash_name = git_stash.create_named_stash("catchup", current, cwd)
+                emit(SyncEventType.AUTOSTASHED, stash_ref=stash_ref, stash_name=stash_name)
                 if not json_output:
                     console.info(f"Stashed local changes: {stash_ref}")
             except GitError as exc:
@@ -2093,12 +2095,15 @@ def catchup(
         abort_on_conflict=True,
     )
 
+    stash_restored = True
     if stash_ref is not None:
         # Merge aborted on conflict or succeeded — restore stash either way.
-        _handle_stash_restoration(stash_ref, cwd, result.success, emit, json_output)
+        stash_restored = _handle_stash_restoration(
+            stash_ref, cwd, result.success, emit, json_output
+        )
 
     return SyncResult(
-        success=result.success,
+        success=result.success and stash_restored,
         current_branch=result.current_branch,
         main_branch=result.main_branch,
         conflicts=result.conflicts,

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -12,6 +12,9 @@ import os
 import re
 import tempfile
 import webbrowser
+from dataclasses import dataclass
+from dataclasses import field as _field
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +25,7 @@ from wade.config.loader import load_config
 from wade.git import branch as git_branch
 from wade.git import pr as git_pr
 from wade.git import repo as git_repo
+from wade.git import stash as git_stash
 from wade.git import sync as git_sync
 from wade.git import worktree as git_worktree
 from wade.git.repo import GitError
@@ -1530,22 +1534,46 @@ def _build_pr_body(
 # ---------------------------------------------------------------------------
 
 
+class _DirtyCategory(StrEnum):
+    """Categorization of the working tree's dirty state for sync pre-flight."""
+
+    CLEAN = "clean"
+    ARTIFACTS_ONLY = "artifacts_only"
+    USER_DIRTY = "user_dirty"
+
+
+@dataclass
+class _PreflightOK:
+    """Successful pre-flight result — git repo and branch checks passed."""
+
+    repo_root: Path
+    current_branch: str
+    resolved_main: str
+    dirty_category: _DirtyCategory
+    session_files: list[str] = _field(default_factory=list)
+    dirty_paths: list[str] = _field(default_factory=list)
+    has_tracked_changes: bool = False
+
+
 def _sync_preflight(
     cwd: Path,
     main_branch_override: str | None,
     config: Any,
     emit: Any,
-    *,
-    json_output: bool = False,
-) -> tuple[Path, str, str] | SyncResult:
+) -> _PreflightOK | SyncResult:
     """Run pre-flight checks shared by sync() and catchup().
 
-    Resolves the repo root, current branch, and base branch. Emits ERROR
-    events via ``emit`` on failure (which populates the caller's events list).
+    Resolves the repo root, current branch, and base branch. Categorizes the
+    working-tree dirty state but does NOT make the pass/fail decision for dirty
+    trees — callers decide whether to auto-stash or error based on the returned
+    _DirtyCategory.
+
+    Emits ERROR events via ``emit`` on hard failures (not_git_repo, detached_head,
+    no_main_branch, on_main_branch).
 
     Returns:
-        (repo_root, current_branch, resolved_main) on success.
-        SyncResult(events=[]) on failure — caller must add its events list.
+        _PreflightOK on success (caller handles dirty_category).
+        SyncResult(success=False) on hard failure.
     """
     try:
         repo_root = git_repo.get_repo_root(cwd)
@@ -1580,38 +1608,110 @@ def _sync_preflight(
         emit(SyncEventType.ERROR, reason="on_main_branch")
         return SyncResult(success=False, current_branch=current, main_branch=resolved_main)
 
-    if not git_repo.is_clean(cwd):
-        detail_str = _format_uncommitted_summary(cwd)
-        dirty_paths = _get_dirty_file_paths(cwd)
-        session_files = _identify_session_dirty_files(dirty_paths)
-        if session_files:
-            emit(
-                SyncEventType.ERROR,
-                reason="dirty_worktree",
-                details=detail_str,
-                session_files=session_files,
-            )
-        else:
-            emit(SyncEventType.ERROR, reason="dirty_worktree", details=detail_str)
-        if not json_output:
-            console.error(f"Working tree is dirty ({detail_str})")
-            if session_files:
-                console.warn(
-                    "The following dirty files are wade session artifacts"
-                    " \N{EM DASH} do NOT commit them."
-                )
-                console.hint("Restore with: git checkout -- <file>")
-                for sf in session_files:
-                    console.detail(sf)
-                console.empty()
-            console.hint(
-                "Commit or stash your non-session changes first"
-                if session_files
-                else "Commit or stash your changes first"
-            )
-        return SyncResult(success=False, current_branch=current, main_branch=resolved_main)
+    if git_repo.is_clean(cwd):
+        return _PreflightOK(
+            repo_root=repo_root,
+            current_branch=current,
+            resolved_main=resolved_main,
+            dirty_category=_DirtyCategory.CLEAN,
+        )
 
-    return (repo_root, current, resolved_main)
+    dirty_paths = _get_dirty_file_paths(cwd)
+    session_files = _identify_session_dirty_files(dirty_paths)
+    non_session_paths = [p for p in dirty_paths if p not in set(session_files)]
+
+    if not non_session_paths:
+        return _PreflightOK(
+            repo_root=repo_root,
+            current_branch=current,
+            resolved_main=resolved_main,
+            dirty_category=_DirtyCategory.ARTIFACTS_ONLY,
+            session_files=session_files,
+            dirty_paths=dirty_paths,
+        )
+
+    # Determine if staged/unstaged tracked changes exist (stash is only useful for these).
+    dirty_status = git_repo.get_dirty_status(cwd)
+    has_tracked_changes = dirty_status["staged"] > 0 or dirty_status["unstaged"] > 0
+    return _PreflightOK(
+        repo_root=repo_root,
+        current_branch=current,
+        resolved_main=resolved_main,
+        dirty_category=_DirtyCategory.USER_DIRTY,
+        session_files=session_files,
+        dirty_paths=dirty_paths,
+        has_tracked_changes=has_tracked_changes,
+    )
+
+
+def _emit_dirty_worktree_error(
+    emit: Any,
+    preflight: _PreflightOK,
+    json_output: bool,
+) -> None:
+    """Emit ERROR dirty_worktree event and console output (--no-stash path)."""
+    detail_str = _format_uncommitted_summary(preflight.repo_root)
+    if preflight.session_files:
+        emit(
+            SyncEventType.ERROR,
+            reason="dirty_worktree",
+            details=detail_str,
+            session_files=preflight.session_files,
+        )
+    else:
+        emit(SyncEventType.ERROR, reason="dirty_worktree", details=detail_str)
+    if not json_output:
+        console.error(f"Working tree is dirty ({detail_str})")
+        if preflight.session_files:
+            console.warn(
+                "The following dirty files are wade session artifacts"
+                " \N{EM DASH} do NOT commit them."
+            )
+            console.hint("Restore with: git checkout -- <file>")
+            for sf in preflight.session_files:
+                console.detail(sf)
+            console.empty()
+        console.hint(
+            "Commit or stash your non-session changes first"
+            if preflight.session_files
+            else "Commit or stash your changes first"
+        )
+
+
+def _handle_stash_restoration(
+    stash_ref: str,
+    cwd: Path,
+    result_success: bool,
+    emit: Any,
+    json_output: bool,
+) -> bool:
+    """Pop the stash and emit events. Returns True if stash was cleanly restored.
+
+    On a stash-pop conflict the stash is left in place and STASH_LEFT_BEHIND is
+    emitted. Callers should treat a False return as a sync failure.
+    """
+    pop_result = git_stash.pop_stash(stash_ref, cwd)
+    if pop_result.returncode == 0:
+        emit(SyncEventType.STASH_RESTORED, stash_ref=stash_ref)
+        if not json_output:
+            console.success("Restored stashed changes.")
+        return True
+
+    recovery_cmd = f"git stash apply {stash_ref}"
+    emit(
+        SyncEventType.STASH_LEFT_BEHIND,
+        stash_ref=stash_ref,
+        recovery_hint=recovery_cmd,
+    )
+    if not json_output:
+        if result_success:
+            console.error("Conflict while restoring stash \N{EM DASH} changes preserved:")
+        else:
+            console.error(
+                "Could not restore stash after failed merge \N{EM DASH} changes preserved:"
+            )
+        console.hint(f"Recover with: {recovery_cmd}")
+    return False
 
 
 def _merge_base(
@@ -1748,14 +1848,15 @@ def sync(
     json_output: bool = False,
     project_root: Path | None = None,
     session_type: str = "implementation",
+    no_stash: bool = False,
 ) -> SyncResult:
     """Sync current branch with main.
 
     Flow:
-    1. Pre-flight checks (in git repo, not on main, clean worktree)
-    2. Fetch origin
-    3. Count commits behind
-    4. Merge (unless dry-run or up-to-date)
+    1. Pre-flight checks (in git repo, not on main)
+    2. Handle dirty worktree: auto-stash user changes or fail with --no-stash
+    3. Fetch origin, count commits behind, merge
+    4. Restore stash (or emit STASH_LEFT_BEHIND on pop conflict)
     5. Emit structured events
     """
     config = load_config(project_root)
@@ -1768,7 +1869,7 @@ def sync(
         if json_output:
             console.raw(json.dumps({"event": event, **data}) + "\n")
 
-    preflight = _sync_preflight(cwd, main_branch, config, emit, json_output=json_output)
+    preflight = _sync_preflight(cwd, main_branch, config, emit)
     if isinstance(preflight, SyncResult):
         return SyncResult(
             success=preflight.success,
@@ -1776,7 +1877,60 @@ def sync(
             main_branch=preflight.main_branch,
             events=events,
         )
-    repo_root, current, resolved_main = preflight
+    repo_root = preflight.repo_root
+    current = preflight.current_branch
+    resolved_main = preflight.resolved_main
+
+    stash_ref: str | None = None
+
+    if preflight.dirty_category == _DirtyCategory.USER_DIRTY:
+        if no_stash:
+            _emit_dirty_worktree_error(emit, preflight, json_output)
+            return SyncResult(
+                success=False, current_branch=current, main_branch=resolved_main, events=events
+            )
+
+        # Fetch to get the latest merge target for the collision probe.
+        merge_ref_for_probe = resolved_main
+        has_remote = False
+        try:
+            has_remote = git_repo.has_remote(repo_root)
+            if has_remote:
+                git_sync.fetch_origin(repo_root)
+                merge_ref_for_probe = f"origin/{resolved_main}"
+        except GitError:
+            pass
+
+        collisions = git_stash.detect_untracked_collisions(cwd, merge_ref_for_probe)
+        if collisions:
+            emit(SyncEventType.UNTRACKED_CONFLICT, paths="\n".join(collisions))
+            if not json_output:
+                console.error("Untracked files would be overwritten by the merge:")
+                for p in collisions:
+                    console.detail(p)
+                console.hint("Commit, move, or delete these files before syncing.")
+            return SyncResult(
+                success=False, current_branch=current, main_branch=resolved_main, events=events
+            )
+
+        if preflight.has_tracked_changes:
+            try:
+                stash_ref = git_stash.create_named_stash(session_type, current, cwd)
+                emit(SyncEventType.AUTOSTASHED, stash_ref=stash_ref)
+                if not json_output:
+                    console.info(f"Stashed local changes: {stash_ref}")
+            except GitError as exc:
+                emit(SyncEventType.ERROR, reason="stash_failed", details=str(exc))
+                if not json_output:
+                    console.error(f"Could not stash local changes: {exc}")
+                return SyncResult(
+                    success=False, current_branch=current, main_branch=resolved_main, events=events
+                )
+    elif preflight.dirty_category == _DirtyCategory.ARTIFACTS_ONLY and no_stash:
+        _emit_dirty_worktree_error(emit, preflight, json_output)
+        return SyncResult(
+            success=False, current_branch=current, main_branch=resolved_main, events=events
+        )
 
     # Non-blocking: warn if wade-only session files are tracked in git
     tracked_managed = _check_tracked_managed_files(cwd)
@@ -1800,6 +1954,7 @@ def sync(
     if not json_output:
         console.step(f"Syncing {current} with {resolved_main}")
 
+    # When we stashed, abort on conflict so the worktree stays clean.
     result = _merge_base(
         repo_root,
         current,
@@ -1807,9 +1962,24 @@ def sync(
         emit,
         dry_run=dry_run,
         json_output=json_output,
-        abort_on_conflict=False,
+        abort_on_conflict=stash_ref is not None,
         session_type=session_type,
     )
+
+    if stash_ref is not None:
+        if result.success:
+            stash_ok = _handle_stash_restoration(stash_ref, cwd, True, emit, json_output)
+            if not stash_ok:
+                return SyncResult(
+                    success=False,
+                    current_branch=result.current_branch,
+                    main_branch=result.main_branch,
+                    events=events,
+                )
+        else:
+            # Merge was aborted (abort_on_conflict=True) — restore stash.
+            _handle_stash_restoration(stash_ref, cwd, False, emit, json_output)
+
     return SyncResult(
         success=result.success,
         current_branch=result.current_branch,
@@ -1825,6 +1995,7 @@ def catchup(
     main_branch: str | None = None,
     json_output: bool = False,
     project_root: Path | None = None,
+    no_stash: bool = False,
 ) -> SyncResult:
     """Sync the worktree branch with its base branch at session startup.
 
@@ -1847,7 +2018,7 @@ def catchup(
         if json_output:
             console.raw(json.dumps({"event": event, **data}) + "\n")
 
-    preflight = _sync_preflight(cwd, main_branch, config, emit, json_output=json_output)
+    preflight = _sync_preflight(cwd, main_branch, config, emit)
     if isinstance(preflight, SyncResult):
         return SyncResult(
             success=preflight.success,
@@ -1855,7 +2026,58 @@ def catchup(
             main_branch=preflight.main_branch,
             events=events,
         )
-    repo_root, current, resolved_main = preflight
+    repo_root = preflight.repo_root
+    current = preflight.current_branch
+    resolved_main = preflight.resolved_main
+
+    stash_ref: str | None = None
+
+    if preflight.dirty_category == _DirtyCategory.USER_DIRTY:
+        if no_stash:
+            _emit_dirty_worktree_error(emit, preflight, json_output)
+            return SyncResult(
+                success=False, current_branch=current, main_branch=resolved_main, events=events
+            )
+
+        # Fetch to get the latest merge target for the collision probe.
+        merge_ref_for_probe = resolved_main
+        try:
+            if git_repo.has_remote(repo_root):
+                git_sync.fetch_origin(repo_root)
+                merge_ref_for_probe = f"origin/{resolved_main}"
+        except GitError:
+            pass
+
+        collisions = git_stash.detect_untracked_collisions(cwd, merge_ref_for_probe)
+        if collisions:
+            emit(SyncEventType.UNTRACKED_CONFLICT, paths="\n".join(collisions))
+            if not json_output:
+                console.error("Untracked files would be overwritten by the merge:")
+                for p in collisions:
+                    console.detail(p)
+                console.hint("Commit, move, or delete these files before syncing.")
+            return SyncResult(
+                success=False, current_branch=current, main_branch=resolved_main, events=events
+            )
+
+        if preflight.has_tracked_changes:
+            try:
+                stash_ref = git_stash.create_named_stash("catchup", current, cwd)
+                emit(SyncEventType.AUTOSTASHED, stash_ref=stash_ref)
+                if not json_output:
+                    console.info(f"Stashed local changes: {stash_ref}")
+            except GitError as exc:
+                emit(SyncEventType.ERROR, reason="stash_failed", details=str(exc))
+                if not json_output:
+                    console.error(f"Could not stash local changes: {exc}")
+                return SyncResult(
+                    success=False, current_branch=current, main_branch=resolved_main, events=events
+                )
+    elif preflight.dirty_category == _DirtyCategory.ARTIFACTS_ONLY and no_stash:
+        _emit_dirty_worktree_error(emit, preflight, json_output)
+        return SyncResult(
+            success=False, current_branch=current, main_branch=resolved_main, events=events
+        )
 
     emit(SyncEventType.PREFLIGHT_OK, current_branch=current, main_branch=resolved_main)
     if not json_output:
@@ -1870,6 +2092,11 @@ def catchup(
         json_output=json_output,
         abort_on_conflict=True,
     )
+
+    if stash_ref is not None:
+        # Merge aborted on conflict or succeeded — restore stash either way.
+        _handle_stash_restoration(stash_ref, cwd, result.success, emit, json_output)
+
     return SyncResult(
         success=result.success,
         current_branch=result.current_branch,

--- a/templates/skills/implementation-session/SKILL.md
+++ b/templates/skills/implementation-session/SKILL.md
@@ -72,6 +72,12 @@ Run `wade implementation-session check` as your **first action**:
 at startup (before this session begins). The catchup output appears in the
 startup log.
 
+**Auto-stash**: If the worktree has staged or unstaged user changes, catchup
+automatically stashes them, runs the merge, and restores them. Session
+artifacts (PLAN.md, PR-SUMMARY.md, etc.) are left in place — they are never
+stashed. Use `--no-stash` to get the old strict behavior (fail immediately on
+any uncommitted changes).
+
 **If the startup output reports a merge conflict**, note that the catchup
 command always aborts the merge and leaves the worktree clean — there are no
 conflict markers to resolve. `wade implementation-session catchup --json` is
@@ -91,6 +97,17 @@ Then resolve using the standard flow:
 3. Resolve the conflict markers in each file
 4. Stage only the resolved files: `git add <file1> <file2> ...`
 5. Complete the merge: `git commit --no-edit`
+
+**If catchup reports an `untracked_conflict` error**, untracked files in your
+worktree would be overwritten by the merge. The paths are listed in the error.
+Commit, move, or delete them, then re-run catchup.
+
+**If catchup reports a `stash_left_behind` error**, the stash pop conflicted
+after a merge. Your changes are preserved in the named stash. Recover with:
+
+```bash
+git stash apply <stash-ref>   # ref shown in the error output
+```
 
 The closing `sync` step remains necessary for changes that land on the base
 branch *during* your implementation session.
@@ -156,13 +173,15 @@ the PR body. If the file is missing, the PR will have no description.
 > conflicts. The actual sync is performed as part of the closing workflow below
 > (Step 3). Do not run sync separately.
 
-### Step 1: Commit uncommitted work
+### Step 1: Commit your implementation work
 
 ```bash
 git status --porcelain
 ```
 
-If there is output, stage and commit your changes before syncing.
+If there is output from files you authored, stage and commit them before
+syncing. Wade session artifacts (PLAN.md, PR-SUMMARY.md, etc.) can be left
+dirty — sync will skip stashing them.
 
 ### Step 2: Run the sync command
 
@@ -170,20 +189,32 @@ If there is output, stage and commit your changes before syncing.
 wade implementation-session sync --json
 ```
 
+**Auto-stash**: sync automatically stashes any staged or unstaged tracked user
+changes, runs the merge, then restores them. You do not need to stash manually.
+Add `--no-stash` to disable auto-stash and restore the strict old behavior
+(fail immediately on any uncommitted changes).
+
 ### Step 3: Handle the result
 
 **Exit code 0 — Success**: Branch is up to date with main. Proceed to closing.
 
-**Exit code 2 — Conflict**: The merge is paused due to conflicts:
-1. Run `git diff --name-only --diff-filter=U` to list conflicted files
-2. Read each conflicted file — understand both sides of the conflict
-3. Resolve the conflict markers in each file
-4. Stage only the resolved files: `git add <file1> <file2> ...`
-5. Complete the merge: `git commit --no-edit`
-6. Re-run `wade implementation-session sync --json` to verify clean
+**Exit code 2 — Conflict**: The merge conflicted. When auto-stash is active the
+merge is aborted and your stash is restored automatically — the worktree is
+clean. Re-run sync after resolving the conflict manually (see Catchup section).
 
-**Exit code 4 — Pre-flight failure**: Report the issue (dirty worktree, not
-in repo, already on main) and suggest how to fix it.
+**Exit code 4 — Pre-flight failure**: Report the issue (not in git repo, already
+on main, or `--no-stash` with a dirty worktree) and suggest how to fix it.
+
+**`untracked_conflict` error**: Untracked files in your worktree would be
+overwritten by the incoming merge. Commit, move, or delete the listed paths
+before re-running sync.
+
+**`stash_left_behind` error**: The stash pop conflicted after a successful
+merge. Your changes are preserved. Recover with:
+
+```bash
+git stash apply <stash-ref>   # ref shown in the error output
+```
 
 **Never re-implement git operations yourself.** Always use `wade implementation-session sync`.
 

--- a/tests/integration/test_autostash.py
+++ b/tests/integration/test_autostash.py
@@ -1,0 +1,259 @@
+"""Integration tests for auto-stash sync/catchup — real git repos, no mocks."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from wade.models.config import ProjectConfig, ProjectSettings
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command in *repo* and return stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, name: str, content: str, message: str) -> None:
+    (repo / name).write_text(content)
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", message)
+
+
+def _setup_branch_behind_main(repo: Path, branch: str = "feat/42-test") -> tuple[Path, str]:
+    """Create a feature branch, add a commit to main, return (repo, branch)."""
+    _git(repo, "checkout", "-b", branch)
+    _git(repo, "checkout", "main")
+    _commit(repo, "main-new.txt", "from main\n", "main: add new file")
+    _git(repo, "checkout", branch)
+    return repo, branch
+
+
+# ===========================================================================
+# Happy path: auto-stash, merge, restore
+# ===========================================================================
+
+
+class TestAutoStashHappyPath:
+    """Sync with staged/unstaged user changes: stash → merge → pop."""
+
+    def test_staged_changes_survive_sync(self, tmp_git_repo: Path) -> None:
+        """Staged changes are preserved after sync merges main into feature branch."""
+        from wade.services.implementation_service import sync
+
+        repo, _ = _setup_branch_behind_main(tmp_git_repo)
+
+        # Stage a user change on the feature branch
+        (repo / "user-work.txt").write_text("my work\n")
+        _git(repo, "add", "user-work.txt")
+        assert _git(repo, "status", "--porcelain").startswith("A")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = sync(project_root=repo)
+
+        assert result.success, f"Sync failed: {[e.data for e in result.events]}"
+        # Verify main-new.txt was merged in
+        assert (repo / "main-new.txt").exists()
+        # Verify user-work.txt was restored
+        assert (repo / "user-work.txt").read_text() == "my work\n"
+        # user-work.txt should still be staged after pop
+        status = _git(repo, "status", "--porcelain")
+        assert "user-work.txt" in status
+
+    def test_unstaged_changes_survive_sync(self, tmp_git_repo: Path) -> None:
+        """Unstaged modifications to tracked files survive the sync."""
+        from wade.services.implementation_service import sync
+
+        repo, _ = _setup_branch_behind_main(tmp_git_repo)
+
+        # Modify an existing tracked file without staging
+        (repo / "README.md").write_text("modified by user\n")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = sync(project_root=repo)
+
+        assert result.success
+        assert (repo / "README.md").read_text() == "modified by user\n"
+
+    def test_autostashed_and_stash_restored_events_emitted(self, tmp_git_repo: Path) -> None:
+        """AUTOSTASHED and STASH_RESTORED events appear in the result."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        repo, _ = _setup_branch_behind_main(tmp_git_repo)
+        (repo / "user-work.txt").write_text("my work\n")
+        _git(repo, "add", "user-work.txt")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = sync(project_root=repo)
+
+        assert result.success
+        assert any(e.event == SyncEventType.AUTOSTASHED for e in result.events)
+        assert any(e.event == SyncEventType.STASH_RESTORED for e in result.events)
+
+    def test_stash_name_is_wade_prefixed(self, tmp_git_repo: Path) -> None:
+        """The created stash has the wade-autostash/ prefix for easy identification."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        repo, _ = _setup_branch_behind_main(tmp_git_repo)
+        (repo / "user-work.txt").write_text("my work\n")
+        _git(repo, "add", "user-work.txt")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = sync(project_root=repo)
+
+        assert result.success
+        stash_ev = next(e for e in result.events if e.event == SyncEventType.AUTOSTASHED)
+        # After successful pop, the stash is gone from the list — but during sync
+        # the ref should have been 'stash@{0}'
+        assert "stash@{" in stash_ev.data["stash_ref"]
+
+
+# ===========================================================================
+# Untracked files
+# ===========================================================================
+
+
+class TestAutoStashUntrackedFiles:
+    """Untracked-file behavior: collision detection and non-interference."""
+
+    def test_untracked_non_colliding_passes(self, tmp_git_repo: Path) -> None:
+        """Untracked file that main does not touch: sync proceeds."""
+        from wade.services.implementation_service import sync
+
+        repo, _ = _setup_branch_behind_main(tmp_git_repo)
+        (repo / "my-notes.txt").write_text("scratch notes\n")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = sync(project_root=repo)
+
+        assert result.success
+        assert (repo / "my-notes.txt").exists()
+
+    def test_untracked_collision_fails_before_mutation(self, tmp_git_repo: Path) -> None:
+        """Untracked file that main WOULD add: sync reports error before touching anything."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        _git(tmp_git_repo, "checkout", "-b", "feat/42-test")
+        _git(tmp_git_repo, "checkout", "main")
+        # Add a file to main that the feature branch will have as untracked
+        _commit(tmp_git_repo, "collision-file.txt", "from main\n", "add collision file")
+        _git(tmp_git_repo, "checkout", "feat/42-test")
+
+        # Create the untracked collision file
+        (tmp_git_repo / "collision-file.txt").write_text("local untracked version\n")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = sync(project_root=tmp_git_repo)
+
+        assert not result.success
+        assert any(e.event == SyncEventType.UNTRACKED_CONFLICT for e in result.events)
+        conflict_ev = next(e for e in result.events if e.event == SyncEventType.UNTRACKED_CONFLICT)
+        assert "collision-file.txt" in conflict_ev.data["paths"]
+        # The local version must be unchanged (no mutation before error)
+        assert (tmp_git_repo / "collision-file.txt").read_text() == "local untracked version\n"
+
+
+# ===========================================================================
+# --no-stash: strict old behavior
+# ===========================================================================
+
+
+class TestNoStashFlag:
+    """--no-stash: dirty worktree always fails."""
+
+    def test_no_stash_with_staged_changes_fails(self, tmp_git_repo: Path) -> None:
+        """--no-stash: staged changes → dirty_worktree error."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        _git(tmp_git_repo, "checkout", "-b", "feat/42-test")
+        (tmp_git_repo / "user-work.txt").write_text("my work\n")
+        _git(tmp_git_repo, "add", "user-work.txt")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = sync(project_root=tmp_git_repo, no_stash=True)
+
+        assert not result.success
+        assert any(
+            e.event == SyncEventType.ERROR and e.data.get("reason") == "dirty_worktree"
+            for e in result.events
+        )
+
+    def test_no_stash_session_artifacts_fails(self, tmp_git_repo: Path) -> None:
+        """--no-stash: even session artifacts (PLAN.md) → dirty_worktree error."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        _git(tmp_git_repo, "checkout", "-b", "feat/42-test")
+        (tmp_git_repo / "PLAN.md").write_text("# Plan\n")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = sync(project_root=tmp_git_repo, no_stash=True)
+
+        assert not result.success
+        assert any(
+            e.event == SyncEventType.ERROR and e.data.get("reason") == "dirty_worktree"
+            for e in result.events
+        )
+
+
+# ===========================================================================
+# Catchup auto-stash
+# ===========================================================================
+
+
+class TestCatchupAutoStash:
+    """catchup() with auto-stash — real git."""
+
+    def test_catchup_stashes_and_restores_on_clean_merge(self, tmp_git_repo: Path) -> None:
+        """catchup: staged changes survive a clean merge."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import catchup
+
+        repo, _ = _setup_branch_behind_main(tmp_git_repo)
+        (repo / "user-work.txt").write_text("catchup work\n")
+        _git(repo, "add", "user-work.txt")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(project=ProjectSettings(main_branch="main")),
+        ):
+            result = catchup(project_root=repo)
+
+        assert result.success
+        assert (repo / "user-work.txt").read_text() == "catchup work\n"
+        assert any(e.event == SyncEventType.STASH_RESTORED for e in result.events)

--- a/tests/integration/test_autostash.py
+++ b/tests/integration/test_autostash.py
@@ -68,7 +68,8 @@ class TestAutoStashHappyPath:
         assert (repo / "user-work.txt").read_text() == "my work\n"
         # user-work.txt should still be staged after pop
         status = _git(repo, "status", "--porcelain")
-        assert "user-work.txt" in status
+        staged_line = next((ln for ln in status.splitlines() if ln.endswith("user-work.txt")), "")
+        assert staged_line.startswith("A "), f"expected staged add, got: {staged_line!r}"
 
     def test_unstaged_changes_survive_sync(self, tmp_git_repo: Path) -> None:
         """Unstaged modifications to tracked files survive the sync."""
@@ -127,6 +128,7 @@ class TestAutoStashHappyPath:
         # After successful pop, the stash is gone from the list — but during sync
         # the ref should have been 'stash@{0}'
         assert "stash@{" in stash_ev.data["stash_ref"]
+        assert stash_ev.data["stash_name"].startswith("wade-autostash/")
 
 
 # ===========================================================================

--- a/tests/unit/test_cli/test_work_cli.py
+++ b/tests/unit/test_cli/test_work_cli.py
@@ -42,6 +42,7 @@ class TestWorkSyncExitCodes:
             main_branch=None,
             json_output=False,
             session_type="implementation",
+            no_stash=False,
         )
 
     def test_sync_conflicts_map_to_exit_two(self) -> None:
@@ -56,6 +57,7 @@ class TestWorkSyncExitCodes:
             main_branch=None,
             json_output=False,
             session_type="implementation",
+            no_stash=False,
         )
 
     def test_sync_preflight_error_maps_to_exit_four(self) -> None:
@@ -74,6 +76,7 @@ class TestWorkSyncExitCodes:
             main_branch=None,
             json_output=False,
             session_type="implementation",
+            no_stash=False,
         )
 
     def test_sync_other_error_maps_to_exit_one(self) -> None:
@@ -92,6 +95,7 @@ class TestWorkSyncExitCodes:
             main_branch=None,
             json_output=False,
             session_type="implementation",
+            no_stash=False,
         )
 
 

--- a/tests/unit/test_services/test_catchup.py
+++ b/tests/unit/test_services/test_catchup.py
@@ -202,22 +202,23 @@ class TestCatchupStackedBranch:
 
 
 class TestCatchupDirtyWorktree:
-    """Dirty worktree: catchup reports pre-flight failure."""
+    """Dirty worktree: catchup reports pre-flight failure with --no-stash."""
 
     @patch("wade.services.implementation_service.core.git_sync")
     @patch("wade.services.implementation_service.core.git_branch")
     @patch("wade.services.implementation_service.bootstrap.git_repo")
     @patch("wade.services.implementation_service.core.git_repo")
     @patch("wade.services.implementation_service.core.load_config")
-    def test_fails_on_dirty_worktree(
+    def test_fails_on_dirty_worktree_no_stash(
         self,
         mock_config: MagicMock,
         mock_repo: MagicMock,
-        _mock_bootstrap_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
         mock_branch: MagicMock,
         mock_sync: MagicMock,
         tmp_path: Path,
     ) -> None:
+        """--no-stash: dirty worktree causes immediate failure (old strict behavior)."""
         from wade.models.config import ProjectConfig
         from wade.services.implementation_service import catchup
 
@@ -226,8 +227,11 @@ class TestCatchupDirtyWorktree:
         mock_repo.get_current_branch.return_value = "feat/1-my-feature"
         mock_repo.is_clean.return_value = False
         mock_repo.detect_main_branch.return_value = "main"
+        # Simulate staged user change (non-session artifact)
+        mock_bootstrap_repo.get_dirty_file_paths.return_value = ["src/main.py"]
+        mock_repo.get_dirty_status.return_value = {"staged": 1, "unstaged": 0, "untracked": 0}
 
-        result = catchup(project_root=tmp_path)
+        result = catchup(project_root=tmp_path, no_stash=True)
 
         assert result.success is False
         assert result.conflicts == []

--- a/tests/unit/test_services/test_implementation_done_sync.py
+++ b/tests/unit/test_services/test_implementation_done_sync.py
@@ -575,13 +575,12 @@ class TestSync:
             assert result.success
             assert any(e.event == "merged" for e in result.events)
 
-    def test_dirty_worktree(self, tmp_git_repo: Path) -> None:
-        """Sync fails with dirty worktree."""
+    def test_dirty_worktree_no_stash(self, tmp_git_repo: Path) -> None:
+        """--no-stash preserves strict behavior: sync fails immediately on dirty worktree."""
         import subprocess
 
         from wade.services.implementation_service import sync
 
-        # Create and checkout feature branch
         subprocess.run(
             ["git", "checkout", "-b", "feat/42-test"],
             cwd=tmp_git_repo,
@@ -589,7 +588,7 @@ class TestSync:
             check=True,
         )
 
-        # Create dirty state
+        # Create dirty state (untracked file)
         (tmp_git_repo / "dirty.txt").write_text("dirty\n")
 
         with patch(
@@ -598,7 +597,7 @@ class TestSync:
                 project=ProjectSettings(main_branch="main"),
             ),
         ):
-            result = sync(project_root=tmp_git_repo)
+            result = sync(project_root=tmp_git_repo, no_stash=True)
             assert not result.success
             assert any(
                 e.data.get("reason") == "dirty_worktree"
@@ -606,8 +605,8 @@ class TestSync:
                 if e.event == "error"
             )
 
-    def test_dirty_worktree_with_session_files_in_event(self, tmp_git_repo: Path) -> None:
-        """session_files is included in the ERROR event payload for dirty session artifacts."""
+    def test_dirty_worktree_untracked_passes_without_collision(self, tmp_git_repo: Path) -> None:
+        """Untracked files that don't collide with the merge proceed without stashing."""
         import subprocess
 
         from wade.services.implementation_service import sync
@@ -619,7 +618,32 @@ class TestSync:
             check=True,
         )
 
-        # Create a dirty session artifact
+        # Untracked file that main does NOT introduce
+        (tmp_git_repo / "my-notes.txt").write_text("work in progress\n")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(
+                project=ProjectSettings(main_branch="main"),
+            ),
+        ):
+            result = sync(project_root=tmp_git_repo)
+            assert result.success
+
+    def test_dirty_worktree_session_artifacts_only_proceeds(self, tmp_git_repo: Path) -> None:
+        """Only session artifacts dirty: sync proceeds without stashing."""
+        import subprocess
+
+        from wade.services.implementation_service import sync
+
+        subprocess.run(
+            ["git", "checkout", "-b", "feat/42-test"],
+            cwd=tmp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        # Session artifact — not a user change, sync should proceed
         (tmp_git_repo / "PLAN.md").write_text("# Plan\n")
 
         with patch(
@@ -629,6 +653,31 @@ class TestSync:
             ),
         ):
             result = sync(project_root=tmp_git_repo)
+            assert result.success
+
+    def test_dirty_worktree_session_artifacts_no_stash_fails(self, tmp_git_repo: Path) -> None:
+        """With --no-stash, even session artifacts cause dirty_worktree error."""
+        import subprocess
+
+        from wade.services.implementation_service import sync
+
+        subprocess.run(
+            ["git", "checkout", "-b", "feat/42-test"],
+            cwd=tmp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        # Session artifact
+        (tmp_git_repo / "PLAN.md").write_text("# Plan\n")
+
+        with patch(
+            "wade.services.implementation_service.core.load_config",
+            return_value=ProjectConfig(
+                project=ProjectSettings(main_branch="main"),
+            ),
+        ):
+            result = sync(project_root=tmp_git_repo, no_stash=True)
             assert not result.success
             error_event = next(
                 (
@@ -665,6 +714,472 @@ class TestSync:
             assert result.success
             # Events should include preflight_ok
             assert any(e.event == "preflight_ok" for e in result.events)
+
+
+# ---------------------------------------------------------------------------
+# Auto-stash unit tests (mocked git)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncAutoStash:
+    """Unit tests for sync() auto-stash flow — all git mocked."""
+
+    def _make_sync_mocks(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+        *,
+        dirty_paths: list[str],
+        staged: int = 0,
+        unstaged: int = 0,
+        untracked: int = 0,
+        stash_ref: str = "stash@{0}",
+        behind: int = 0,
+    ) -> None:
+        from wade.models.config import ProjectConfig
+        from wade.models.session import SyncResult
+
+        mock_config.return_value = ProjectConfig()
+        mock_repo.get_repo_root.return_value = tmp_path
+        mock_repo.get_current_branch.return_value = "feat/1-feature"
+        mock_repo.is_clean.return_value = False
+        mock_repo.has_remote.return_value = False
+        mock_repo.detect_main_branch.return_value = "main"
+        mock_repo.get_dirty_status.return_value = {
+            "staged": staged,
+            "unstaged": unstaged,
+            "untracked": untracked,
+        }
+        mock_bootstrap_repo.get_dirty_file_paths.return_value = dirty_paths
+        mock_stash.detect_untracked_collisions.return_value = []
+        mock_stash.create_named_stash.return_value = stash_ref
+        mock_stash.pop_stash.return_value = MagicMock(returncode=0)
+        mock_branch.commits_ahead.return_value = behind
+        if behind > 0:
+            mock_sync_mod.merge_branch.return_value = SyncResult(
+                success=True,
+                current_branch="feat/1-feature",
+                main_branch="main",
+                commits_merged=behind,
+            )
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_staged_changes_auto_stash_and_restore(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Staged user changes: stash → merge → pop — all events emitted."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        self._make_sync_mocks(
+            mock_config,
+            mock_repo,
+            mock_bootstrap_repo,
+            mock_branch,
+            mock_sync_mod,
+            mock_stash,
+            tmp_path,
+            dirty_paths=["src/app.py"],
+            staged=1,
+        )
+
+        result = sync(project_root=tmp_path)
+
+        assert result.success
+        mock_stash.create_named_stash.assert_called_once()
+        mock_stash.pop_stash.assert_called_once_with("stash@{0}", tmp_path)
+        assert any(e.event == SyncEventType.AUTOSTASHED for e in result.events)
+        assert any(e.event == SyncEventType.STASH_RESTORED for e in result.events)
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_unstaged_changes_auto_stash(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Unstaged user changes trigger auto-stash."""
+        from wade.services.implementation_service import sync
+
+        self._make_sync_mocks(
+            mock_config,
+            mock_repo,
+            mock_bootstrap_repo,
+            mock_branch,
+            mock_sync_mod,
+            mock_stash,
+            tmp_path,
+            dirty_paths=["src/app.py"],
+            unstaged=1,
+        )
+
+        result = sync(project_root=tmp_path)
+
+        assert result.success
+        mock_stash.create_named_stash.assert_called_once()
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_untracked_only_no_stash_needed(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Untracked-only dirty state: no stash created, merge proceeds."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        self._make_sync_mocks(
+            mock_config,
+            mock_repo,
+            mock_bootstrap_repo,
+            mock_branch,
+            mock_sync_mod,
+            mock_stash,
+            tmp_path,
+            dirty_paths=["notes.txt"],
+            untracked=1,
+        )
+
+        result = sync(project_root=tmp_path)
+
+        assert result.success
+        mock_stash.create_named_stash.assert_not_called()
+        assert not any(e.event == SyncEventType.AUTOSTASHED for e in result.events)
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_untracked_collision_fails_before_mutation(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Untracked collision detected before any mutation — no stash, no merge."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        self._make_sync_mocks(
+            mock_config,
+            mock_repo,
+            mock_bootstrap_repo,
+            mock_branch,
+            mock_sync_mod,
+            mock_stash,
+            tmp_path,
+            dirty_paths=["new-feature.py"],
+            untracked=1,
+        )
+        mock_stash.detect_untracked_collisions.return_value = ["new-feature.py"]
+
+        result = sync(project_root=tmp_path)
+
+        assert not result.success
+        mock_stash.create_named_stash.assert_not_called()
+        mock_sync_mod.merge_branch.assert_not_called()
+        assert any(e.event == SyncEventType.UNTRACKED_CONFLICT for e in result.events)
+        conflict_ev = next(e for e in result.events if e.event == SyncEventType.UNTRACKED_CONFLICT)
+        assert "new-feature.py" in conflict_ev.data["paths"]
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_stash_pop_conflict_leaves_stash_behind(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Stash pop conflict: named stash left, STASH_LEFT_BEHIND emitted, sync fails."""
+        from wade.models.session import SyncEventType, SyncResult
+        from wade.services.implementation_service import sync
+
+        self._make_sync_mocks(
+            mock_config,
+            mock_repo,
+            mock_bootstrap_repo,
+            mock_branch,
+            mock_sync_mod,
+            mock_stash,
+            tmp_path,
+            dirty_paths=["src/app.py"],
+            staged=1,
+            behind=1,
+        )
+        mock_sync_mod.merge_branch.return_value = SyncResult(
+            success=True, current_branch="feat/1-feature", main_branch="main", commits_merged=1
+        )
+        mock_stash.pop_stash.return_value = MagicMock(returncode=1)
+
+        result = sync(project_root=tmp_path)
+
+        assert not result.success
+        assert any(e.event == SyncEventType.STASH_LEFT_BEHIND for e in result.events)
+        ev = next(e for e in result.events if e.event == SyncEventType.STASH_LEFT_BEHIND)
+        assert "stash@{0}" in ev.data["stash_ref"]
+        assert "recovery_hint" in ev.data
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_merge_conflict_with_stash_aborts_and_restores(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Merge conflict when stashed: merge aborted, stash restored, error returned."""
+        from wade.models.session import SyncEventType, SyncResult
+        from wade.services.implementation_service import sync
+
+        self._make_sync_mocks(
+            mock_config,
+            mock_repo,
+            mock_bootstrap_repo,
+            mock_branch,
+            mock_sync_mod,
+            mock_stash,
+            tmp_path,
+            dirty_paths=["src/app.py"],
+            staged=1,
+            behind=1,
+        )
+        mock_sync_mod.merge_branch.return_value = SyncResult(
+            success=False,
+            current_branch="feat/1-feature",
+            main_branch="main",
+            conflicts=["src/app.py"],
+        )
+
+        result = sync(project_root=tmp_path)
+
+        assert not result.success
+        # abort_on_conflict=True when stash_ref is set, so abort_merge is called
+        mock_sync_mod.abort_merge.assert_called_once()
+        # Stash should be restored after abort
+        mock_stash.pop_stash.assert_called_once_with("stash@{0}", tmp_path)
+        assert any(e.event == SyncEventType.STASH_RESTORED for e in result.events)
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_no_stash_with_user_dirty_fails(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """--no-stash: USER_DIRTY causes immediate failure, no merge attempted."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        self._make_sync_mocks(
+            mock_config,
+            mock_repo,
+            mock_bootstrap_repo,
+            mock_branch,
+            mock_sync_mod,
+            mock_stash,
+            tmp_path,
+            dirty_paths=["src/app.py"],
+            staged=1,
+        )
+
+        result = sync(project_root=tmp_path, no_stash=True)
+
+        assert not result.success
+        mock_stash.create_named_stash.assert_not_called()
+        mock_sync_mod.merge_branch.assert_not_called()
+        error_events = [e for e in result.events if e.event == SyncEventType.ERROR]
+        assert any(e.data.get("reason") == "dirty_worktree" for e in error_events)
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_artifacts_only_proceeds_without_stash(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Only session artifacts dirty: proceeds without stash."""
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import sync
+
+        mock_config.return_value = __import__(
+            "wade.models.config", fromlist=["ProjectConfig"]
+        ).ProjectConfig()
+        mock_repo.get_repo_root.return_value = tmp_path
+        mock_repo.get_current_branch.return_value = "feat/1-feature"
+        mock_repo.is_clean.return_value = False
+        mock_repo.has_remote.return_value = False
+        mock_repo.detect_main_branch.return_value = "main"
+        mock_bootstrap_repo.get_dirty_file_paths.return_value = ["PLAN.md"]
+        mock_branch.commits_ahead.return_value = 0
+
+        result = sync(project_root=tmp_path)
+
+        assert result.success
+        mock_stash.create_named_stash.assert_not_called()
+        assert not any(e.event == SyncEventType.AUTOSTASHED for e in result.events)
+
+
+class TestCatchupAutoStash:
+    """Unit tests for catchup() auto-stash flow — all git mocked."""
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_staged_changes_auto_stash_and_restore(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Staged user changes: catchup stashes → merges → restores stash."""
+        from wade.models.config import ProjectConfig
+        from wade.models.session import SyncEventType, SyncResult
+        from wade.services.implementation_service import catchup
+
+        mock_config.return_value = ProjectConfig()
+        mock_repo.get_repo_root.return_value = tmp_path
+        mock_repo.get_current_branch.return_value = "feat/1-feature"
+        mock_repo.is_clean.return_value = False
+        mock_repo.has_remote.return_value = False
+        mock_repo.detect_main_branch.return_value = "main"
+        mock_repo.get_dirty_status.return_value = {"staged": 1, "unstaged": 0, "untracked": 0}
+        mock_bootstrap_repo.get_dirty_file_paths.return_value = ["src/app.py"]
+        mock_stash.detect_untracked_collisions.return_value = []
+        mock_stash.create_named_stash.return_value = "stash@{0}"
+        mock_stash.pop_stash.return_value = MagicMock(returncode=0)
+        mock_branch.commits_ahead.return_value = 1
+        mock_sync_mod.merge_branch.return_value = SyncResult(
+            success=True, current_branch="feat/1-feature", main_branch="main", commits_merged=1
+        )
+
+        result = catchup(project_root=tmp_path)
+
+        assert result.success
+        mock_stash.create_named_stash.assert_called_once()
+        mock_stash.pop_stash.assert_called_once()
+        assert any(e.event == SyncEventType.AUTOSTASHED for e in result.events)
+        assert any(e.event == SyncEventType.STASH_RESTORED for e in result.events)
+
+    @patch("wade.services.implementation_service.core.git_stash")
+    @patch("wade.services.implementation_service.core.git_sync")
+    @patch("wade.services.implementation_service.core.git_branch")
+    @patch("wade.services.implementation_service.bootstrap.git_repo")
+    @patch("wade.services.implementation_service.core.git_repo")
+    @patch("wade.services.implementation_service.core.load_config")
+    def test_no_stash_preserves_strict_behavior(
+        self,
+        mock_config: MagicMock,
+        mock_repo: MagicMock,
+        mock_bootstrap_repo: MagicMock,
+        mock_branch: MagicMock,
+        mock_sync_mod: MagicMock,
+        mock_stash: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """--no-stash: catchup fails immediately on user dirty state."""
+        from wade.models.config import ProjectConfig
+        from wade.models.session import SyncEventType
+        from wade.services.implementation_service import catchup
+
+        mock_config.return_value = ProjectConfig()
+        mock_repo.get_repo_root.return_value = tmp_path
+        mock_repo.get_current_branch.return_value = "feat/1-feature"
+        mock_repo.is_clean.return_value = False
+        mock_repo.has_remote.return_value = False
+        mock_repo.detect_main_branch.return_value = "main"
+        mock_repo.get_dirty_status.return_value = {"staged": 1, "unstaged": 0, "untracked": 0}
+        mock_bootstrap_repo.get_dirty_file_paths.return_value = ["src/app.py"]
+
+        result = catchup(project_root=tmp_path, no_stash=True)
+
+        assert not result.success
+        mock_stash.create_named_stash.assert_not_called()
+        mock_sync_mod.merge_branch.assert_not_called()
+        error_events = [e for e in result.events if e.event == SyncEventType.ERROR]
+        assert any(e.data.get("reason") == "dirty_worktree" for e in error_events)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #305

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem

`wade implementation-session sync` and the implicit startup `catchup` hard-fail
whenever the worktree is dirty. The pre-flight in
`src/wade/services/implementation_service/core.py::_sync_preflight` calls
`git_repo.is_clean()` and emits an ERROR event with `reason="dirty_worktree"`
the moment any uncommitted, unstaged, or untracked file is present. The user
is then asked to commit or stash by hand before retrying.

This is unreliable in practice:

- During long implementation sessions the worktree is *frequently* dirty
  (in-progress edits, generated files, wade session artifacts).
- The pre-flight already distinguishes wade-managed session artifacts
  (PLAN.md, PR-SUMMARY.md, etc.) via `_identify_session_dirty_files` (added in
  #257), but still refuses to proceed even when the only dirty files are
  artifacts wade itself put there.
- Untracked files that would be overwritten by the incoming merge are not
  detected up front — they can blow up mid-merge with a `git checkout` failure
  and leave the worktree in a half-applied state.
- No auto-stash mechanism exists in the sync/catchup paths. The only stash use
  in the service today is `_pull_main_after_merge`.

The goal is to make sync and catchup tolerate a dirty worktree by default,
while preserving the strict behavior behind an opt-out flag and never silently
dropping the user's changes.

## Proposed Solution

Auto-stash the user's dirty changes before the merge, run the merge, then
restore the stash. Treat wade-managed session artifacts as safe to leave in
place. Probe for untracked-file collisions before starting the merge. If
anything goes wrong, leave a named stash and emit a structured recovery hint.

**Behavior matrix:**

| Worktree state                          | Default (auto-stash on)                          | `--no-stash`           |
|-----------------------------------------|--------------------------------------------------|------------------------|
| Clean                                   | Merge directly                                   | Merge directly         |
| Only session artifacts dirty            | Skip stash, merge directly                       | ERROR `dirty_worktree` |
| User changes (staged/unstaged)          | Stash → merge → pop                              | ERROR `dirty_worktree` |
| Untracked files conflicting with merge  | ERROR `untracked_conflict` (before any mutation) | Same                   |
| Merge conflict after stash              | Abort merge → pop stash → ERROR `merge_conflict` | Abort merge → ERROR    |
| Stash pop conflict after merge          | Leave named stash → ERROR `stash_pop_conflict` with recovery hint | n/a   |

**Stash naming:** `wade-autostash/<session-type>/<branch>/<UTC timestamp>` so
the user can find and recover it manually.

**Untracked-file probe:** Use `git merge-tree --name-only HEAD <other>` (or a
`git merge --no-commit --no-ff` + immediate `git merge --abort` if merge-tree
is not viable) to list paths the merge would touch, then intersect with the
set of untracked paths from `git status --porcelain`. Surface the colliding
paths in the ERROR event payload.

**Scope:**

- `src/wade/services/implementation_service/core.py` — refactor `_sync_preflight`
  and the `sync` / `catchup` entry points around the new auto-stash flow.
- `src/wade/git/` — add a small stash helper module (named stash create, list,
  apply, drop) and an untracked-collision detector.
- `src/wade/cli/implementation_session.py` — add `--no-stash` flag to both
  `sync` and `catchup`.
- Event taxonomy — add `AUTOSTASHED`, `STASH_RESTORED`, `STASH_LEFT_BEHIND`
  events for observability and JSON output.
- `templates/skills/implementation-session/SKILL.md` lines 69–96 and 153–188 —
  document the new default, the `--no-stash` opt-out, and how to recover a
  stuck stash.

**Non-goals:**

- No change to `wade implementation-session done` (it has its own pre-flight
  with different semantics — leave alone).
- No interactive prompts: this stays JSON/event-driven so it remains
  scriptable.
- No change to the rebase-vs-merge strategy.

## Tasks

- [ ] Add stash helper in `src/wade/git/stash.py` (or extend existing module):
      `create_named_stash(label, cwd) -> stash_ref`, `pop_stash(ref, cwd)`,
      `list_wade_autostashes(cwd) -> list[StashEntry]`.
- [ ] Add untracked-collision detector in `src/wade/git/` that returns the
      list of untracked paths the incoming merge would overwrite, given a
      target ref.
- [ ] Refactor `_sync_preflight` so it returns a structured `PreflightResult`
      (clean / artifacts-only / user-dirty / untracked-conflict) instead of a
      boolean.
- [ ] Wire auto-stash flow into `sync()` in `implementation_service/core.py`:
      categorize → stash if needed → merge → pop → handle each failure
      branch with the correct event.
- [ ] Wire the same flow into the startup `catchup` call (lines ~982–996)
      and the standalone `catchup` CLI.
- [ ] Add `--no-stash` flag to both `sync` and `catchup` in
      `src/wade/cli/implementation_session.py` and plumb through to the
      service.
- [ ] Add new event types (`AUTOSTASHED`, `STASH_RESTORED`,
      `STASH_LEFT_BEHIND`, `UNTRACKED_CONFLICT`) and update the event schema
      docs / JSON output consumers.
- [ ] Update `templates/skills/implementation-session/SKILL.md` (Catchup and
      Syncing sections) to describe the new default, the opt-out, and the
      recovery procedure for an orphaned `wade-autostash/*` stash.
- [ ] Unit tests in `tests/unit/test_services/test_implementation_done_sync.py`
      and `test_catchup.py`: clean tree, session-artifacts-only,
      staged-only, unstaged-only, untracked-only, mixed dirty, untracked
      conflict, merge conflict with stash recovery, stash-pop conflict,
      `--no-stash` preserves old behavior.
- [ ] Integration test that exercises a real git repo (no mocks) for the
      happy auto-stash path and the stash-pop-conflict path, to catch
      stash-name quoting and detached-HEAD edge cases.
- [ ] Run `./scripts/check-all.sh` and confirm all gates pass.

## Acceptance Criteria

- [ ] `wade implementation-session sync` succeeds on a worktree with staged
      and unstaged user changes; after the command the worktree is on the
      merged commit and the user's changes are reapplied on top.
- [ ] `wade implementation-session sync` succeeds when the only dirty paths
      are wade session artifacts (PLAN.md, PR-SUMMARY.md), without creating
      a stash.
- [ ] When untracked files in the worktree would be overwritten by the
      merge, sync fails *before* touching anything, with a structured
      ERROR event listing the colliding paths.
- [ ] When the post-merge `git stash pop` conflicts, the named stash is
      preserved, sync exits with a structured ERROR event whose payload
      includes the stash ref and an `apply` command the user can copy/paste.
- [ ] `wade implementation-session sync --no-stash` reproduces today's
      strict behavior exactly (ERROR `dirty_worktree` on any user change).
- [ ] The catchup CLI and the implicit startup catchup both use the same
      flow.
- [ ] `templates/skills/implementation-session/SKILL.md` documents the new
      default, the `--no-stash` opt-out, and stash recovery; the existing
      "commit or stash first" guidance is updated rather than left stale.
- [ ] `./scripts/test.sh` and `./scripts/check.sh` pass.

<!-- wade:plan:end -->


## What was done

Made `wade implementation-session sync` and `catchup` tolerate a dirty worktree by default: user changes (staged and unstaged tracked files) are automatically stashed before the merge and restored after. The old strict "fail on any uncommitted changes" behavior is preserved behind a `--no-stash` opt-out flag. Session artifacts (PLAN.md, PR-SUMMARY.md, .wade/) are never stashed — they are gitignored and the merge doesn't touch them.

## Changes

- Added `src/wade/git/stash.py` — new stash helper module with `create_named_stash`, `pop_stash`, `apply_stash`, `drop_stash`, `list_wade_autostashes`, and `detect_untracked_collisions`. Stashes carry a `wade-autostash/<session-type>/<branch>/<timestamp>` label for easy identification.
- Added 4 new `SyncEventType` values: `AUTOSTASHED`, `STASH_RESTORED`, `STASH_LEFT_BEHIND`, `UNTRACKED_CONFLICT` — for structured observability of the stash lifecycle.
- Refactored `_sync_preflight()` in `core.py` to return `_PreflightOK | SyncResult` (was a 3-tuple), introducing `_DirtyCategory` (CLEAN / ARTIFACTS_ONLY / USER_DIRTY) and `has_tracked_changes` flag to separate "can we stash?" from "is the worktree dirty?".
- Wired auto-stash flow into both `sync()` and `catchup()`: detect untracked collision → stash tracked changes → merge → restore stash. If stash pop fails after a successful merge, the stash is left behind and a `STASH_LEFT_BEHIND` event is emitted with the recovery command.
- Added `--no-stash` CLI flag to both `implementation-session sync` and `implementation-session catchup`.
- Updated `templates/skills/implementation-session/SKILL.md` to document auto-stash behavior, `--no-stash` opt-out, and recovery flows for `stash_left_behind` and `untracked_conflict`.

## Testing

- Added `tests/integration/test_autostash.py` — 9 real-git-repo tests (no mocks): staged changes survive sync, unstaged changes survive, events emitted, stash name is wade-prefixed, untracked non-colliding file passes, untracked collision detected before any mutation, `--no-stash` with staged/artifact changes fails, catchup stashes and restores.
- Added `TestSyncAutoStash` (8 unit tests) and `TestCatchupAutoStash` (2 unit tests) in `test_implementation_done_sync.py` with full mock coverage of all code paths.
- Updated existing unit tests for `no_stash=True` behavior and new ARTIFACTS_ONLY→success path.
- All 2460 tests pass; ruff + mypy strict clean.

## Notes for reviewers

- Untracked files are never stashed (`git stash` doesn't touch them). The collision check (`detect_untracked_collisions`) detects when the incoming merge would add a file that already exists as untracked, and fails before touching anything.
- `abort_on_conflict=True` is passed to `_merge_base` when a stash is held, so if the merge conflicts the worktree is left clean and the stash is restored before returning. This differs from the normal sync path where conflicts are left in place for manual resolution.
- The pre-fetch before the collision check causes a double-fetch on the happy path (one in collision check, one in merge). This is intentional and idempotent — the collision check needs the remote refs before merge runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-stash` flag to `sync` and `catchup` commands for stricter uncommitted change handling
  * Automatic stashing of uncommitted work during sync/catchup with automatic restoration afterward
  * Untracked file collision detection and reporting during merge operations
  * New sync event types for auto-stash and conflict tracking

* **Documentation**
  * Updated implementation-session guidance with auto-stash workflow and error recovery instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ivanviragine/wade/pull/306)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

## What was done

Made `wade implementation-session sync` and `catchup` tolerate a dirty worktree by default: user changes (staged and unstaged tracked files) are automatically stashed before the merge and restored after. The old strict "fail on any uncommitted changes" behavior is preserved behind a `--no-stash` opt-out flag. Session artifacts (PLAN.md, PR-SUMMARY.md, .wade/) are never stashed — they are gitignored and the merge doesn't touch them.

## Changes

- Added `src/wade/git/stash.py` — new stash helper module with `create_named_stash`, `pop_stash`, `apply_stash`, `drop_stash`, `list_wade_autostashes`, and `detect_untracked_collisions`. Stashes carry a `wade-autostash/<session-type>/<branch>/<timestamp>` label for easy identification.
- Added 4 new `SyncEventType` values: `AUTOSTASHED`, `STASH_RESTORED`, `STASH_LEFT_BEHIND`, `UNTRACKED_CONFLICT` — for structured observability of the stash lifecycle.
- Refactored `_sync_preflight()` in `core.py` to return `_PreflightOK | SyncResult` (was a 3-tuple), introducing `_DirtyCategory` (CLEAN / ARTIFACTS_ONLY / USER_DIRTY) and `has_tracked_changes` flag to separate "can we stash?" from "is the worktree dirty?".
- Wired auto-stash flow into both `sync()` and `catchup()`: detect untracked collision → stash tracked changes → merge → restore stash. If stash pop fails after a successful merge, the stash is left behind and a `STASH_LEFT_BEHIND` event is emitted with the recovery command.
- Added `--no-stash` CLI flag to both `implementation-session sync` and `implementation-session catchup`.
- Updated `templates/skills/implementation-session/SKILL.md` to document auto-stash behavior, `--no-stash` opt-out, and recovery flows for `stash_left_behind` and `untracked_conflict`.

## Testing

- Added `tests/integration/test_autostash.py` — 9 real-git-repo tests (no mocks): staged changes survive sync, unstaged changes survive, events emitted, stash name is wade-prefixed, untracked non-colliding file passes, untracked collision detected before any mutation, `--no-stash` with staged/artifact changes fails, catchup stashes and restores.
- Added `TestSyncAutoStash` (8 unit tests) and `TestCatchupAutoStash` (2 unit tests) in `test_implementation_done_sync.py` with full mock coverage of all code paths.
- Updated existing unit tests for `no_stash=True` behavior and new ARTIFACTS_ONLY→success path.
- All 2460 tests pass; ruff + mypy strict clean.

## Notes for reviewers

- Untracked files are never stashed (`git stash` doesn't touch them). The collision check (`detect_untracked_collisions`) detects when the incoming merge would add a file that already exists as untracked, and fails before touching anything.
- `abort_on_conflict=True` is passed to `_merge_base` when a stash is held, so if the merge conflicts the worktree is left clean and the stash is restored before returning. This differs from the normal sync path where conflicts are left in place for manual resolution.
- The pre-fetch before the collision check causes a double-fetch on the happy path (one in collision check, one in merge). This is intentional and idempotent — the collision check needs the remote refs before merge runs.

## Review comment fixes (PR #306)

All 6 CodeRabbit comments addressed:

- **Typed Pydantic model for stash entries** (`stash.py`): `list_wade_autostashes` now returns `list[AutoStashEntry]` instead of `list[dict[str, str]]`. `create_named_stash` returns `(ref, message)` so callers can emit the human-readable stash name.
- **`_PreflightOK` converted from dataclass to Pydantic BaseModel** (`core.py`): Added `cwd: Path` field populated by `_sync_preflight`.
- **Fixed dirty-worktree summary for linked worktrees** (`core.py`): `_emit_dirty_worktree_error` now uses `preflight.cwd` instead of `preflight.repo_root`.
- **`catchup()` propagates stash restoration failure** (`core.py`): Captured return of `_handle_stash_restoration` and ANDed with `result.success`.
- **Strengthened test assertions** (`test_autostash.py`): staged-status assertion now checks the porcelain index column; stash-naming test now also verifies `wade-autostash/` prefix via emitted `stash_name`.

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | *unavailable* |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `1c5ea7de-8756-46d6-b258-08f158e10c57` |
| Review | `claude` | `495da8c2-7600-44b1-b4c6-fa41674682e0` |

<!-- wade:sessions:end -->
