### PR TITLE
refactor: refine auto-stash sync — skip redundant fetch, extend --no-stash to review session, drop dead stash helpers

### DIFF
--- a/src/wade/cli/review_pr_comments_session.py
+++ b/src/wade/cli/review_pr_comments_session.py
@@ -32,6 +32,11 @@ def sync(
     main_branch: str | None = typer.Option(
         None, "--main-branch", help="Override main branch name."
     ),
+    no_stash: bool = typer.Option(
+        False,
+        "--no-stash",
+        help="Disable auto-stash: fail immediately on any uncommitted changes.",
+    ),
 ) -> None:
     """Sync current branch with main."""
     from wade.cli.session_shared import handle_sync_result
@@ -42,6 +47,7 @@ def sync(
         main_branch=main_branch,
         json_output=json_output,
         session_type="review-pr-comments",
+        no_stash=no_stash,
     )
     handle_sync_result(
         result,

--- a/src/wade/git/stash.py
+++ b/src/wade/git/stash.py
@@ -7,20 +7,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import structlog
-from pydantic import BaseModel
 
 from wade.git.repo import GitError, _run_git
 
 log = structlog.get_logger(__name__)
 
 AUTOSTASH_PREFIX = "wade-autostash"
-
-
-class AutoStashEntry(BaseModel):
-    """A single wade autostash entry from the git stash list."""
-
-    ref: str
-    message: str
 
 
 def _stash_message(session_type: str, branch: str) -> str:
@@ -80,34 +72,6 @@ def _find_stash_ref(message: str, cwd: Path) -> str | None:
 def pop_stash(stash_ref: str, cwd: Path) -> subprocess.CompletedProcess[str]:
     """Apply and remove *stash_ref*. Returns CompletedProcess (never raises)."""
     return _run_git("stash", "pop", stash_ref, cwd=cwd, check=False)
-
-
-def apply_stash(stash_ref: str, cwd: Path) -> subprocess.CompletedProcess[str]:
-    """Apply *stash_ref* without removing it. Returns CompletedProcess."""
-    return _run_git("stash", "apply", stash_ref, cwd=cwd, check=False)
-
-
-def drop_stash(stash_ref: str, cwd: Path) -> subprocess.CompletedProcess[str]:
-    """Remove *stash_ref* from the stash list. Returns CompletedProcess."""
-    return _run_git("stash", "drop", stash_ref, cwd=cwd, check=False)
-
-
-def list_wade_autostashes(cwd: Path) -> list[AutoStashEntry]:
-    """Return all wade autostash entries."""
-    result = _run_git("stash", "list", "--format=%gd %gs", cwd=cwd, check=False)
-    if result.returncode != 0:
-        return []
-    entries: list[AutoStashEntry] = []
-    for line in result.stdout.splitlines():
-        if not line.strip():
-            continue
-        parts = line.split(" ", 1)
-        if len(parts) < 2:
-            continue
-        ref, subject = parts[0], parts[1]
-        if AUTOSTASH_PREFIX in subject:
-            entries.append(AutoStashEntry(ref=ref, message=subject))
-    return entries
 
 
 def detect_untracked_collisions(cwd: Path, merge_ref: str) -> list[str]:

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -1726,6 +1726,7 @@ def _merge_base(
     json_output: bool = False,
     abort_on_conflict: bool = False,
     session_type: str = "implementation",
+    already_fetched: bool = False,
 ) -> SyncResult:
     """Fetch, count commits behind, and merge base branch into current branch.
 
@@ -1744,6 +1745,9 @@ def _merge_base(
             path) so the worktree stays clean. When False (sync path), leave
             the merge in progress for the AI to resolve manually.
         session_type: Used in the conflict hint message.
+        already_fetched: Skip the fetch step — the caller already fetched
+            origin (e.g. for the autostash collision probe) and the local
+            ``origin/<main>`` ref is fresh enough for the merge.
 
     Returns:
         SyncResult with success/conflicts/commits_merged (events=[]).
@@ -1756,14 +1760,17 @@ def _merge_base(
         has_remote = False
 
     if has_remote:
-        try:
-            git_sync.fetch_origin(repo_root)
+        if already_fetched:
             merge_ref = f"origin/{resolved_main}"
-            if not json_output:
-                console.detail(f"Fetched latest from origin/{resolved_main}")
-        except GitError:
-            if not json_output:
-                console.warn("Fetch failed; using local main")
+        else:
+            try:
+                git_sync.fetch_origin(repo_root)
+                merge_ref = f"origin/{resolved_main}"
+                if not json_output:
+                    console.detail(f"Fetched latest from origin/{resolved_main}")
+            except GitError:
+                if not json_output:
+                    console.warn("Fetch failed; using local main")
 
     # Count commits behind
     try:
@@ -1884,6 +1891,7 @@ def sync(
     resolved_main = preflight.resolved_main
 
     stash_ref: str | None = None
+    already_fetched = False
 
     if preflight.dirty_category == _DirtyCategory.USER_DIRTY:
         if no_stash:
@@ -1900,6 +1908,7 @@ def sync(
             if has_remote:
                 git_sync.fetch_origin(repo_root)
                 merge_ref_for_probe = f"origin/{resolved_main}"
+                already_fetched = True
         except GitError:
             pass
 
@@ -1966,6 +1975,7 @@ def sync(
         json_output=json_output,
         abort_on_conflict=stash_ref is not None,
         session_type=session_type,
+        already_fetched=already_fetched,
     )
 
     if stash_ref is not None:
@@ -2033,6 +2043,7 @@ def catchup(
     resolved_main = preflight.resolved_main
 
     stash_ref: str | None = None
+    already_fetched = False
 
     if preflight.dirty_category == _DirtyCategory.USER_DIRTY:
         if no_stash:
@@ -2047,6 +2058,7 @@ def catchup(
             if git_repo.has_remote(repo_root):
                 git_sync.fetch_origin(repo_root)
                 merge_ref_for_probe = f"origin/{resolved_main}"
+                already_fetched = True
         except GitError:
             pass
 
@@ -2093,6 +2105,7 @@ def catchup(
         dry_run=dry_run,
         json_output=json_output,
         abort_on_conflict=True,
+        already_fetched=already_fetched,
     )
 
     stash_restored = True


### PR DESCRIPTION
Closes #310

<!-- wade:plan:start -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-stash` option to synchronization commands, allowing operations to fail immediately when uncommitted changes are present.

* **Bug Fixes**
  * Improved synchronization and catch-up workflows to avoid redundant remote fetches.
  * Preserved reliable merge behavior when fetches succeed or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->