### PR TITLE
fix: remove(stale=True) misclassifies worktree as ACTIVE when provider read fails in CI (regression from #315)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -153,3 +153,21 @@ Session prompt templates (templates/prompts/) are NOT symlinked — they are rea
 When splitting a wade service module, a module-level dependency import must stay module-level (not function-local) if any test patches it via that module (e.g. done.load_config). mock.patch resolves the attribute on the module object; a function-local import re-binds from the source module at call time, so the patch is silently ignored. Also: a moved helper imported into several modules is patched in the CALLER's namespace (e.g. find_worktree_path is patched at done./cleanup./core. depending on which function is under test), not where it is defined (_shared).
 
 ---
+
+## b7ff010c | 2026-07-17 | implementation | tags: refactoring, architecture, imports | Issue #317
+
+When splitting a service module into a package, a constant/helper shared by a leaf submodule and an upper one must live in the LEAF, not the upper module — the upper already imports from the leaf, so hosting it upstream creates an import cycle. E.g. init_service `_COMMAND_OVERRIDE_NAMES` belongs in config_io (a leaf), not prompts_setup, since prompts_setup imports `_resolve_models` from config_io.
+
+---
+
+## 129ab9bd | 2026-07-17 | plan | tags: testing, providers, error-handling | Issue #326
+
+GitHubProvider.read_task_or_none() raises RuntimeError (not silently returns None) on any gh CLI failure that isn't a genuine 'not found' match — e.g. missing GH_TOKEN, auth, network, rate-limit. Callers relying on it as a fail-safe (e.g. classify_staleness's task_lookup_failed) must catch exceptions around the call, not just check for None.
+
+---
+
+## 3045ea00 | 2026-07-17 | plan | tags: testing, mocking, ci | Issue #326
+
+Tests that call remove(stale=True)/_remove_stale() or list_sessions() in cleanup.py must mock wade.services.implementation_service.cleanup.get_provider (not just cleanup.load_config), or they instantiate a real GitHubProvider and shell out to gh — passing locally with authenticated gh but failing in CI with no GH_TOKEN. See TestListSessions.test_gracefully_handles_issue_lookup_failures for the mocking pattern.
+
+---

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -1,3 +1,7 @@
+0bad70f3:
+  down: 0
+  stale: 0
+  up: 3
 164c355e:
   down: 0
   stale: 0
@@ -17,7 +21,7 @@
 4863036c:
   down: 0
   stale: 0
-  up: 1
+  up: 4
 54326c98:
   down: 1
   stale: 0
@@ -25,6 +29,7 @@
 a24d65b0:
   down: 0
   stale: 0
+  superseded_by: c71d1a70
   up: 1
 b61e247e:
   down: 0
@@ -43,6 +48,10 @@ cedeaad0:
   down: 1
   stale: 0
   up: 1
+d65003eb:
+  down: 0
+  stale: 0
+  up: 2
 e2a49ac1:
   down: 0
   stale: 0

--- a/tests/integration/test_implementation_lifecycle.py
+++ b/tests/integration/test_implementation_lifecycle.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from wade.models.config import ProjectConfig, ProjectSettings
 from wade.models.session import WorktreeState
@@ -204,10 +204,18 @@ class TestImplementationLifecycle:
         create_worktree(tmp_git_repo, "feat/42-auth", wt1, "main")
         create_worktree(tmp_git_repo, "feat/43-db", wt2, "main")
 
-        with patch(
-            "wade.services.implementation_service.cleanup.load_config",
-            return_value=ProjectConfig(
-                project=ProjectSettings(main_branch="main"),
+        provider = MagicMock()
+        provider.read_task_or_none.return_value = None
+
+        with (
+            patch(
+                "wade.services.implementation_service.cleanup.load_config",
+                return_value=ProjectConfig(
+                    project=ProjectSettings(main_branch="main"),
+                ),
+            ),
+            patch(
+                "wade.services.implementation_service.cleanup.get_provider", return_value=provider
             ),
         ):
             # List should show both

--- a/tests/unit/test_services/test_implementation_done_sync.py
+++ b/tests/unit/test_services/test_implementation_done_sync.py
@@ -1327,10 +1327,18 @@ class TestListSessions:
         wt_dir = tmp_git_repo.parent / "wt-42"
         create_worktree(tmp_git_repo, "feat/42-test", wt_dir, "main")
 
-        with patch(
-            "wade.services.implementation_service.cleanup.load_config",
-            return_value=ProjectConfig(
-                project=ProjectSettings(main_branch="main"),
+        provider = MagicMock()
+        provider.read_task_or_none.return_value = None
+
+        with (
+            patch(
+                "wade.services.implementation_service.cleanup.load_config",
+                return_value=ProjectConfig(
+                    project=ProjectSettings(main_branch="main"),
+                ),
+            ),
+            patch(
+                "wade.services.implementation_service.cleanup.get_provider", return_value=provider
             ),
         ):
             sessions = list_sessions(project_root=tmp_git_repo)
@@ -1354,10 +1362,18 @@ class TestListSessions:
         wt_dir = tmp_git_repo.parent / "wt-42"
         create_worktree(tmp_git_repo, "feat/42-test", wt_dir, "main")
 
-        with patch(
-            "wade.services.implementation_service.cleanup.load_config",
-            return_value=ProjectConfig(
-                project=ProjectSettings(main_branch="main"),
+        provider = MagicMock()
+        provider.read_task_or_none.return_value = None
+
+        with (
+            patch(
+                "wade.services.implementation_service.cleanup.load_config",
+                return_value=ProjectConfig(
+                    project=ProjectSettings(main_branch="main"),
+                ),
+            ),
+            patch(
+                "wade.services.implementation_service.cleanup.get_provider", return_value=provider
             ),
         ):
             sessions = list_sessions(json_output=True, project_root=tmp_git_repo)
@@ -1447,10 +1463,18 @@ class TestRemove:
         wt_dir = tmp_git_repo.parent / "wt-42"
         create_worktree(tmp_git_repo, "feat/42-test", wt_dir, "main")
 
-        with patch(
-            "wade.services.implementation_service.cleanup.load_config",
-            return_value=ProjectConfig(
-                project=ProjectSettings(main_branch="main"),
+        provider = MagicMock()
+        provider.read_task_or_none.return_value = None
+
+        with (
+            patch(
+                "wade.services.implementation_service.cleanup.load_config",
+                return_value=ProjectConfig(
+                    project=ProjectSettings(main_branch="main"),
+                ),
+            ),
+            patch(
+                "wade.services.implementation_service.cleanup.get_provider", return_value=provider
             ),
         ):
             # Stale but no force — should still return True (preview mode)
@@ -1466,15 +1490,52 @@ class TestRemove:
         wt_dir = tmp_git_repo.parent / "wt-42"
         create_worktree(tmp_git_repo, "feat/42-test", wt_dir, "main")
 
-        with patch(
-            "wade.services.implementation_service.cleanup.load_config",
-            return_value=ProjectConfig(
-                project=ProjectSettings(main_branch="main"),
+        provider = MagicMock()
+        provider.read_task_or_none.return_value = None
+
+        with (
+            patch(
+                "wade.services.implementation_service.cleanup.load_config",
+                return_value=ProjectConfig(
+                    project=ProjectSettings(main_branch="main"),
+                ),
+            ),
+            patch(
+                "wade.services.implementation_service.cleanup.get_provider", return_value=provider
             ),
         ):
             result = remove(stale=True, force=True, project_root=tmp_git_repo)
             assert result
             assert not wt_dir.exists()
+
+    def test_remove_stale_provider_failure_keeps_worktree(self, tmp_git_repo: Path) -> None:
+        """A provider read failure (e.g. unauthenticated gh in CI) must not cause
+        --force --stale to delete a worktree whose issue state is unknown."""
+        from wade.git.worktree import create_worktree
+        from wade.services.implementation_service import remove
+
+        wt_dir = tmp_git_repo.parent / "wt-42"
+        create_worktree(tmp_git_repo, "feat/42-test", wt_dir, "main")
+
+        provider = MagicMock()
+        provider.read_task_or_none.side_effect = RuntimeError("gh unavailable")
+
+        with (
+            patch(
+                "wade.services.implementation_service.cleanup.load_config",
+                return_value=ProjectConfig(
+                    project=ProjectSettings(main_branch="main"),
+                ),
+            ),
+            patch(
+                "wade.services.implementation_service.cleanup.get_provider", return_value=provider
+            ),
+        ):
+            result = remove(stale=True, force=True, project_root=tmp_git_repo)
+            assert result
+            # Fail-safe: unknown issue state keeps the worktree ACTIVE, so
+            # --force --stale must not remove it.
+            assert wt_dir.exists()
 
     def test_remove_no_args(self, tmp_git_repo: Path) -> None:
         from wade.services.implementation_service import remove


### PR DESCRIPTION
Closes #326

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

The CI `test` job fails on Python 3.11 / 3.12 / 3.13 on a single test:

```
tests/unit/test_services/test_implementation_done_sync.py::TestRemove::test_remove_stale_with_force
AssertionError: assert not True   # the worktree was NOT removed
```

It passes locally (where `gh` is authenticated) but fails in CI, and is now red
on `main`, blocking every PR's CI including unrelated refactors.

**Regression window:** Green at `v0.30.3` / #323. Red starting at #315
("modularize `implementation_service/core.py` into focused submodules") and
still red at `v0.31.0`. The test file itself was not changed by #315 — the
behavior of the code it exercises changed (the split surfaced a pre-existing
test-isolation gap).

**Root cause:** `test_remove_stale_with_force` (and `test_remove_stale_no_force`)
in `tests/unit/test_services/test_implementation_done_sync.py::TestRemove`
never mock `wade.services.implementation_service.cleanup.get_provider`. They
only patch `cleanup.load_config`, so `remove(stale=True, ...)` resolves a real,
unmocked `GitHubProvider()` via `get_provider(config)` and calls
`_remove_stale(..., provider)`, which invokes
`provider.read_task_or_none("42")` — shelling out to the real `gh` CLI.

In CI there is no `GH_TOKEN`. `GitHubProvider.read_task_or_none`
(`src/wade/providers/github.py:185-229`) distinguishes "not found" from other
failures: for a genuine "not found" stderr match it returns `None`, but for
any other failure (auth, network, rate-limit — exactly the no-token case) it
logs `github.read_task_or_none_failed` (WARNING) and **raises `RuntimeError`**.
Note: this differs slightly from the issue's original write-up, which
describes the read as "returning `None` without raising" — the actual
mechanism is a raised exception, but the net effect is identical.

`_remove_stale` (`src/wade/services/implementation_service/cleanup.py:240-252`)
wraps that call in `try/except Exception`, catches the `RuntimeError`, logs
`implementation.remove_stale_issue_read_failed`, and sets
`task_lookup_failed = True`. `classify_staleness`
(`src/wade/services/implementation_service/sync.py:49-123`) then hits its
documented fail-safe: *"If `task_lookup_failed` is True, issue state is
treated as unknown and the worktree is kept `ACTIVE`."* This is intentional,
correct behavior — it exists specifically so `--force --stale` never deletes
a worktree whose issue state couldn't be verified.

Because the worktree is (correctly) classified `ACTIVE`, `_remove_stale` finds
`stale_wts` empty, logs "No stale worktrees found," and never touches
`wt-42` — so `test_remove_stale_with_force`'s `assert not wt_dir.exists()`
fails. `test_remove_stale_no_force` doesn't fail (its assertions hold either
way), but it also isn't testing what it claims: it's meant to verify
"stale-but-no-force previews without removing," yet the worktree involved is
never actually classified stale, so the preview path isn't exercised.

**This is a test-isolation bug, not a production bug.** The fail-safe
classification logic (`task_lookup_failed` → `ACTIVE`) already does exactly
what the issue's "Provider-failure classification" proposal (item 2) asks
for. `TestListSessions.test_gracefully_handles_issue_lookup_failures`
(same test file, ~line 1366) already covers this exact fail-safe for the
`list_sessions()` path by mocking `cleanup.get_provider`; the `_remove_stale`
path has no equivalent mock, which is the actual gap.

## Proposed Solution

Test-only fix in `tests/unit/test_services/test_implementation_done_sync.py`.
No production code changes.

1. Fix `test_remove_stale_with_force` and `test_remove_stale_no_force` to
   patch `wade.services.implementation_service.cleanup.get_provider` with a
   `MagicMock` provider whose `read_task_or_none` returns `None` (simulating
   a clean "issue not found," not a lookup failure). With zero commits ahead
   of `main` (the worktree created by the test has none), this deterministically
   yields `WorktreeState.STALE_EMPTY`, so:
   - `test_remove_stale_with_force` (`force=True`) removes the worktree.
   - `test_remove_stale_no_force` (`force=False`) previews only and leaves the
     worktree in place — now genuinely exercising the preview path.
2. Add a new regression test (e.g.
   `test_remove_stale_provider_failure_keeps_worktree`) that mocks
   `get_provider().read_task_or_none` to raise (mirroring
   `TestListSessions.test_gracefully_handles_issue_lookup_failures`'s
   pattern), and asserts that `remove(stale=True, force=True, ...)` does
   **not** remove the worktree — explicit coverage for the exact CI scenario
   (provider read fails → fail-safe keeps the worktree `ACTIVE`).
3. Verify locally with `GH_TOKEN` unset to prove CI-equivalence before
   running the full suite.

## Tasks

- [ ] Reproduce the CI failure locally with `gh` auth fully sandboxed — not
      just `GH_TOKEN` unset, since a locally-authenticated `gh auth login`
      session (stored in `~/.config/gh/hosts.yml` or the system keychain)
      would otherwise still succeed and mask the issue. Use e.g.
      `env -u GH_TOKEN -u GH_ENTERPRISE_TOKEN GH_CONFIG_DIR=$(mktemp -d) ./scripts/test.sh tests/unit/test_services/test_implementation_done_sync.py -k TestRemove`
      and confirm `test_remove_stale_with_force` fails with the diagnosed cause.
- [ ] Grep the test tree for other callers of `remove()` / `_remove_stale()` /
      `list_sessions()` that patch `cleanup.load_config` but not
      `cleanup.get_provider`, to confirm these two tests are the only instance
      of this anti-pattern (no other latent live-`gh`-dependent test).
- [ ] Update `test_remove_stale_with_force` in
      `tests/unit/test_services/test_implementation_done_sync.py` to patch
      `wade.services.implementation_service.cleanup.get_provider` with a
      `MagicMock()` (`read_task_or_none.return_value = None`), following the
      `with patch(...), patch(...):` pattern already used in
      `test_gracefully_handles_issue_lookup_failures`.
- [ ] Apply the same `get_provider` mock to `test_remove_stale_no_force` so it
      deterministically tests the preview-mode (no removal) path.
- [ ] Add `test_remove_stale_provider_failure_keeps_worktree` (or similar
      name) to `TestRemove`: mock `get_provider().read_task_or_none` with
      `side_effect = RuntimeError(...)`, call
      `remove(stale=True, force=True, project_root=tmp_git_repo)`, and assert
      `wt_dir.exists()` — the concrete, load-bearing check (the return value
      alone doesn't distinguish "correctly kept ACTIVE" from other
      early-return-`True` paths).
- [ ] Re-run the sandboxed-`gh` command from step 1 to confirm all
      `TestRemove` tests pass without live `gh` auth.
- [ ] Run `./scripts/test.sh` (full suite) and `./scripts/check.sh` to confirm
      no regressions.

## Acceptance Criteria

- [ ] `test_remove_stale_with_force` passes in CI (no `GH_TOKEN`) and locally.
- [ ] Neither `test_remove_stale_with_force` nor `test_remove_stale_no_force`
      depends on live `gh` authentication or network access — both mock
      `cleanup.get_provider`.
- [ ] A new test explicitly covers "provider read fails → worktree stays
      `ACTIVE` and is not deleted by `--force --stale`," asserted via
      `wt_dir.exists()`.
- [ ] No other test in the suite exhibits the same unmocked-`get_provider`
      anti-pattern for `remove()` / `_remove_stale()` / `list_sessions()`.
- [ ] `./scripts/test.sh` and `./scripts/check.sh` pass.
- [ ] No production code changes — `remove(stale=True)`'s existing fail-safe
      behavior (keep a worktree `ACTIVE` when the provider read fails) is
      confirmed correct via tests, not altered.

<!-- wade:plan:end -->

## Summary

## What was done

Fixed a test-isolation bug causing `test_remove_stale_with_force` (and related
tests) to fail in CI on Python 3.11/3.12/3.13, while passing locally. No
production code changed — the fail-safe behavior being tested was already
correct.

## Why these changes

CI has no `GH_TOKEN`. `test_remove_stale_with_force` and
`test_remove_stale_no_force` only mocked `cleanup.load_config`, not
`cleanup.get_provider`, so `remove(stale=True, ...)` resolved a real
`GitHubProvider` and shelled out to `gh`. In CI, `read_task_or_none` raises
`RuntimeError` (unauthenticated), `_remove_stale` catches it and sets
`task_lookup_failed = True`, and `classify_staleness`'s documented fail-safe
correctly keeps the worktree `ACTIVE` (issue state unknown → never delete).
Because the worktree stayed `ACTIVE`, `_remove_stale` found no stale
worktrees and never removed it — failing the test's
`assert not wt_dir.exists()`.

This was a regression surfaced by #315 (module split), not introduced by it —
the underlying test-isolation gap pre-existed; the refactor just changed
whether it manifested.

## Changes

- `tests/unit/test_services/test_implementation_done_sync.py`:
  - `test_remove_stale_with_force` / `test_remove_stale_no_force`: mock
    `cleanup.get_provider` with a `MagicMock` returning `None` from
    `read_task_or_none`, deterministically classifying the worktree
    `STALE_EMPTY` (zero commits ahead) so `force=True` actually exercises
    removal and `force=False` actually exercises the preview path.
  - Added `test_remove_stale_provider_failure_keeps_worktree`: mocks
    `get_provider().read_task_or_none` to raise `RuntimeError`, asserting
    `remove(stale=True, force=True, ...)` does **not** remove the worktree —
    explicit regression coverage for the exact CI failure mode.
  - `TestListSessions.test_lists_worktrees` and `test_json_output`: also
    patched to mock `get_provider`. These weren't failing, but exhibited the
    identical unmocked-provider anti-pattern (their assertions just didn't
    depend on the provider outcome) — found via a repo-wide grep for
    `cleanup.load_config` callers, beyond the two tests named in the issue.
- `tests/integration/test_implementation_lifecycle.py`:
  - `test_list_and_remove_flow`: same fix, same reasoning.

## Testing

- Reproduced the CI failure locally with fully sandboxed `gh` auth:
  `env -u GH_TOKEN -u GH_ENTERPRISE_TOKEN GH_CONFIG_DIR=$(mktemp -d) ./scripts/test.sh ... -k TestRemove`
  — confirmed `test_remove_stale_with_force` failed with the diagnosed
  `RuntimeError` from `GitHubProvider.read_task_or_none`.
- Re-ran the same sandboxed command after the fix: all `TestRemove` and
  `TestListSessions` tests pass (11/11), plus the integration test, with zero
  live `gh` dependency.
- `./scripts/test.sh` (full suite): 2238 passed.
- `./scripts/check.sh`: ruff lint, ruff format, and mypy --strict all clean.
- `wade review implementation`: clean, no actionable findings.

## Notes for reviewers

- Confirmed via `remove()`'s source that `target`-based removal
  (`_remove_target`) never calls `get_provider`, so `test_remove_by_target`,
  `test_remove_unknown_target`, and `test_remove_no_args` don't need the same
  fix — only the `stale=True` path (`_remove_stale`) and `list_sessions()`
  call the provider.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | **98,014** |
| Input tokens | **97,400** |
| Output tokens | **614** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `1c725b10-d170-482f-af77-8d1c24d3c5ea` |

<!-- wade:sessions:end -->
