### PR TITLE
fix: skip self-upgrade for editable uv-tool installs

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -129,3 +129,27 @@ When splitting a wade service module into submodules, moving a function to a new
 Fix: add a re-exec breadcrumb env var (WADE_SELF_UPGRADE_FROM=<old version>) so a post-re-exec process detects the version did NOT advance and stops with a warning; force a cache-bypassing fresh PyPI check for the explicit self-upgrade path; and skip yanked releases when selecting the latest version.
 
 ---
+
+## d65003eb | 2026-07-16 | implementation | tags: testing, mocking | Issue #321
+
+Functions imported locally inside a function body (e.g. `from wade.utils.install import detect_install_method` inside `_maybe_self_upgrade()`) must be mock-patched at their *source* module (`wade.utils.install.detect_install_method`), not at the importing module (`wade.services.init_service.detect_install_method`) — the local import re-resolves the name from the source module at call time, so patching the importer's namespace has no effect.
+
+---
+
+## c71d1a70 | 2026-07-16 | implementation | tags: pypi | Issue #321
+
+PyPI's JSON API (pypi.org/pypi/<pkg>/json) does not expose a top-level 'yanked' flag on `info` — yanked status lives per-file inside `releases[version]`, where each file dict has a `yanked` bool. `info.version` does not account for yanking, so it can point at a release that pip/uv will refuse to install; select from `releases` and filter out versions where every file is yanked instead of trusting `info.version`.
+
+---
+
+## bcfa4bb3 | 2026-07-17 | implementation | tags: skills, prompts, architecture | Issue #314
+
+Session prompt templates (templates/prompts/) are NOT symlinked — they are read directly by service code: plan_service.py and implementation_service/draft_pr.py (build_implementation_prompt, moved there from core.py in the #314 split). Skill files (templates/skills/) ARE symlinked into .claude/skills/. When fixing agent instructions, check BOTH the skill files AND the prompt templates.
+
+---
+
+## 0bad70f3 | 2026-07-17 | implementation | tags: testing, mocking, refactoring | Issue #314
+
+When splitting a wade service module, a module-level dependency import must stay module-level (not function-local) if any test patches it via that module (e.g. done.load_config). mock.patch resolves the attribute on the module object; a function-local import re-binds from the source module at call time, so the patch is silently ignored. Also: a moved helper imported into several modules is patched in the CALLER's namespace (e.g. find_worktree_path is patched at done./cleanup./core. depending on which function is under test), not where it is defined (_shared).
+
+---

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -13,6 +13,10 @@
 54326c98:
   down: 1
   up: 0
+a24d65b0:
+  down: 0
+  superseded_by: c71d1a70
+  up: 1
 b61e247e:
   down: 0
   up: 3

--- a/src/wade/utils/install.py
+++ b/src/wade/utils/install.py
@@ -10,7 +10,9 @@ import os
 import shutil
 import subprocess
 import sys
+import tomllib
 from enum import StrEnum
+from pathlib import Path
 
 import structlog
 
@@ -39,12 +41,32 @@ def _package_name_for_self_upgrade() -> str:
     return PACKAGE_NAME
 
 
+def _is_editable_uv_tool(exe: str) -> bool:
+    """Return True if the uv-tool env at ``exe`` was installed with --editable.
+
+    `uv tool upgrade` is a no-op against an editable install — it just
+    re-resolves the local source path, which reports the same version until
+    that source changes — so treating it as a normal UV_TOOL would make
+    self-upgrade silently do nothing forever. The tool env's uv-receipt.toml
+    records an `editable = "<path>"` key on the requirement for such installs.
+    """
+    receipt = Path(exe).parent.parent / "uv-receipt.toml"
+    try:
+        with receipt.open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    requirements = data.get("tool", {}).get("requirements", [])
+    return any(isinstance(req, dict) and "editable" in req for req in requirements)
+
+
 def detect_install_method() -> InstallMethod:
     """Infer how wade was installed by inspecting sys.executable."""
     exe = sys.executable
 
     if "/.local/share/uv/tools/" in exe or "\\.local\\share\\uv\\tools\\" in exe:
-        return InstallMethod.UV_TOOL
+        return InstallMethod.EDITABLE if _is_editable_uv_tool(exe) else InstallMethod.UV_TOOL
     if "/.local/pipx/venvs/" in exe or "\\pipx\\venvs\\" in exe:
         return InstallMethod.PIPX
     if "/homebrew/" in exe.lower() or "/cellar/" in exe.lower():

--- a/tests/unit/test_utils/test_install.py
+++ b/tests/unit/test_utils/test_install.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from wade.utils.install import (
@@ -54,6 +55,50 @@ class TestDetectInstallMethod:
         with patch("wade.utils.install.sys") as mock_sys:
             mock_sys.executable = "/usr/local/bin/python3"
             assert detect_install_method() == InstallMethod.UNKNOWN
+
+    def test_detects_editable_uv_tool(self, tmp_path: Path) -> None:
+        """A uv-tool env installed with --editable → EDITABLE, not UV_TOOL.
+
+        `uv tool upgrade` is a no-op against an editable install, so it must
+        be treated like a dev checkout and skipped by self-upgrade.
+        """
+        tool_dir = tmp_path / ".local" / "share" / "uv" / "tools" / "wade-cli"
+        (tool_dir / "bin").mkdir(parents=True)
+        exe = tool_dir / "bin" / "python3"
+        exe.touch()
+        receipt = (
+            "[tool]\n"
+            'requirements = [{ name = "wade-cli", editable = "/Users/user/workspace/wade" }]\n'
+            "entrypoints = []\n"
+        )
+        _ = (tool_dir / "uv-receipt.toml").write_text(receipt)
+
+        with patch("wade.utils.install.sys") as mock_sys:
+            mock_sys.executable = str(exe)
+            assert detect_install_method() == InstallMethod.EDITABLE
+
+    def test_detects_non_editable_uv_tool(self, tmp_path: Path) -> None:
+        """A normal (non-editable) uv-tool env with a receipt still → UV_TOOL."""
+        tool_dir = tmp_path / ".local" / "share" / "uv" / "tools" / "wade-cli"
+        (tool_dir / "bin").mkdir(parents=True)
+        exe = tool_dir / "bin" / "python3"
+        exe.touch()
+        receipt = (
+            "[tool]\n"
+            'requirements = [{ name = "wade-cli", specifier = "==0.30.2" }]\n'
+            "entrypoints = []\n"
+        )
+        _ = (tool_dir / "uv-receipt.toml").write_text(receipt)
+
+        with patch("wade.utils.install.sys") as mock_sys:
+            mock_sys.executable = str(exe)
+            assert detect_install_method() == InstallMethod.UV_TOOL
+
+    def test_uv_tool_without_receipt_defaults_to_uv_tool(self) -> None:
+        """No uv-receipt.toml on disk (e.g. mocked path) → falls back to UV_TOOL."""
+        with patch("wade.utils.install.sys") as mock_sys:
+            mock_sys.executable = "/home/user/.local/share/uv/tools/wade-cli/bin/python"
+            assert detect_install_method() == InstallMethod.UV_TOOL
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `detect_install_method()` classified any executable under `~/.local/share/uv/tools/` as a normal `UV_TOOL` install, even when installed with `--editable` (e.g. a local dev checkout registered globally via `uv tool install --editable .`).
- `uv tool upgrade` is a no-op against an editable install — it just re-resolves the local source, which reports the same version until that source changes — so `wade update`'s self-upgrade would report success, re-exec, and land back on the unchanged version every time, always hitting the "self-upgrade did not change the installed version" warning added in #322.
- Now inspects the tool env's `uv-receipt.toml` for an `editable` requirement and classifies those installs as `EDITABLE`, which self-upgrade already skips.

## Test plan
- [x] `uv run pytest tests/unit/test_utils/test_install.py -q` — 25 passed (3 new cases: editable receipt → `EDITABLE`, non-editable receipt → `UV_TOOL`, missing receipt → falls back to `UV_TOOL`)
- [x] `uv run pytest tests/unit -q` — 2028 passed
- [x] `uv run ruff check src/wade/utils/install.py tests/unit/test_utils/test_install.py` — clean
- [x] Reproduced against my own machine's install (`uv tool install --editable` of this repo) before the fix and confirmed the classification now correctly returns `EDITABLE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-upgrade detection for editable installations, preventing them from being treated as standard tool upgrades.
  * Preserved correct detection for regular installations and environments without installation metadata.

* **Documentation**
  * Added project guidance for mocking locally imported functions, selecting valid package versions, and understanding template sourcing.
  * Added a rating and supersession record for an existing knowledge document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->