### PR TITLE
feat: add `stale` rating to knowledge entries

### DIFF
--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -6,7 +6,7 @@
   up: 1
 2b4d5319:
   down: 0
-  up: 1
+  up: 2
 3463fbd4:
   down: 0
   up: 1

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -1,6 +1,12 @@
 164c355e:
   down: 0
   up: 1
+1c18f1d4:
+  down: 0
+  up: 1
+2b4d5319:
+  down: 0
+  up: 1
 3463fbd4:
   down: 0
   up: 1
@@ -15,7 +21,7 @@ b6a3a637:
   up: 1
 cc91cd11:
   down: 0
-  up: 2
+  up: 3
 cedeaad0:
   down: 1
   up: 1

--- a/src/wade/cli/knowledge.py
+++ b/src/wade/cli/knowledge.py
@@ -155,9 +155,9 @@ def get(
 @knowledge_app.command()
 def rate(
     entry_id: str = typer.Argument(help="Entry ID to rate."),
-    direction: str = typer.Argument(help="Rating direction: up or down."),
+    direction: str = typer.Argument(help="Rating direction: up, down, or stale."),
 ) -> None:
-    """Rate a knowledge entry (thumbs up or down)."""
+    """Rate a knowledge entry (up, down, or stale)."""
     from pathlib import Path
 
     from wade.config.loader import load_config

--- a/src/wade/cli/knowledge.py
+++ b/src/wade/cli/knowledge.py
@@ -169,8 +169,8 @@ def rate(
     )
     from wade.ui.console import console
 
-    if direction not in ("up", "down"):
-        console.error(f"Invalid direction '{direction}'. Must be 'up' or 'down'.")
+    if direction not in ("up", "down", "stale"):
+        console.error(f"Invalid direction '{direction}'. Must be 'up', 'down', or 'stale'.")
         raise typer.Exit(1)
 
     config = load_config()
@@ -198,8 +198,11 @@ def rate(
     except OSError as exc:
         console.error(str(exc))
         raise typer.Exit(1) from exc
-    symbol = "+" if direction == "up" else "-"
-    console.success(f"Recorded {symbol}1 for entry {entry_id}")
+    if direction == "stale":
+        console.success(f"Recorded stale vote for entry {entry_id}")
+    else:
+        symbol = "+" if direction == "up" else "-"
+        console.success(f"Recorded {symbol}1 for entry {entry_id}")
 
 
 @knowledge_app.command()

--- a/src/wade/services/knowledge_service.py
+++ b/src/wade/services/knowledge_service.py
@@ -72,6 +72,7 @@ class EntryRating(BaseModel):
 
     up: int = 0
     down: int = 0
+    stale: int = 0
     superseded_by: str | None = None
 
 
@@ -317,19 +318,21 @@ def record_rating(
     entry_id: str,
     direction: str,
 ) -> None:
-    """Increment the up or down counter for an entry in the sidecar file.
+    """Increment the up, down, or stale counter for an entry in the sidecar file.
 
-    ``direction`` must be ``"up"`` or ``"down"``.
+    ``direction`` must be ``"up"``, ``"down"``, or ``"stale"``.
     """
-    if direction not in ("up", "down"):
-        raise ValueError(f"Invalid direction {direction!r}: must be 'up' or 'down'")
+    if direction not in ("up", "down", "stale"):
+        raise ValueError(f"Invalid direction {direction!r}: must be 'up', 'down', or 'stale'")
 
     def _modify(data: dict[str, EntryRating]) -> None:
         entry = data.setdefault(entry_id, EntryRating())
         if direction == "up":
             entry.up += 1
-        else:
+        elif direction == "down":
             entry.down += 1
+        else:
+            entry.stale += 1
 
     _read_modify_write_ratings(ratings_path, _modify)
 
@@ -454,11 +457,12 @@ def get_annotated_knowledge(
         entry_rating = ratings.get(entry.entry_id) if entry.entry_id else None
         up = entry_rating.up if entry_rating else 0
         down = entry_rating.down if entry_rating else 0
+        stale = entry_rating.stale if entry_rating else 0
         net_score = up - down
         total_votes = up + down
         should_annotate = entry.entry_id is not None
 
-        # Score filtering
+        # Score and stale filtering
         if not no_filter:
             if min_score is not None:
                 # Hard cutoff mode
@@ -470,6 +474,9 @@ def get_annotated_knowledge(
                 and total_votes >= 5
                 and net_score < auto_threshold
             ):
+                continue
+            # Stale threshold filter (independent of score filter)
+            if entry.entry_id is not None and stale >= 2:
                 continue
 
         # Search/tag filtering (OR semantics)
@@ -489,7 +496,8 @@ def get_annotated_knowledge(
         if heading_match and should_annotate:
             id_part = f"{entry.entry_id} | " if entry.entry_id else ""
             assert entry.date is not None  # entry_id is always accompanied by a date
-            heading = f"## {id_part}{entry.date} | {entry.heading_rest} [+{up}/-{down}]"
+            stale_part = f"/stale:{stale}" if stale > 0 else ""
+            heading = f"## {id_part}{entry.date} | {entry.heading_rest} [+{up}/-{down}{stale_part}]"
             raw_lines = entry.raw.split("\n")
             raw_lines[0] = heading
             result_parts.append("\n".join(raw_lines))

--- a/templates/skills/knowledge/SKILL.md
+++ b/templates/skills/knowledge/SKILL.md
@@ -127,7 +127,7 @@ Knowledge is **not a changelog** — it is a searchable store of facts, gotchas,
 - Content already in `AGENTS.md` or `CLAUDE.md`: anything that is documented there does not need a knowledge entry.
 - Anything reconstructable from `git log`, `git blame`, or reading the current source — if a future agent can find it in 10 seconds, it doesn't belong here.
 
-Entry dates (shown in search results) indicate freshness — rate an entry down if it no longer applies.
+Entry dates (shown in search results) indicate freshness — rate an entry stale if it no longer applies (two stale votes hide it by default; use `--no-filter` to still show it).
 
 ```bash
 echo "Your learnings here" | wade knowledge add --session <type> --issue <number> --tag <topic>

--- a/templates/skills/knowledge/SKILL.md
+++ b/templates/skills/knowledge/SKILL.md
@@ -76,8 +76,9 @@ wade knowledge tag list <entry-id>   # tags for one entry
 **For each entry you open and evaluate, make an explicit decision per the decision tree below** — not per search call. A broad search returning many results does not force you to rate all of them; only entries you actually read and assessed require a decision. Rate up/down when appropriate; otherwise intentionally leave the entry unrated.
 
 ```bash
-wade knowledge rate <entry-id> up    # entry was useful
-wade knowledge rate <entry-id> down  # entry was outdated or misleading
+wade knowledge rate <entry-id> up     # entry was useful
+wade knowledge rate <entry-id> down   # entry is incorrect or misleading
+wade knowledge rate <entry-id> stale  # entry is outdated / no longer applies
 ```
 
 **How to decide:**
@@ -88,7 +89,8 @@ wade knowledge rate <entry-id> down  # entry was outdated or misleading
 2. Search was appropriate; entry came back legitimately:
    - **Useful for your task** → rate **up**.
    - **Correct content but not applicable to your task** → do **not** rate (entry is fine; refine future searches).
-   - **Content is outdated or incorrect** → rate **down**.
+   - **Outdated / no longer applies** → rate **stale**. Two stale votes hide the entry by default; `--no-filter` still shows it.
+   - **Incorrect or misleading** → rate **down**.
    - **Tags or terminology are wrong/missing (content itself is correct)** → do **not** rate down — fix tags via `wade knowledge tag add/remove <id> <tag>`. Downvoting good content for tag problems mis-signals the auto-pruner.
 
 3. **Entry surfaced due to a known parser/search bug** → do not rate; flag as a system issue.
@@ -139,7 +141,8 @@ echo "Corrected info" | wade knowledge add --session <type> --supersedes <old-en
 ## Filtering
 
 By default, entries with enough negative votes are automatically pruned
-(statistical auto-filter). Override with:
+(statistical auto-filter), and entries with `stale >= 2` votes are hidden.
+Override with:
 
 - `--min-score N` — hard cutoff on net score (bypasses auto-filter)
-- `--no-filter` — show everything, no score filtering
+- `--no-filter` — show everything, bypasses both score filtering and stale filtering

--- a/tests/unit/test_cli/test_knowledge_cli.py
+++ b/tests/unit/test_cli/test_knowledge_cli.py
@@ -205,6 +205,64 @@ class TestKnowledgeGetCommand:
         assert "Plain content." in result.output
         assert "[+" not in result.output
 
+    def test_stale_filter_hides_entry_by_default(self, tmp_path: Path) -> None:
+        content = (
+            KNOWLEDGE_TEMPLATE
+            + "\n## a1b2c3d4 | 2026-03-24 | plan\n\nStale content.\n\n---\n"
+            + "\n## f5e6d7c8 | 2026-03-20 | implementation\n\nFresh content.\n\n---\n"
+        )
+        (tmp_path / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        ratings_path = resolve_ratings_path(tmp_path / "KNOWLEDGE.md")
+        ratings_path.write_text(
+            yaml.safe_dump({"a1b2c3d4": {"up": 0, "down": 0, "stale": 2}}),
+            encoding="utf-8",
+        )
+        config = ProjectConfig(
+            project_root=str(tmp_path),
+            knowledge=KnowledgeConfig(enabled=True, path="KNOWLEDGE.md"),
+        )
+        with patch("wade.config.loader.load_config", return_value=config):
+            result = runner.invoke(app, ["knowledge", "get"])
+        assert result.exit_code == 0
+        assert "Stale content." not in result.output
+        assert "Fresh content." in result.output
+
+    def test_no_filter_bypasses_stale_filter(self, tmp_path: Path) -> None:
+        content = (
+            KNOWLEDGE_TEMPLATE + "\n## a1b2c3d4 | 2026-03-24 | plan\n\nStale content.\n\n---\n"
+        )
+        (tmp_path / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        ratings_path = resolve_ratings_path(tmp_path / "KNOWLEDGE.md")
+        ratings_path.write_text(
+            yaml.safe_dump({"a1b2c3d4": {"up": 0, "down": 0, "stale": 5}}),
+            encoding="utf-8",
+        )
+        config = ProjectConfig(
+            project_root=str(tmp_path),
+            knowledge=KnowledgeConfig(enabled=True, path="KNOWLEDGE.md"),
+        )
+        with patch("wade.config.loader.load_config", return_value=config):
+            result = runner.invoke(app, ["knowledge", "get", "--no-filter"])
+        assert result.exit_code == 0
+        assert "Stale content." in result.output
+
+    def test_stale_annotation_shown_in_heading(self, tmp_path: Path) -> None:
+        content = KNOWLEDGE_TEMPLATE + "\n## a1b2c3d4 | 2026-03-24 | plan\n\nContent.\n\n---\n"
+        (tmp_path / "KNOWLEDGE.md").write_text(content, encoding="utf-8")
+        ratings_path = resolve_ratings_path(tmp_path / "KNOWLEDGE.md")
+        ratings_path.write_text(
+            yaml.safe_dump({"a1b2c3d4": {"up": 2, "down": 0, "stale": 1}}),
+            encoding="utf-8",
+        )
+        config = ProjectConfig(
+            project_root=str(tmp_path),
+            knowledge=KnowledgeConfig(enabled=True, path="KNOWLEDGE.md"),
+        )
+        with patch("wade.config.loader.load_config", return_value=config):
+            result = runner.invoke(app, ["knowledge", "get", "--no-filter"])
+        assert result.exit_code == 0
+        assert "[+2/-0/stale:1]" in result.output
+
 
 class TestKnowledgeRateCommand:
     def _setup_knowledge(self, tmp_path: Path) -> ProjectConfig:
@@ -300,6 +358,20 @@ class TestKnowledgeRateCommand:
             result = runner.invoke(app, ["knowledge", "rate", "my_entry_name", "down"])
         assert result.exit_code == 0
         assert "-1" in result.output
+
+    def test_rate_stale(self, tmp_path: Path) -> None:
+        config = self._setup_knowledge(tmp_path)
+        with patch("wade.config.loader.load_config", return_value=config):
+            result = runner.invoke(app, ["knowledge", "rate", "a1b2c3d4", "stale"])
+        assert result.exit_code == 0
+        assert "stale" in result.output.lower()
+
+    def test_exits_1_for_invalid_direction_rejects_non_stale(self, tmp_path: Path) -> None:
+        config = self._setup_knowledge(tmp_path)
+        with patch("wade.config.loader.load_config", return_value=config):
+            result = runner.invoke(app, ["knowledge", "rate", "a1b2c3d4", "sideways"])
+        assert result.exit_code == 1
+        assert "stale" in result.output
 
 
 class TestKnowledgeAddSupersedes:

--- a/tests/unit/test_services/test_knowledge_service.py
+++ b/tests/unit/test_services/test_knowledge_service.py
@@ -394,9 +394,35 @@ class TestRecordRating:
         assert data["a1b2c3d4"].up == 2
         assert data["a1b2c3d4"].down == 1
 
+    def test_records_stale(self, tmp_path: Path) -> None:
+        ratings_path = tmp_path / "KNOWLEDGE.ratings.yml"
+        record_rating(ratings_path, "a1b2c3d4", "stale")
+        data = read_ratings(ratings_path)
+        assert data["a1b2c3d4"].stale == 1
+        assert data["a1b2c3d4"].up == 0
+        assert data["a1b2c3d4"].down == 0
+
+    def test_stale_does_not_affect_net_score(self, tmp_path: Path) -> None:
+        ratings_path = tmp_path / "KNOWLEDGE.ratings.yml"
+        record_rating(ratings_path, "a1b2c3d4", "up")
+        record_rating(ratings_path, "a1b2c3d4", "stale")
+        record_rating(ratings_path, "a1b2c3d4", "stale")
+        data = read_ratings(ratings_path)
+        assert data["a1b2c3d4"].up == 1
+        assert data["a1b2c3d4"].down == 0
+        assert data["a1b2c3d4"].stale == 2
+        assert data["a1b2c3d4"].up - data["a1b2c3d4"].down == 1  # net score unaffected
+
+    def test_stale_increments_independently(self, tmp_path: Path) -> None:
+        ratings_path = tmp_path / "KNOWLEDGE.ratings.yml"
+        record_rating(ratings_path, "a1b2c3d4", "stale")
+        record_rating(ratings_path, "a1b2c3d4", "stale")
+        data = read_ratings(ratings_path)
+        assert data["a1b2c3d4"].stale == 2
+
     def test_rejects_invalid_direction(self, tmp_path: Path) -> None:
         ratings_path = tmp_path / "KNOWLEDGE.ratings.yml"
-        with pytest.raises(ValueError, match="must be 'up' or 'down'"):
+        with pytest.raises(ValueError, match="must be 'up', 'down', or 'stale'"):
             record_rating(ratings_path, "a1b2c3d4", "sideways")
 
     def test_multiple_entries(self, tmp_path: Path) -> None:
@@ -512,6 +538,75 @@ class TestGetAnnotatedKnowledge:
         assert result.content is not None
         assert "Old entry." in result.content
         assert "[+" not in result.content
+
+    def test_stale_annotation_shown_when_positive(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        self._make_knowledge_file(project_root)
+        ratings_path = resolve_ratings_path(project_root / "KNOWLEDGE.md")
+        record_rating(ratings_path, "a1b2c3d4", "stale")
+
+        result = get_annotated_knowledge(project_root, config, no_filter=True)
+        assert result.content is not None
+        assert "[+0/-0/stale:1]" in result.content
+
+    def test_stale_annotation_not_shown_when_zero(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        self._make_knowledge_file(project_root)
+        result = get_annotated_knowledge(project_root, config, no_filter=True)
+        assert result.content is not None
+        assert "stale:" not in result.content
+        assert "[+0/-0]" in result.content
+
+    def test_stale_filter_hides_entries_at_threshold(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        self._make_knowledge_file(project_root)
+        ratings_path = resolve_ratings_path(project_root / "KNOWLEDGE.md")
+        record_rating(ratings_path, "a1b2c3d4", "stale")
+        record_rating(ratings_path, "a1b2c3d4", "stale")  # stale=2 → hidden
+
+        result = get_annotated_knowledge(project_root, config)
+        assert result.content is not None
+        assert "Useful content." not in result.content
+        assert "Outdated content." in result.content  # unaffected entry still shown
+
+    def test_stale_filter_shows_entries_below_threshold(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        self._make_knowledge_file(project_root)
+        ratings_path = resolve_ratings_path(project_root / "KNOWLEDGE.md")
+        record_rating(ratings_path, "a1b2c3d4", "stale")  # stale=1 → not hidden
+
+        result = get_annotated_knowledge(project_root, config)
+        assert result.content is not None
+        assert "Useful content." in result.content
+
+    def test_no_filter_bypasses_stale_threshold(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        self._make_knowledge_file(project_root)
+        ratings_path = resolve_ratings_path(project_root / "KNOWLEDGE.md")
+        for _ in range(5):
+            record_rating(ratings_path, "a1b2c3d4", "stale")
+
+        result = get_annotated_knowledge(project_root, config, no_filter=True)
+        assert result.content is not None
+        assert "Useful content." in result.content
+
+    def test_stale_filter_with_min_score_also_applies(
+        self, project_root: Path, config: KnowledgeConfig
+    ) -> None:
+        self._make_knowledge_file(project_root)
+        ratings_path = resolve_ratings_path(project_root / "KNOWLEDGE.md")
+        record_rating(ratings_path, "a1b2c3d4", "up")
+        record_rating(ratings_path, "a1b2c3d4", "stale")
+        record_rating(ratings_path, "a1b2c3d4", "stale")  # stale=2 → hidden even with min_score
+
+        result = get_annotated_knowledge(project_root, config, min_score=0)
+        assert result.content is not None
+        assert "Useful content." not in result.content
 
 
 class TestBackwardCompatibility:


### PR DESCRIPTION
Closes #307

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem
The knowledge rating system currently only supports `up` and `down` votes. The decision tree conflates two distinct signals into "down": content that is **incorrect/misleading** and content that is **outdated/no longer applies**. Stale content isn't wrong — it just needs to be retired. Treating both as "down" pollutes the auto-filter's "quality" signal with freshness decay, and makes it harder to act on either.

## Proposed Solution
Add a third rating direction, `stale`, to `wade knowledge rate`. Stale votes are tracked in the sidecar ratings file as a separate counter that does NOT affect net score (`up - down`) or the existing statistical auto-filter. Instead, entries with `stale >= 2` are hidden from default `wade knowledge get` output (requires two independent agents to flag staleness, preventing single-agent false positives). The existing `--no-filter` flag bypasses both the auto-filter and the stale-filter; entries always show in `--no-filter` mode.

Headings annotate stale counts only when present: `[+2/-0/stale:1]`. No stale annotation when count is 0 (preserves current `[+N/-M]` format for un-stale entries).

The knowledge skill's decision tree splits the current "outdated or incorrect → down" branch into:
- Outdated / no longer applies → **stale**
- Incorrect / misleading → **down**

## Tasks
- [ ] Add `stale: int = 0` field to `EntryRating` model in `src/wade/services/knowledge_service.py`
- [ ] Extend `record_rating()` to accept `"stale"` direction and increment the stale counter
- [ ] Update `rate` CLI command in `src/wade/cli/knowledge.py` to accept `stale` (alongside `up`/`down`); update error message and success symbol
- [ ] Update `get_annotated_knowledge()` heading annotation to append `/stale:K` only when K > 0
- [ ] Add stale-threshold filtering in `get_annotated_knowledge()`: hide entries where `stale >= 2`, bypassed by `--no-filter`
- [ ] Update `templates/skills/knowledge/SKILL.md`: split decision tree branch, document `stale` value and threshold, add command to rating section
- [ ] Update success message in CLI to handle stale (e.g. `Recorded stale vote for entry <id>`)
- [ ] Add unit tests in `tests/unit/test_services/test_knowledge_service.py`: stale counter increments, stale doesn't affect net score, threshold-based hiding, annotation format
- [ ] Add CLI tests in `tests/unit/test_cli/test_knowledge_cli.py`: accepts `stale` direction; invalid directions still rejected
- [ ] Verify `--no-filter` bypasses the stale threshold filter (existing test extension)

## Acceptance Criteria
- [ ] `wade knowledge rate <id> stale` increments a `stale` counter in `KNOWLEDGE.ratings.yml`
- [ ] `wade knowledge rate <id> <invalid>` still rejects anything except `up`/`down`/`stale`
- [ ] Stale counter does not affect net score or the statistical auto-filter
- [ ] Entries with `stale >= 2` are hidden from `wade knowledge get` by default
- [ ] Entries with `stale >= 2` are shown by `wade knowledge get --no-filter`
- [ ] Entries with `stale < 2` are unaffected
- [ ] Headings show `[+N/-M/stale:K]` when K > 0; `[+N/-M]` when K == 0
- [ ] Knowledge skill SKILL.md decision tree updated to distinguish stale from down
- [ ] All existing tests pass (no breaking changes to up/down behavior or ratings file format)
- [ ] `./scripts/check-all.sh` passes

<!-- wade:plan:end -->


## What was done

Added a third rating direction, `stale`, to `wade knowledge rate`. Stale entries (those that have received two or more stale votes) are hidden from default `wade knowledge get` output but remain visible with `--no-filter`. The stale counter is completely independent of the net score and does not affect the statistical auto-filter.

## Changes

- Added `stale: int = 0` field to `EntryRating` model in `knowledge_service.py`
- Extended `record_rating()` to accept `"stale"` direction (increments stale counter only)
- Added stale-threshold filter in `get_annotated_knowledge()`: entries with `stale >= 2` are hidden unless `no_filter=True`
- Updated heading annotation to show `/stale:K` suffix only when K > 0 (e.g. `[+2/-0/stale:1]`)
- Updated `wade knowledge rate` CLI to accept `stale` with a distinct success message ("Recorded stale vote for entry …")
- Updated `templates/skills/knowledge/SKILL.md` decision tree: split "outdated or incorrect → down" into "outdated/no-longer-applies → stale" and "incorrect/misleading → down"
- Added unit tests for stale counter, net-score independence, threshold filtering, annotation format
- Added CLI tests for stale direction, filter bypass with `--no-filter`, and stale annotation in headings

## Testing

- All 2453 tests pass (`./scripts/check-all.sh`)
- Ruff lint, format, and strict mypy all pass
- New tests cover: stale increments, stale doesn't affect net score, stale=1 not filtered, stale=2 filtered, `--no-filter` bypass, stale annotation shown only when >0, stale filter applies alongside `min_score` mode

## Notes for reviewers

The stale filter is placed inside the `if not no_filter:` block and runs after the score filter (but independently of it) — so entries with `stale >= 2` are hidden in all modes (default, `--min-score`) except `--no-filter`. Backward compatibility is preserved: existing ratings files without a `stale` key deserialize correctly using the Pydantic default of 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "stale" as a third rating option for knowledge entries alongside "up" and "down," allowing users to mark entries as outdated.
  * Entries with 2+ stale votes are now automatically hidden from results; use `--no-filter` to show them.

* **Documentation**
  * Updated knowledge skill documentation to explain the new stale rating feature and filtering behavior.

* **Tests**
  * Added comprehensive test coverage for stale rating functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ivanviragine/wade/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

## What was done

Added a third rating direction, `stale`, to `wade knowledge rate`. Stale entries (those that have received two or more stale votes) are hidden from default `wade knowledge get` output but remain visible with `--no-filter`. The stale counter is completely independent of the net score and does not affect the statistical auto-filter.

## Changes

- Added `stale: int = 0` field to `EntryRating` model in `knowledge_service.py`
- Extended `record_rating()` to accept `"stale"` direction (increments stale counter only)
- Added stale-threshold filter in `get_annotated_knowledge()`: entries with `stale >= 2` are hidden unless `no_filter=True`
- Updated heading annotation to show `/stale:K` suffix only when K > 0 (e.g. `[+2/-0/stale:1]`)
- Updated `wade knowledge rate` CLI to accept `stale` with a distinct success message ("Recorded stale vote for entry …")
- Updated `templates/skills/knowledge/SKILL.md` decision tree: split "outdated or incorrect → down" into "outdated/no-longer-applies → stale" and "incorrect/misleading → down"
- Added unit tests for stale counter, net-score independence, threshold filtering, annotation format
- Added CLI tests for stale direction, filter bypass with `--no-filter`, and stale annotation in headings

## Review comments addressed

- Fixed contradictory guidance in `templates/skills/knowledge/SKILL.md` line 130: changed "rate an entry **down** if it no longer applies" to "rate an entry **stale** if it no longer applies" and added the two-stale-votes hiding behavior / `--no-filter` note to align with the decision tree.

## Testing

- All 2453 tests pass (`./scripts/check-all.sh`)
- Ruff lint, format, and strict mypy all pass
- New tests cover: stale increments, stale doesn't affect net score, stale=1 not filtered, stale=2 filtered, `--no-filter` bypass, stale annotation shown only when >0, stale filter applies alongside `min_score` mode

## Notes for reviewers

The stale filter is placed inside the `if not no_filter:` block and runs after the score filter (but independently of it) — so entries with `stale >= 2` are hidden in all modes (default, `--min-score`) except `--no-filter`. Backward compatibility is preserved: existing ratings files without a `stale` key deserialize correctly using the Pydantic default of 0.

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-4.6` |
| Total tokens | *unavailable* |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `b5f7b61c-0c3d-4fff-aacc-25da4e04c528` |
| Review | `claude` | `95388d72-fa39-4838-93db-65059ca9586d` |

<!-- wade:sessions:end -->
