### PR TITLE
fix: prevent infinite self-upgrade re-exec loop in `wade update`

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -113,3 +113,19 @@ and keep `bot_status` as a secondary input only.
 When a service does 'from datetime import UTC, datetime' and calls datetime.now(UTC), patch the module-level class reference (e.g. wade.services.review_service.datetime). Set mock_datetime.now.return_value = fixed_now. Avoid naming local variables 'now' as datetime when the same function later uses 'now = time.time()' (float) — mypy strict mode flags the type mismatch even across mutually-exclusive code paths (use a distinct name like 'settle_now').
 
 ---
+
+## 4863036c | 2026-07-16 | plan | tags: refactoring, testing, mocking, architecture
+
+When splitting a wade service module into submodules, moving a function to a new module breaks tests that patch its dependencies: the suite patches fully-qualified paths heavily (e.g. mock.patch("wade.services.implementation_service.core.git_sync"), ~200+ such sites), and mock.patch binds where a name is looked up. Repoint every moved function's patch targets to its new submodule. Also note: the implementation_service package re-exports via "from .sub import *", which does NOT re-export underscore-prefixed helpers — re-export those explicitly in __init__.py.
+
+---
+
+## a24d65b0 | 2026-07-16 | plan | tags: update, self-upgrade, gotcha
+
+`wade update` self-upgrade can infinitely re-exec. Three defects combine:
+(1) `utils/install._run_upgrade` treats package-manager exit code 0 as a successful upgrade — but `uv tool upgrade wade-cli` exits 0 for no-ops too (already up to date, or the target version is yanked/unavailable), so a no-op is reported as success;
+(2) `services/init_service._maybe_self_upgrade` calls `re_exec()` with no loop guard — after re-exec it re-runs the same check with no memory it just tried and no check that the version actually advanced;
+(3) `utils/update_check.check_for_update` trusts the 2-hour nag cache at `~/.local/share/wade/update-check.json`. A stale/yanked `latest_version` (observed: cache said 0.30.1 while 0.29.6 was installed and was repo HEAD) makes every re-exec take the identical upgrade path → infinite "wade upgraded — restarting..." loop for the whole cache TTL.
+Fix: add a re-exec breadcrumb env var (WADE_SELF_UPGRADE_FROM=<old version>) so a post-re-exec process detects the version did NOT advance and stops with a warning; force a cache-bypassing fresh PyPI check for the explicit self-upgrade path; and skip yanked releases when selecting the latest version.
+
+---

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -9,13 +9,13 @@
   up: 2
 3463fbd4:
   down: 0
-  up: 1
+  up: 2
 54326c98:
   down: 1
   up: 0
 b61e247e:
   down: 0
-  up: 2
+  up: 3
 b6a3a637:
   down: 0
   up: 1
@@ -27,4 +27,4 @@ cedeaad0:
   up: 1
 e2a49ac1:
   down: 0
-  up: 2
+  up: 3

--- a/src/wade/services/init_service.py
+++ b/src/wade/services/init_service.py
@@ -795,10 +795,31 @@ def _maybe_self_upgrade() -> bool:
     Checks PyPI first — only upgrades if a newer version is actually available.
     If upgrade is applied, calls re_exec() which replaces this process.
     Returns True if an upgrade was triggered, False if skipped or up to date.
+
+    Guards against an infinite re-exec loop: immediately before re-exec'ing,
+    the pre-upgrade version is recorded in WADE_SELF_UPGRADE_FROM, which
+    os.execv inherits into the replacement process. On entry, if that
+    breadcrumb is present this call is a post-re-exec retry, so it is always
+    cleared and the function returns False without attempting another
+    upgrade — regardless of whether the version actually advanced.
     """
     from wade import __version__
     from wade.utils.install import InstallMethod, detect_install_method, re_exec, self_upgrade
     from wade.utils.update_check import check_for_update
+
+    breadcrumb = os.environ.pop("WADE_SELF_UPGRADE_FROM", None)
+    if breadcrumb is not None:
+        if breadcrumb == __version__:
+            console.warn(
+                f"self-upgrade did not change the installed version ({__version__}); "
+                "the reported latest may be unavailable — continuing with "
+                f"{__version__}. Use --skip-self-upgrade to skip."
+            )
+        else:
+            logger.info(
+                "_maybe_self_upgrade.upgraded", from_version=breadcrumb, to_version=__version__
+            )
+        return False
 
     method = detect_install_method()
 
@@ -808,12 +829,13 @@ def _maybe_self_upgrade() -> bool:
 
     console.step("Checking for WADE updates...")
 
-    latest = check_for_update(__version__)
+    latest = check_for_update(__version__, force=True)
     if not latest:
         return False  # Already at the latest version
 
     if self_upgrade():
         console.success("wade upgraded — restarting...")
+        os.environ["WADE_SELF_UPGRADE_FROM"] = __version__
         re_exec()  # Does not return
         return True  # pragma: no cover
 

--- a/src/wade/utils/install.py
+++ b/src/wade/utils/install.py
@@ -106,6 +106,11 @@ def re_exec() -> None:
 
     Replaces the current process image so the newly installed code is loaded.
     Does not return.
+
+    Uses os.execv (not execve), so the replacement process inherits the
+    calling process's environment unchanged — callers rely on this to pass
+    state across the re-exec (e.g. init_service._maybe_self_upgrade sets
+    WADE_SELF_UPGRADE_FROM beforehand to guard against re-exec loops).
     """
     executable = sys.argv[0]
 

--- a/src/wade/utils/update_check.py
+++ b/src/wade/utils/update_check.py
@@ -26,20 +26,22 @@ PYPI_URL = "https://pypi.org/pypi/wade-cli/json"
 CACHE_FILE = Path.home() / ".local" / "share" / "wade" / "update-check.json"
 
 
-def _is_newer(candidate: str, current: str) -> bool:
-    """Return True if candidate version is strictly newer than current.
+def _version_tuple(v: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a comparable integer tuple.
 
-    Uses simple numeric tuple comparison — sufficient for standard semver.
-    Falls back to False on any parse error.
+    Uses simple numeric tuple parsing — sufficient for standard semver.
+    Non-numeric segments are dropped; falls back to an empty tuple on any
+    parse error.
     """
     try:
-
-        def to_tuple(v: str) -> tuple[int, ...]:
-            return tuple(int(x) for x in v.split(".")[:3] if x.isdigit())
-
-        return to_tuple(candidate) > to_tuple(current)
+        return tuple(int(x) for x in v.split(".")[:3] if x.isdigit())
     except (ValueError, TypeError):
-        return False
+        return ()
+
+
+def _is_newer(candidate: str, current: str) -> bool:
+    """Return True if candidate version is strictly newer than current."""
+    return _version_tuple(candidate) > _version_tuple(current)
 
 
 def _load_cache() -> dict[str, object] | None:
@@ -72,38 +74,63 @@ def _save_cache(latest_version: str, timestamp: float) -> None:
         pass
 
 
+def _select_latest_non_yanked(releases: dict[str, object]) -> str | None:
+    """Return the highest version among releases with at least one non-yanked file.
+
+    A release with no files, or where every file is yanked, is skipped —
+    PyPI's `info.version` does not account for yanking, so it can point at a
+    release that is no longer installable.
+    """
+    candidates = [
+        version
+        for version, files in releases.items()
+        if isinstance(files, list)
+        and files
+        and not all(isinstance(f, dict) and f.get("yanked") for f in files)
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=_version_tuple)
+
+
 def _fetch_latest_version() -> str | None:
-    """Fetch the latest wade-cli version from PyPI. Returns None on any error."""
+    """Fetch the latest non-yanked wade-cli version from PyPI. Returns None on any error."""
     try:
         with urlopen(PYPI_URL, timeout=5) as resp:
             data = json.loads(resp.read())
-            version = data["info"]["version"]
-            if isinstance(version, str):
-                return version
+            releases = data["releases"]
+            if not isinstance(releases, dict):
+                return None
+            return _select_latest_non_yanked(releases)
     except (URLError, OSError, json.JSONDecodeError, KeyError, TypeError):
         pass
     return None
 
 
-def check_for_update(current_version: str) -> str | None:
+def check_for_update(current_version: str, force: bool = False) -> str | None:
     """Return latest PyPI version if newer than current, else None.
 
-    Uses a 2-hour file cache to avoid hammering PyPI.
+    Uses a 2-hour file cache to avoid hammering PyPI, unless force=True.
 
     Args:
         current_version: The currently installed version string.
+        force: When True, bypass the cache and fetch live from PyPI (the
+            fresh result still refreshes the cache). Used by the explicit
+            self-upgrade path so a stale or yanked cached "latest" cannot
+            drive the upgrade decision.
 
     Returns:
         The latest version string if an update is available, otherwise None.
     """
     now = datetime.now(UTC).timestamp()
 
-    cached = _load_cache()
-    if cached is not None:
-        age = now - float(str(cached["timestamp"]))
-        if age < CHECK_INTERVAL_SECS:
-            latest = str(cached["latest_version"])
-            return latest if _is_newer(latest, current_version) else None
+    if not force:
+        cached = _load_cache()
+        if cached is not None:
+            age = now - float(str(cached["timestamp"]))
+            if age < CHECK_INTERVAL_SECS:
+                latest = str(cached["latest_version"])
+                return latest if _is_newer(latest, current_version) else None
 
     fetched = _fetch_latest_version()
     if fetched:

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,6 +19,7 @@ from wade.services.init_service import (
     _check_gh_auth,
     _clean_gitignore,
     _ensure_wade_dir_self_ignoring,
+    _maybe_self_upgrade,
     _migrate_gitignore_block,
     _patch_config,
     _prompt_ai_section,
@@ -48,6 +50,7 @@ from wade.skills.pointer import (
     remove_pointer,
     write_pointer,
 )
+from wade.utils.install import InstallMethod
 
 # ---------------------------------------------------------------------------
 # Pointer tests
@@ -1430,6 +1433,110 @@ class TestUpdateExtended:
 
         success = update(project_root=tmp_git_repo, skip_self_upgrade=True)
         assert success  # update should succeed and detect version difference
+
+
+# ---------------------------------------------------------------------------
+# _maybe_self_upgrade — re-exec loop guard (issue #321)
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeSelfUpgrade:
+    """A WADE_SELF_UPGRADE_FROM breadcrumb must cap re-exec at one attempt."""
+
+    def setup_method(self) -> None:
+        os.environ.pop("WADE_SELF_UPGRADE_FROM", None)
+
+    def teardown_method(self) -> None:
+        os.environ.pop("WADE_SELF_UPGRADE_FROM", None)
+
+    def test_breadcrumb_unchanged_warns_and_clears_env(self) -> None:
+        """breadcrumb == current version → no re-exec, a warning, env cleared."""
+        from wade import __version__
+
+        os.environ["WADE_SELF_UPGRADE_FROM"] = __version__
+
+        with (
+            patch("wade.utils.install.detect_install_method") as mock_detect,
+            patch("wade.services.init_service.console") as mock_console,
+        ):
+            result = _maybe_self_upgrade()
+
+        assert result is False
+        mock_console.warn.assert_called_once()
+        assert "WADE_SELF_UPGRADE_FROM" not in os.environ
+        mock_detect.assert_not_called()
+
+    def test_breadcrumb_differs_clears_env_without_warning(self) -> None:
+        """breadcrumb != current version → upgrade succeeded, no re-exec, env cleared."""
+        os.environ["WADE_SELF_UPGRADE_FROM"] = "0.0.1"
+
+        with (
+            patch("wade.utils.install.detect_install_method") as mock_detect,
+            patch("wade.services.init_service.console") as mock_console,
+        ):
+            result = _maybe_self_upgrade()
+
+        assert result is False
+        mock_console.warn.assert_not_called()
+        assert "WADE_SELF_UPGRADE_FROM" not in os.environ
+        mock_detect.assert_not_called()
+
+    def test_no_breadcrumb_runs_normal_flow(self) -> None:
+        """No breadcrumb present → proceeds to the ordinary upgrade check."""
+        with patch(
+            "wade.utils.install.detect_install_method", return_value=InstallMethod.UNKNOWN
+        ) as mock_detect:
+            result = _maybe_self_upgrade()
+
+        assert result is False
+        mock_detect.assert_called_once()
+
+    def test_newer_version_sets_breadcrumb_before_re_exec(self) -> None:
+        """A genuinely newer version sets the breadcrumb before calling re_exec()."""
+        from wade import __version__
+
+        captured: dict[str, str] = {}
+
+        def fake_re_exec() -> None:
+            captured["breadcrumb"] = os.environ.get("WADE_SELF_UPGRADE_FROM", "")
+
+        with (
+            patch("wade.utils.install.detect_install_method", return_value=InstallMethod.UV_TOOL),
+            patch("wade.utils.update_check.check_for_update", return_value="99.0.0") as mock_check,
+            patch("wade.utils.install.self_upgrade", return_value=True),
+            patch("wade.utils.install.re_exec", side_effect=fake_re_exec),
+        ):
+            result = _maybe_self_upgrade()
+
+        assert result is True
+        assert captured["breadcrumb"] == __version__
+        mock_check.assert_called_once_with(__version__, force=True)
+
+    def test_at_most_one_re_exec_across_check_upgrade_recheck_chain(self) -> None:
+        """End-to-end: check → upgrade → re-exec → post-re-exec re-check triggers
+        at most one re_exec call across the whole chain."""
+
+        re_exec_calls = 0
+
+        def fake_re_exec() -> None:
+            nonlocal re_exec_calls
+            re_exec_calls += 1
+            # os.execv inherits the current environment into the "new" process —
+            # simulate that by leaving WADE_SELF_UPGRADE_FROM set for the next call.
+
+        with (
+            patch("wade.utils.install.detect_install_method", return_value=InstallMethod.UV_TOOL),
+            patch("wade.utils.update_check.check_for_update", return_value="99.0.0"),
+            patch("wade.utils.install.self_upgrade", return_value=True),
+            patch("wade.utils.install.re_exec", side_effect=fake_re_exec),
+        ):
+            first = _maybe_self_upgrade()  # simulates the pre-upgrade invocation
+            second = _maybe_self_upgrade()  # simulates the post-re-exec invocation
+
+        assert first is True
+        assert second is False
+        assert re_exec_calls == 1
+        assert "WADE_SELF_UPGRADE_FROM" not in os.environ
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_utils/test_update_check.py
+++ b/tests/unit/test_utils/test_update_check.py
@@ -14,9 +14,11 @@ import pytest
 
 from wade.utils.update_check import (
     CHECK_INTERVAL_SECS,
+    _fetch_latest_version,
     _is_newer,
     _load_cache,
     _save_cache,
+    _select_latest_non_yanked,
     check_for_update,
     maybe_print_update_hint,
 )
@@ -184,6 +186,121 @@ class TestCheckForUpdate:
 
         assert result == "2.0.0"
         mock_fetch.assert_not_called()
+
+    def test_force_bypasses_fresh_cache_and_calls_fetcher(self, tmp_path: Path) -> None:
+        """force=True skips a fresh cache entirely and hits the fetcher."""
+        cache_file = tmp_path / "update-check.json"
+        now = datetime.now(UTC).timestamp()
+        cache_file.write_text(
+            json.dumps({"timestamp": now, "latest_version": "2.0.0"}), encoding="utf-8"
+        )
+        with (
+            patch("wade.utils.update_check.CACHE_FILE", cache_file),
+            patch("wade.utils.update_check._fetch_latest_version", return_value="1.3.0"),
+        ):
+            result = check_for_update("1.0.0", force=True)
+
+        assert result == "1.3.0"
+
+    def test_force_refreshes_cache_with_fetched_result(self, tmp_path: Path) -> None:
+        """force=True still writes the freshly fetched result back to the cache."""
+        cache_file = tmp_path / "update-check.json"
+        now = datetime.now(UTC).timestamp()
+        cache_file.write_text(
+            json.dumps({"timestamp": now, "latest_version": "9.9.9"}), encoding="utf-8"
+        )
+        with (
+            patch("wade.utils.update_check.CACHE_FILE", cache_file),
+            patch("wade.utils.update_check._fetch_latest_version", return_value="1.3.0"),
+        ):
+            check_for_update("1.0.0", force=True)
+            cached = _load_cache()
+
+        assert cached is not None
+        assert cached["latest_version"] == "1.3.0"
+
+
+# ---------------------------------------------------------------------------
+# _select_latest_non_yanked / _fetch_latest_version
+# ---------------------------------------------------------------------------
+
+
+class TestSelectLatestNonYanked:
+    def test_picks_highest_version(self) -> None:
+        releases = {
+            "1.0.0": [{"yanked": False}],
+            "1.2.0": [{"yanked": False}],
+            "1.1.0": [{"yanked": False}],
+        }
+        assert _select_latest_non_yanked(releases) == "1.2.0"
+
+    def test_skips_yanked_highest_version(self) -> None:
+        """A yanked highest version is not selected; the next-highest wins."""
+        releases = {
+            "1.0.0": [{"yanked": False}],
+            "1.2.0": [{"yanked": True}],
+            "1.1.0": [{"yanked": False}],
+        }
+        assert _select_latest_non_yanked(releases) == "1.1.0"
+
+    def test_all_yanked_returns_none(self) -> None:
+        releases = {
+            "1.0.0": [{"yanked": True}],
+            "1.1.0": [{"yanked": True}],
+        }
+        assert _select_latest_non_yanked(releases) is None
+
+    def test_release_with_no_files_is_skipped(self) -> None:
+        releases = {
+            "1.0.0": [{"yanked": False}],
+            "1.1.0": [],
+        }
+        assert _select_latest_non_yanked(releases) == "1.0.0"
+
+    def test_release_with_any_non_yanked_file_counts(self) -> None:
+        """A release is usable if at least one of its files isn't yanked."""
+        releases = {
+            "1.0.0": [{"yanked": True}, {"yanked": False}],
+        }
+        assert _select_latest_non_yanked(releases) == "1.0.0"
+
+    def test_empty_releases_returns_none(self) -> None:
+        assert _select_latest_non_yanked({}) is None
+
+
+class TestFetchLatestVersion:
+    def test_ignores_yanked_release_from_pypi(self) -> None:
+        """A yanked info.version is not treated as the latest — the fetcher
+        selects the highest non-yanked release instead."""
+        payload = json.dumps(
+            {
+                "info": {"version": "1.2.0"},
+                "releases": {
+                    "1.0.0": [{"yanked": False}],
+                    "1.2.0": [{"yanked": True}],
+                    "1.1.0": [{"yanked": False}],
+                },
+            }
+        ).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = payload
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = False
+        with patch("wade.utils.update_check.urlopen", return_value=mock_resp):
+            result = _fetch_latest_version()
+
+        assert result == "1.1.0"
+
+    def test_returns_none_when_releases_missing(self) -> None:
+        payload = json.dumps({"info": {"version": "1.0.0"}}).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = payload
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = False
+        with patch("wade.utils.update_check.urlopen", return_value=mock_resp):
+            result = _fetch_latest_version()
+
+        assert result is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #321

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem

`wade update` can enter an infinite loop, repeatedly printing
`wade upgraded — restarting...` while the installed version never changes
(observed stuck at v0.29.6), only escapable with Ctrl-C.

**Root cause** (`services/init_service._maybe_self_upgrade` → `utils/install`):

1. `check_for_update("0.29.6")` reads the 2-hour update-check cache
   (`~/.local/share/wade/update-check.json`), which holds
   `latest_version: "0.30.1"` — a version newer than the repo's own HEAD and
   **not installable** (yanked/unavailable). It returns `"0.30.1"` on every call.
2. `self_upgrade()` runs `uv tool upgrade wade-cli`, which exits **0** without
   changing the installed version (no-op). `_run_upgrade` maps exit-0 → `True`,
   so a no-op is reported as a successful upgrade.
3. `_maybe_self_upgrade` prints the success message and calls `re_exec()`,
   replacing the process with `wade update` again.
4. The re-exec'd process is still 0.29.6 and the cache still says 0.30.1
   (age < 2h) → identical decision → re-exec → infinite loop.

Three defects combine:
- (a) `self_upgrade` cannot distinguish a real upgrade from a no-op;
- (b) there is no loop guard across `re_exec`;
- (c) the self-upgrade gate trusts the soft nag cache, so a stale/yanked
  "latest" traps the loop for the full 2-hour TTL.

Note: this install is `~/.local/share/uv/tools/wade-cli/bin/wade`, so the
package name resolves correctly to `wade-cli` for both the check and the
upgrade — this is **not** a package-name mismatch.

## Proposed Solution

Make an infinite loop **impossible** (at most one re-exec per `wade update`),
and reduce false triggers:

1. **Re-exec breadcrumb** — before `re_exec()`, `_maybe_self_upgrade` sets
   `WADE_SELF_UPGRADE_FROM=<current __version__>` in the environment (inherited
   across `os.execv`). At the top of `_maybe_self_upgrade`, if the breadcrumb is
   present:
   - **version advanced** (`breadcrumb != __version__`): upgrade succeeded —
     clear the breadcrumb, return `False` (proceed with the normal update flow,
     no further upgrade attempt).
   - **version unchanged** (`breadcrumb == __version__`): the previous upgrade
     was a no-op (target unavailable/yanked) — clear the breadcrumb, warn
     (e.g. `self-upgrade did not change the installed version (X); the reported
     latest may be unavailable — continuing with X. Use --skip-self-upgrade to
     skip.`), and return `False`.
   - Always clear the breadcrumb so ordinary `wade` invocations are unaffected.

2. **Force a fresh check for the explicit upgrade path** — add
   `force: bool = False` to `check_for_update`; when `True`, bypass the cache
   read and fetch live from PyPI (still refreshing the cache with the result).
   `_maybe_self_upgrade` calls it with `force=True` so a stale/yanked cached
   "latest" no longer drives the decision.

3. **Prefer non-yanked releases** (hardening) — when selecting the latest
   version in `_fetch_latest_version`, ignore yanked releases so a yanked
   `info.version` cannot be treated as an upgrade target.

Net effect: the breadcrumb guarantees termination regardless of
package-manager behavior; the fresh check + yank-awareness prevent the false
trigger in the first place.

## Tasks
- [ ] `utils/update_check.py`: add `force: bool = False` param to
  `check_for_update` (bypass the cache read when `True`, still write the fresh
  result); update `_fetch_latest_version` to select the highest **non-yanked**
  release from PyPI instead of blindly trusting `info.version`.
- [ ] `services/init_service.py` `_maybe_self_upgrade`: at entry, read and clear
  `WADE_SELF_UPGRADE_FROM`; branch on version-advanced vs. version-unchanged
  (warn) and return `False` in both cases without re-attempting the upgrade.
- [ ] `services/init_service.py` `_maybe_self_upgrade`: call
  `check_for_update(__version__, force=True)`; set
  `WADE_SELF_UPGRADE_FROM=__version__` immediately before `re_exec()`.
- [ ] `utils/install.py`: confirm `re_exec` inherits the environment via
  `os.execv` (breadcrumb set by the caller); document the invariant that the
  breadcrumb propagates across the re-exec. Add an env-injection helper only if
  it reads more cleanly than setting `os.environ` in the caller.
- [ ] Tests (`tests/unit/test_utils/test_update_check.py`):
  `check_for_update(..., force=True)` bypasses a fresh cache and calls the
  fetcher; yanked releases are skipped when picking the latest version.
- [ ] Tests (`tests/unit/test_services/test_init.py` and/or
  `tests/unit/test_utils/test_install.py`): breadcrumb-equal → no re-exec +
  warning + env cleared; breadcrumb-differs → no re-exec + env cleared; first
  pass with a genuinely newer version sets the breadcrumb before `re_exec`;
  end-to-end simulation confirms at most one `re_exec` call across a
  check → upgrade → re-exec → re-check chain.
- [ ] Manually verify: with the cache pinned to an unavailable
  `latest_version`, `wade update` performs at most one restart, then warns and
  completes (no loop). Clean up the stale cache entry left on the machine.
- [ ] Run `./scripts/check-all.sh` (tests + lint + strict types).

## Acceptance Criteria
- [ ] `wade update` never re-execs more than once per invocation: it either
  restarts into a genuinely newer version or warns and continues on the current
  version.
- [ ] A no-op or failed package-manager upgrade (exit 0 but version unchanged)
  no longer triggers a restart loop; the user sees a clear warning.
- [ ] The explicit self-upgrade decision uses a fresh PyPI check (not the stale
  2-hour cache), and yanked releases are not treated as upgrade targets.
- [ ] `WADE_SELF_UPGRADE_FROM` is always cleared after being read, so ordinary
  `wade <cmd>` runs are unaffected by the breadcrumb.
- [ ] `--skip-self-upgrade` still fully bypasses the self-upgrade path.
- [ ] `./scripts/check-all.sh` passes (tests, lint, strict mypy).

<!-- wade:plan:end -->

## Summary

## What was done

Fixed an infinite re-exec loop in `wade update`: a stale/yanked cached "latest
version" combined with `uv tool upgrade` no-op'ing (exit 0, version unchanged)
caused `wade update` to repeatedly print "wade upgraded — restarting..." and
re-exec forever, only escapable with Ctrl-C.

## Changes

- `src/wade/services/init_service.py` (`_maybe_self_upgrade`): added a
  `WADE_SELF_UPGRADE_FROM` re-exec breadcrumb. Before calling `re_exec()`, the
  pre-upgrade version is written to that env var, which `os.execv` inherits
  into the replacement process. On entry, if the breadcrumb is present, it is
  always cleared and the function returns `False` without attempting another
  upgrade — warning the user if the version didn't actually advance (no-op
  upgrade), or logging quietly if it did. This caps re-exec at one attempt per
  `wade update` invocation, regardless of package-manager behavior.
- `src/wade/services/init_service.py`: the explicit self-upgrade check now
  calls `check_for_update(__version__, force=True)` so it always fetches a
  fresh PyPI result instead of trusting the 2-hour nag cache, which can hold a
  stale/yanked "latest" for its full TTL.
- `src/wade/utils/update_check.py`: added `force: bool = False` to
  `check_for_update` (bypasses the cache read, still refreshes the cache with
  the fresh result). `_fetch_latest_version` now selects the highest
  **non-yanked** release from PyPI's `releases` map instead of blindly
  trusting `info.version`, which does not account for yanking.
- `src/wade/utils/install.py`: documented (no behavior change) that `re_exec`
  uses `os.execv`, so the replacement process inherits the environment
  unchanged — this is the invariant the breadcrumb relies on.

## Testing

- Added unit tests in `tests/unit/test_services/test_init.py`
  (`TestMaybeSelfUpgrade`): breadcrumb-equal → warn + no re-exec + env
  cleared; breadcrumb-differs → no re-exec + env cleared, no warning; no
  breadcrumb → normal flow runs; a genuinely newer version sets the
  breadcrumb (and calls `check_for_update` with `force=True`) before
  `re_exec()`; an end-to-end simulation of check → upgrade → re-exec →
  post-re-exec re-check confirms exactly one `re_exec()` call across the
  chain.
- Added unit tests in `tests/unit/test_utils/test_update_check.py`:
  `force=True` bypasses a fresh cache and calls the fetcher, and still
  refreshes the cache with the fetched result; yanked releases are skipped
  when selecting the latest version (including "yanked highest version falls
  back to next-highest" and "all yanked → None" cases); `_fetch_latest_version`
  ignores a yanked `info.version` from a simulated PyPI response.
- Manually reproduced the original bug end-to-end: pinned a temp cache to a
  fresh-timestamp/unavailable "latest_version", stubbed the package manager to
  report a no-op success (exit 0, version unchanged), and confirmed the fixed
  code performs exactly one `re_exec()` call, then warns and completes on the
  simulated post-re-exec invocation — no loop. Cleaned up the real stale
  `~/.local/share/wade/update-check.json` left on this machine from the
  original bug report.
- `./scripts/check-all.sh` passes (2231 tests, ruff lint + format, strict
  mypy on `src/`).

## Notes for reviewers

- `--skip-self-upgrade` is unaffected: it short-circuits before
  `_maybe_self_upgrade()` is ever called, so no breadcrumb is set or read in
  that path.
- The breadcrumb is popped (not just read) at the top of
  `_maybe_self_upgrade`, so it's always cleared regardless of which branch is
  taken — ordinary `wade` invocations after an upgrade are unaffected.

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `118f7376-6658-4021-9bce-6229d161022b` |

<!-- wade:sessions:end -->
