### PR TITLE
ci: use GitHub App token for auto-version push

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -38,9 +38,18 @@ jobs:
         if: steps.detect.outputs.bump == ''
         run: echo "No conventional commit prefix detected — skipping version bump."
 
+      - name: Generate app token
+        if: steps.detect.outputs.bump != ''
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         if: steps.detect.outputs.bump != ''
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
## Summary
- `auto-version.yml` pushed the version-bump commit and tag using the default `GITHUB_TOKEN`. GitHub explicitly blocks workflow runs triggered by the default token from triggering other workflows, so `release.yml` (which listens for `push: tags: ["v*"]`) never fired automatically after a merge.
- This swaps in an installation token from a new dedicated GitHub App (`ivanviragine-release-bot`, Contents: Read/write only) via `actions/create-github-app-token`, so the tag push is a "real" actor and downstream workflows fire normally. Same fix applied to crossby (ivanviragine/crossby#60), which surfaced the issue.

## Requires
- `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` repo secrets (added).
- The App installed on this repo (done).

## Test plan
- [ ] Merge a `feat:`/`fix:` PR and confirm `release.yml` runs off the resulting tag push (draft release appears without manual intervention)
- [ ] Confirm publishing the draft still triggers `publish.yml` as before