### PR TITLE
feat: add current Claude models to registry and fix model probe

### DIFF
--- a/scripts/probe_models.py
+++ b/scripts/probe_models.py
@@ -28,7 +28,10 @@ _DOCS_URLS: dict[str, str] = {
 }
 
 _SCRAPE_PATTERNS: dict[str, str] = {
-    "claude": r"claude-[a-z]+-[0-9]+[-\.][0-9]+[a-zA-Z0-9._-]*",
+    # Family-anchored so single-number versions (claude-sonnet-5, claude-fable-5)
+    # are matched too; the trailing \b stops before dated (-20251001) and -v1
+    # suffixes and docs-page slug run-ons (…-introductory-pricing).
+    "claude": r"claude-(?:opus|sonnet|haiku|fable)-\d(?:[.-]\d)?\b",
     "gemini": r"gemini-[0-9][.0-9]*-(flash|pro|ultra)[a-z0-9._-]*",
     "codex": r"gpt-[0-9][.0-9]*[a-zA-Z0-9._-]*",
 }
@@ -145,19 +148,13 @@ def _scrape_models(tool: str) -> set[str]:
 
 
 def probe_claude() -> set[str]:
-    """Probe claude CLI, fallback to scrape."""
-    try:
-        res = subprocess.run(["claude", "models"], capture_output=True, text=True, timeout=15)
-        if res.returncode == 0:
-            models = set()
-            for line in res.stdout.splitlines():
-                if line.strip() and not line.startswith(("#", "-")):
-                    found = re.findall(rf"`({_SCRAPE_PATTERNS['claude']})`", line)
-                    models.update(found)
-            if models:
-                return models
-    except Exception:
-        pass
+    """Discover Claude Code models by scraping the published model overview.
+
+    Claude Code has no non-interactive "list models" command — ``claude models``
+    is interpreted as a prompt, not a subcommand — so the docs scrape is the
+    reliable source. ``_SCRAPE_PATTERNS['claude']`` keeps the result clean
+    (current base IDs only, no dated/-v1 snapshots or Glasswing-only mythos).
+    """
     return _scrape_models("claude")
 
 

--- a/src/wade/config/defaults.py
+++ b/src/wade/config/defaults.py
@@ -9,9 +9,9 @@ from wade.models.config import ComplexityModelMapping
 TOOL_DEFAULTS: dict[str, ComplexityModelMapping] = {
     AIToolID.CLAUDE: ComplexityModelMapping(
         easy="claude-haiku-4.5",
-        medium="claude-sonnet-4.6",
-        complex="claude-sonnet-4.6",
-        very_complex="claude-opus-4.7",
+        medium="claude-sonnet-5",
+        complex="claude-sonnet-5",
+        very_complex="claude-opus-4.8",
     ),
     AIToolID.COPILOT: ComplexityModelMapping(
         easy="claude-haiku-4.5",

--- a/src/wade/data/models.json
+++ b/src/wade/data/models.json
@@ -2,8 +2,11 @@
   "claude": [
     "claude-haiku-4.5",
     "claude-sonnet-4.6",
+    "claude-sonnet-5",
     "claude-opus-4.6",
-    "claude-opus-4.7"
+    "claude-opus-4.7",
+    "claude-opus-4.8",
+    "claude-fable-5"
   ],
   "cursor": [
     "auto",

--- a/tests/e2e/test_admin_contract.py
+++ b/tests/e2e/test_admin_contract.py
@@ -43,11 +43,11 @@ class TestInitCommand:
         assert config["ai"]["default_tool"] == "claude"
         assert config["models"]["claude"]["easy"] == {"model": "claude-haiku-4.5", "effort": None}
         assert config["models"]["claude"]["medium"] == {
-            "model": "claude-sonnet-4.6",
+            "model": "claude-sonnet-5",
             "effort": None,
         }
         assert config["models"]["claude"]["complex"] == {
-            "model": "claude-sonnet-4.6",
+            "model": "claude-sonnet-5",
             "effort": None,
         }
         assert config["models"]["claude"]["medium"] != config["models"]["claude"]["easy"]

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -31,7 +31,7 @@ class TestInit:
         assert config["version"] == 2
         assert config["ai"]["default_tool"] == "claude"
         assert config["models"]["claude"]["medium"] == {
-            "model": "claude-sonnet-4.6",
+            "model": "claude-sonnet-5",
             "effort": None,
         }
         assert config["models"]["claude"]["medium"] != config["models"]["claude"]["easy"]

--- a/tests/unit/test_ai_tools/test_model_registry.py
+++ b/tests/unit/test_ai_tools/test_model_registry.py
@@ -25,6 +25,20 @@ class TestModelRegistry:
     def test_claude_opus_47_in_claude_registry(self) -> None:
         assert "claude-opus-4.7" in get_models_for_tool("claude")
 
+    def test_current_claude_models_in_registry(self) -> None:
+        claude = get_models_for_tool("claude")
+        for model in ("claude-sonnet-5", "claude-opus-4.8", "claude-fable-5"):
+            assert model in claude, f"expected current model {model} in claude registry"
+
+    def test_claude_defaults_use_known_models(self) -> None:
+        from wade.config.defaults import TOOL_DEFAULTS
+
+        known = set(get_models_for_tool("claude"))
+        mapping = TOOL_DEFAULTS[AIToolID.CLAUDE]
+        for model in (mapping.easy, mapping.medium, mapping.complex, mapping.very_complex):
+            if model:
+                assert model in known, f"Claude default '{model}' not in registry"
+
     def test_claude_opus_47_xhigh_in_cursor_registry(self) -> None:
         assert "claude-opus-4-7-xhigh" in get_models_for_tool("cursor")
 

--- a/tests/unit/test_config/test_defaults.py
+++ b/tests/unit/test_config/test_defaults.py
@@ -29,7 +29,7 @@ class TestMediumTierDefaults:
 
     def test_claude_medium_is_sonnet(self) -> None:
         mapping = get_defaults(AIToolID.CLAUDE)
-        assert mapping.medium == "claude-sonnet-4.6"
+        assert mapping.medium == "claude-sonnet-5"
 
     def test_cursor_medium_is_balanced(self) -> None:
         mapping = get_defaults(AIToolID.CURSOR)

--- a/tests/unit/test_probe_cli_args.py
+++ b/tests/unit/test_probe_cli_args.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import patch
@@ -14,6 +15,47 @@ from unittest.mock import patch
 
 def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> CompletedProcess:  # type: ignore[type-arg]
     return CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# probe_claude — docs scrape must catch current models, drop snapshots/slugs
+# ---------------------------------------------------------------------------
+
+
+class TestProbeClaudeScrape:
+    """The scrape must catch single-number versions (sonnet-5, fable-5) that the
+    old two-part-version regex structurally missed, without dragging in dated
+    snapshots, -v1 variants, docs slugs, or Glasswing-only mythos."""
+
+    _DOCS_HTML = (
+        "`claude-sonnet-5` `claude-fable-5` `claude-opus-4-8` "
+        "`claude-haiku-4-5-20251001` `claude-opus-4-6-v1` "
+        "claude-opus-46 claude-mythos-5 claude-sonnet-5-introductory-pricing"
+    )
+
+    def _probe(self) -> set[str]:
+        from probe_models import probe_claude
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/curl"),
+            patch("subprocess.run", return_value=_completed(stdout=self._DOCS_HTML)),
+        ):
+            return probe_claude()
+
+    def test_catches_current_single_number_versions(self) -> None:
+        models = self._probe()
+        assert "claude-sonnet-5" in models
+        assert "claude-fable-5" in models
+        assert "claude-opus-4-8" in models
+        assert "claude-haiku-4-5" in models
+
+    def test_excludes_snapshots_slugs_and_mythos(self) -> None:
+        models = self._probe()
+        assert "claude-mythos-5" not in models
+        assert "claude-opus-46" not in models
+        assert not any(m.endswith("-v1") for m in models)
+        assert not any(re.search(r"-\d{8}$", m) for m in models)
+        assert not any("introductory" in m for m in models)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Brings the Claude model list up to the current lineup and fixes the probe that is supposed to keep it current.

### Model registry / defaults
- `src/wade/data/models.json` — add `claude-sonnet-5`, `claude-opus-4.8`, `claude-fable-5` to the `claude` list (all verified accepted by the Claude Code CLI via `claude --model <id> --print`).
- `src/wade/config/defaults.py` — bump Claude tier defaults: `medium`/`complex` → `claude-sonnet-5`, `very_complex` → `claude-opus-4.8` (`easy` stays `claude-haiku-4.5`; used Opus 4.8 rather than the pricier specialty Fable 5 as the default).

### Probe fix (`scripts/probe_models.py`)
The probe was missing current models for two reasons:
1. **Scrape regex required a two-part version** (e.g. `4.8`), so single-number versions like `claude-sonnet-5` and `claude-fable-5` were structurally invisible. Replaced with a family-anchored, word-boundary pattern that catches them **and** excludes dated snapshots (`-20251001`), `-v1` variants, docs-page slug run-ons (`…-introductory-pricing`), and Glasswing-only `mythos`.
2. **`claude models` is not a subcommand** — Claude Code has no non-interactive list command, so it ran `models` as a *prompt* and returned prose. Removed that call; the docs scrape is the reliable source.

Verified against the live docs, the fixed `probe_claude()` now returns `claude-sonnet-5`, `claude-fable-5`, `claude-opus-4.8` (plus current/legacy base IDs) with zero junk.

## Tests
- Updated `test_claude_medium_is_sonnet` for the new default.
- Added: current-models-in-registry, Claude-defaults-in-registry, and two scrape-pattern regression tests (catch sonnet-5/fable-5; exclude snapshots/slugs/mythos).
- Full unit suite: **2347 passed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for newly available Claude models, including Sonnet 5, Opus 4.8, and Fable 5.
  * Improved Claude model discovery to recognize current model naming formats.

* **Bug Fixes**
  * Updated default Claude model selections to use the latest supported versions.
  * Improved filtering to exclude outdated, preview, snapshot, and introductory model entries.
  * Added validation to ensure configured default models are available in the model registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->