### PR TITLE
fix: accept 'in-progress' as a synonym for 'in_progress' in Markdown task state parsing

### DIFF
--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -230,7 +230,9 @@ def _format_section(section: _Section) -> str:
 
 def _section_to_task(section: _Section) -> Task:
     """Convert a parsed _Section to a Task model."""
-    state_str = (section.meta.get("state") or "open").lower()
+    # Accept ``in-progress`` (dash) as a synonym for ``in_progress`` so a
+    # hand-edited file doesn't silently downgrade to OPEN.
+    state_str = (section.meta.get("state") or "open").lower().replace("-", "_")
     state = TaskState(state_str) if state_str in _VALID_STATES else TaskState.OPEN
 
     label_names = _split_labels(section.meta.get("labels", ""))
@@ -580,11 +582,11 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
         rejection, signing failure) is logged at WARNING and swallowed —
         the close itself already succeeded on disk.
         """
-        repo_root = self._path.parent
+        cwd = self._path.parent
         try:
             add = run(
                 ["git", "add", str(self._path)],
-                cwd=repo_root,
+                cwd=cwd,
                 check=False,
             )
             if add.returncode != 0:
@@ -596,7 +598,7 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
                 return
             commit = run(
                 ["git", "commit", "-m", f"chore: close #{task_id}"],
-                cwd=repo_root,
+                cwd=cwd,
                 check=False,
             )
             if commit.returncode != 0:

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -340,6 +340,18 @@ class TestReadTask:
         assert task.title == "Fix parser bug"
         assert task.state == TaskState.CLOSED
 
+    def test_reads_canonical_in_progress_state(self, config_factory) -> None:
+        content = "## #7 Busy task\n\n<!-- wade\nstate: in_progress\n-->\n\nbody\n"
+        provider = config_factory(content)
+        assert provider.read_task("7").state == TaskState.IN_PROGRESS
+
+    def test_accepts_hyphenated_in_progress_synonym(self, config_factory) -> None:
+        # A hand-edited file may use the natural hyphenated form. It must
+        # not silently downgrade to OPEN.
+        content = "## #7 Busy task\n\n<!-- wade\nstate: in-progress\n-->\n\nbody\n"
+        provider = config_factory(content)
+        assert provider.read_task("7").state == TaskState.IN_PROGRESS
+
     def test_raises_when_not_found(self, config_factory) -> None:
         provider = config_factory(SAMPLE_FILE)
         with pytest.raises(TaskNotFoundError):


### PR DESCRIPTION
Closes #312

<!-- wade:plan:start -->
