### PR TITLE
feat: supersede existing issue when planning splits it into multiple plan files

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -171,3 +171,9 @@ GitHubProvider.read_task_or_none() raises RuntimeError (not silently returns Non
 Tests that call remove(stale=True)/_remove_stale() or list_sessions() in cleanup.py must mock wade.services.implementation_service.cleanup.get_provider (not just cleanup.load_config), or they instantiate a real GitHubProvider and shell out to gh — passing locally with authenticated gh but failing in CI with no GH_TOKEN. See TestListSessions.test_gracefully_handles_issue_lookup_failures for the mocking pattern.
 
 ---
+
+## 702b274f | 2026-07-21 | plan | tags: prompts, cli, ux
+
+wade/ui/prompts.py helpers (confirm, input_prompt, choice, etc.) return their default when stdin is not a TTY (they guard on is_tty()). When adding an interactive prompt in a service/CLI path, do NOT write your own non-interactive detection — just pass a sensible default and rely on this. The idiom for an auto-proceed-under-yolo confirmation is: proceed = yolo or prompts.confirm(msg, default=True).
+
+---

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -174,6 +174,12 @@ Tests that call remove(stale=True)/_remove_stale() or list_sessions() in cleanup
 
 ## 702b274f | 2026-07-21 | plan | tags: prompts, cli, ux
 
-wade/ui/prompts.py helpers (confirm, input_prompt, choice, etc.) return their default when stdin is not a TTY (they guard on is_tty()). When adding an interactive prompt in a service/CLI path, do NOT write your own non-interactive detection — just pass a sensible default and rely on this. The idiom for an auto-proceed-under-yolo confirmation is: proceed = yolo or prompts.confirm(msg, default=True).
+wade/ui/prompts.py helpers such as confirm, input_prompt, select, and menu return their configured default when stdin is not a TTY; multi_select returns all items. When adding an interactive prompt in a service/CLI path, do NOT write your own non-interactive detection — just pass a sensible default and rely on this. The idiom for an auto-proceed-under-yolo confirmation is: proceed = yolo or prompts.confirm(msg, default=True).
+
+---
+
+## c7a450ff | 2026-07-21 | implementation | tags: testing, python | Issue #330
+
+Python's parenthesized with-statement (with (a, b, c):) does not support unpacking a list of context managers via *patches — it's a syntax error, not a runtime one. To share a list of mock.patch(...) objects across multiple tests, use contextlib.ExitStack() and call stack.enter_context(p) for each, capturing return values for assertions.
 
 ---

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -14,6 +14,10 @@
   down: 0
   stale: 0
   up: 2
+3045ea00:
+  down: 0
+  stale: 0
+  up: 1
 3463fbd4:
   down: 0
   stale: 0

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ Short aliases: `wade p` (plan), `wade i <N>` (implement), `wade r <N>` (review p
 
 Most workflow commands accept `--ai <tool>`, `--model <model>`, `--effort <level>`, and `--yolo` to override configured defaults. `implement` also supports `--detach` (new terminal tab) and `--cd` (print worktree path only).
 
+`wade plan --issue <N>` re-plans an existing issue. If the session produces a
+single plan file, it's attached to `#N` and the issue stays open. If the
+session decides the work should be split into several independent pieces
+(2+ plan files), `#N` is **superseded**: a new issue + draft PR is created
+per plan file, a comment and a `> **Superseded by ...**` banner are added to
+`#N`, and it's closed as *not planned* (confirmed via prompt unless
+`--yolo`/non-interactive). If any plan file fails to become an issue, `#N` is
+left open with a warning instead of superseding on a partial split.
+
 ## Supported AI Tools
 
 Adapters, model/effort resolution, and per-tool config (allowlists, hooks) are powered by [`crossby`](https://github.com/ivanviragine/crossby), WADE's AI-tool-integration dependency.

--- a/src/wade/models/task.py
+++ b/src/wade/models/task.py
@@ -27,6 +27,18 @@ class TaskState(StrEnum):
     CLOSED = "closed"
 
 
+class CloseReason(StrEnum):
+    """Typed reason for closing a task — maps to provider-specific close semantics.
+
+    GitHub renders ``NOT_PLANNED`` as a grey "closed as not planned" state,
+    distinct from the default "closed as completed". Providers without a
+    close-reason concept accept and ignore it.
+    """
+
+    COMPLETED = "completed"
+    NOT_PLANNED = "not planned"
+
+
 class LabelType(StrEnum):
     """Categories of labels managed by WADE."""
 

--- a/src/wade/providers/base.py
+++ b/src/wade/providers/base.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 
 from wade.models.config import ProviderConfig
 from wade.models.review import PRComment, PRReviewStatus, ReviewThread
-from wade.models.task import Label, Task, TaskState
+from wade.models.task import CloseReason, Label, Task, TaskState
 
 
 class AbstractTaskProvider(ABC):
@@ -85,8 +85,11 @@ class AbstractTaskProvider(ABC):
         """Update task title and/or body."""
 
     @abstractmethod
-    def close_task(self, task_id: str) -> Task:
-        """Close a task."""
+    def close_task(self, task_id: str, reason: CloseReason | None = None) -> Task:
+        """Close a task, optionally with a typed reason (e.g. GitHub's "not planned").
+
+        Providers without a close-reason concept accept and ignore ``reason``.
+        """
 
     @abstractmethod
     def comment_on_task(self, task_id: str, body: str) -> None:

--- a/src/wade/providers/clickup.py
+++ b/src/wade/providers/clickup.py
@@ -14,6 +14,7 @@ import structlog
 
 from wade.models.config import ProviderConfig
 from wade.models.task import (
+    CloseReason,
     Label,
     Task,
     TaskState,
@@ -219,8 +220,12 @@ class ClickUpProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
 
         return self.read_task(task_id)
 
-    def close_task(self, task_id: str) -> Task:
-        """Close a task by setting its status to 'closed'."""
+    def close_task(self, task_id: str, reason: CloseReason | None = None) -> Task:
+        """Close a task by setting its status to 'closed'.
+
+        ClickUp has no close-reason concept — ``reason`` is accepted for
+        interface parity with other providers and ignored.
+        """
         self._client.put(
             f"/api/v2/task/{task_id}",
             json={"status": "closed"},

--- a/src/wade/providers/github.py
+++ b/src/wade/providers/github.py
@@ -31,6 +31,7 @@ from wade.models.review import (
     filter_unresolved_threads,
 )
 from wade.models.task import (
+    CloseReason,
     Label,
     Task,
     TaskState,
@@ -269,10 +270,13 @@ class GitHubProvider(AbstractTaskProvider):
 
         return self.read_task(task_id)
 
-    def close_task(self, task_id: str) -> Task:
-        """Close an issue."""
-        run(["gh", "issue", "close", task_id], check=True, retries=3)
-        logger.info("github.issue_closed", number=task_id)
+    def close_task(self, task_id: str, reason: CloseReason | None = None) -> Task:
+        """Close an issue, optionally with a reason (e.g. "not planned")."""
+        cmd = ["gh", "issue", "close", task_id]
+        if reason is not None:
+            cmd.extend(["--reason", reason.value])
+        run(cmd, check=True, retries=3)
+        logger.info("github.issue_closed", number=task_id, reason=reason.value if reason else None)
         return self.read_task(task_id)
 
     def comment_on_task(self, task_id: str, body: str) -> None:

--- a/src/wade/providers/markdown.py
+++ b/src/wade/providers/markdown.py
@@ -57,6 +57,7 @@ else:  # pragma: no cover -- exercised only on Windows
 
 from wade.models.config import ProviderConfig
 from wade.models.task import (
+    CloseReason,
     Label,
     Task,
     TaskState,
@@ -552,11 +553,14 @@ class MarkdownIssueProvider(GitHubPRDelegateMixin, AbstractTaskProvider):
             self._persist(prelude, sections)
         return _section_to_task(section)
 
-    def close_task(self, task_id: str) -> Task:
+    def close_task(self, task_id: str, reason: CloseReason | None = None) -> Task:
         """Mark a task ``closed`` and strip the in-progress label.
 
         If ``auto_commit`` is set in provider settings, commits the change
         to git so the merge flow doesn't leave the working tree dirty.
+
+        The markdown provider has no close-reason concept — ``reason`` is
+        accepted for interface parity with other providers and ignored.
         """
         with self._lock():
             prelude, sections = self._load_sections()

--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -789,7 +789,7 @@ def _attach_plan_to_existing_issue(
         console.warn("Not in a git repo — skipping draft PR creation.")
 
 
-_SUPERSEDE_BANNER_RE = re.compile(r"\A>\s*\*\*Superseded by[^\n]*\*\*\n*")
+_SUPERSEDE_BANNER_RE = re.compile(r"\A\s*>\s*\*\*Superseded by[^\n]*\*\*\n*")
 
 
 def _with_supersede_banner(body: str, issue_refs: str) -> str:

--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 
 from wade.config.loader import load_config
 from wade.models.config import ProjectConfig
-from wade.models.task import PlanFile, Task
+from wade.models.task import CloseReason, PlanFile, Task
 from wade.providers.base import AbstractTaskProvider
 from wade.providers.registry import get_provider
 from wade.services.ai_resolution import (
@@ -540,23 +540,39 @@ def plan(
         if not usage.total_tokens:
             _warn_token_extraction(transcript_path)
 
-    # Existing issue — attach plan files to it (no new issue created)
+    # Existing issue — attach the plan to it, or supersede it if the session
+    # decided the work should be split into multiple issues.
     if existing_issue is not None:
         plan_files = validate_plan_files(Path(plan_dir))
         if plan_files:
             console.info(f"Found {len(plan_files)} plan file(s)")
-            _attach_plan_to_existing_issue(
-                provider=provider,
-                config=config,
-                issue=existing_issue,
-                plan_files=plan_files,
-                repo_root=repo_root,
-            )
+            if len(plan_files) == 1:
+                _attach_plan_to_existing_issue(
+                    provider=provider,
+                    config=config,
+                    issue=existing_issue,
+                    plan_file=plan_files[0],
+                    repo_root=repo_root,
+                )
+                finalize_issue_numbers = [existing_issue.id]
+            else:
+                finalize_issue_numbers = _supersede_issue_with_plans(
+                    provider=provider,
+                    config=config,
+                    issue=existing_issue,
+                    plan_files=plan_files,
+                    repo_root=repo_root,
+                    yolo=resolved_yolo,
+                )
             stop_title_keeper()
+            if not finalize_issue_numbers:
+                console.warn("No issues were created from plan files.")
+                _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
+                return False
             offer_result = _finalize_issues(
                 provider=provider,
                 config=config,
-                issue_numbers=[existing_issue.id],
+                issue_numbers=finalize_issue_numbers,
                 ai_tool=resolved_tool,
                 model=resolved_model,
                 usage=usage,
@@ -579,7 +595,7 @@ def plan(
 
     if plan_files:
         console.info(f"Found {len(plan_files)} plan file(s)")
-        created_numbers = _create_issues_from_plans(
+        created_numbers, _failed_files = _create_issues_from_plans(
             provider=provider,
             config=config,
             plan_files=plan_files,
@@ -649,7 +665,7 @@ def _create_issues_from_plans(
     config: ProjectConfig,
     plan_files: list[PlanFile],
     repo_root: Path | None = None,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     """Create lightweight GitHub issues + draft PRs from validated plan files.
 
     Each plan file produces:
@@ -657,11 +673,13 @@ def _create_issues_from_plans(
     2. A ``complexity:X`` label
     3. A draft PR with the full plan content
 
-    Returns list of created issue numbers.
+    Returns a tuple of (created issue numbers, names of plan files that failed
+    to become issues).
     """
     from wade.git import repo as git_repo
 
     created: list[str] = []
+    failed: list[str] = []
 
     # Resolve repo root for draft PR creation
     if repo_root is None:
@@ -686,6 +704,7 @@ def _create_issues_from_plans(
             console.success(f"Created {console.issue_ref(task.id, task.title)}")
         except Exception as e:
             console.error(f"Failed to create issue: {e}")
+            failed.append(plan.path.name)
             continue
 
         # Add complexity label
@@ -720,33 +739,26 @@ def _create_issues_from_plans(
 
         created.append(task.id)
 
-    return created
+    return created, failed
 
 
 def _attach_plan_to_existing_issue(
     provider: AbstractTaskProvider,
     config: ProjectConfig,
     issue: Task,
-    plan_files: list[PlanFile],
+    plan_file: PlanFile,
     repo_root: Path | None,
 ) -> None:
-    """Attach the first plan file to an existing issue via a draft PR.
+    """Attach a single plan file to an existing issue via a draft PR.
 
     Reuses the same label / PR / body-update logic as _create_issues_from_plans
     but skips issue creation since the issue already exists.  The original issue
     body is preserved — the PR link is appended rather than replacing it.
     """
-    if len(plan_files) > 1:
-        console.warn(
-            f"Multiple plan files found — using '{plan_files[0].path.name}', "
-            f"ignoring {len(plan_files) - 1} other(s)."
-        )
-    plan = plan_files[0]
-
     # Add complexity label
-    if plan.complexity:
+    if plan_file.complexity:
         try:
-            add_complexity_label(provider, issue.id, plan.complexity)
+            add_complexity_label(provider, issue.id, plan_file.complexity)
         except Exception as e:
             logger.warning("plan.complexity_label_failed", error=str(e))
 
@@ -755,7 +767,7 @@ def _attach_plan_to_existing_issue(
         pr_info = bootstrap_draft_pr(
             issue_number=issue.id,
             issue_title=issue.title,
-            plan_body=plan.body,
+            plan_body=plan_file.body,
             config=config,
             repo_root=repo_root,
         )
@@ -775,6 +787,91 @@ def _attach_plan_to_existing_issue(
             console.warn(f"Could not create draft PR for #{issue.id}")
     else:
         console.warn("Not in a git repo — skipping draft PR creation.")
+
+
+_SUPERSEDE_BANNER_RE = re.compile(r"\A>\s*\*\*Superseded by[^\n]*\*\*\n*")
+
+
+def _with_supersede_banner(body: str, issue_refs: str) -> str:
+    """Prepend a 'Superseded by' banner, replacing any existing one instead of stacking."""
+    banner = f"> **Superseded by {issue_refs}**"
+    rest = _SUPERSEDE_BANNER_RE.sub("", body or "", count=1).strip("\n")
+    return f"{banner}\n\n{rest}" if rest else banner
+
+
+def _supersede_issue_with_plans(
+    provider: AbstractTaskProvider,
+    config: ProjectConfig,
+    issue: Task,
+    plan_files: list[PlanFile],
+    repo_root: Path | None,
+    yolo: bool,
+) -> list[str]:
+    """Split an existing issue into one new issue per plan file and supersede it.
+
+    Creates a new lightweight issue + draft PR for every plan file (reusing
+    _create_issues_from_plans). Only if every plan file became an issue does
+    this comment on and close the original issue as "not planned" — a partial
+    result leaves the original open so the split is never silently incomplete.
+
+    Returns the list of successfully created issue numbers — the caller must
+    pass only these to _finalize_issues, never the closed original.
+    """
+    created_numbers, failed_files = _create_issues_from_plans(
+        provider=provider,
+        config=config,
+        plan_files=plan_files,
+        repo_root=repo_root,
+    )
+
+    if failed_files:
+        console.warn(
+            f"Only {len(created_numbers)}/{len(plan_files)} plan file(s) became issues "
+            f"— leaving #{issue.id} open. Failed: {', '.join(failed_files)}"
+        )
+        logger.warning(
+            "plan.supersede_partial_failure",
+            issue=issue.id,
+            plan_file_count=len(plan_files),
+            created_count=len(created_numbers),
+        )
+        return created_numbers
+
+    issue_refs = ", ".join(f"#{n}" for n in created_numbers)
+
+    try:
+        provider.comment_on_task(
+            issue.id,
+            f"\U0001f500 Superseded during planning — split into {issue_refs}.",
+        )
+    except Exception as e:
+        logger.warning("plan.supersede_comment_failed", issue=issue.id, error=str(e))
+        console.warn(f"Could not comment on #{issue.id}: {e}")
+
+    try:
+        updated_body = _with_supersede_banner(issue.body or "", issue_refs)
+        provider.update_task(issue.id, body=updated_body)
+    except Exception as e:
+        logger.warning("plan.supersede_banner_failed", issue=issue.id, error=str(e))
+        console.warn(f"Could not update #{issue.id} body: {e}")
+
+    console.empty()
+    proceed = yolo or prompts.confirm(
+        f"Close #{issue.id} as superseded by {issue_refs}?",
+        default=True,
+    )
+    if not proceed:
+        console.info(f"Leaving #{issue.id} open — superseded by {issue_refs}.")
+        return created_numbers
+
+    try:
+        provider.close_task(issue.id, reason=CloseReason.NOT_PLANNED)
+        console.success(f"Closed #{issue.id} as not planned — superseded by {issue_refs}")
+    except Exception as e:
+        logger.warning("plan.supersede_close_failed", issue=issue.id, error=str(e))
+        console.warn(f"Could not close #{issue.id}: {e}")
+
+    return created_numbers
 
 
 def _finalize_issues(

--- a/tests/unit/test_providers/test_clickup.py
+++ b/tests/unit/test_providers/test_clickup.py
@@ -342,6 +342,20 @@ class TestCloseTask:
         assert call_json["status"] == "closed"
         assert task.state == TaskState.CLOSED
 
+    def test_close_task_ignores_reason(self, provider: ClickUpProvider) -> None:
+        """ClickUp has no close-reason concept — reason is accepted and ignored."""
+        from wade.models.task import CloseReason
+
+        provider._client = MagicMock()
+        provider._client.get.return_value = _make_raw_task(status="closed")
+
+        task = provider.close_task("abc123", reason=CloseReason.NOT_PLANNED)
+
+        provider._client.put.assert_called_once()
+        call_json = provider._client.put.call_args[1]["json"]
+        assert call_json == {"status": "closed"}
+        assert task.state == TaskState.CLOSED
+
 
 class TestCommentOnTask:
     def test_comment(self, provider: ClickUpProvider) -> None:

--- a/tests/unit/test_providers/test_github.py
+++ b/tests/unit/test_providers/test_github.py
@@ -332,6 +332,28 @@ class TestCloseTask:
         # First call is close, second is read
         first_cmd = mock_run.call_args_list[0][0][0]
         assert "close" in first_cmd
+        assert "--reason" not in first_cmd
+
+    @patch("wade.providers.github.run")
+    def test_close_with_not_planned_reason(
+        self, mock_run: MagicMock, provider: GitHubProvider
+    ) -> None:
+        from wade.models.task import CloseReason
+
+        read_response = json.dumps(
+            {
+                "number": 42,
+                "title": "t",
+                "body": "",
+                "state": "CLOSED",
+                "labels": [],
+            }
+        )
+        mock_run.return_value = _make_completed(read_response)
+
+        provider.close_task("42", reason=CloseReason.NOT_PLANNED)
+        first_cmd = mock_run.call_args_list[0][0][0]
+        assert first_cmd == ["gh", "issue", "close", "42", "--reason", "not planned"]
 
 
 class TestCommentOnTask:

--- a/tests/unit/test_providers/test_markdown.py
+++ b/tests/unit/test_providers/test_markdown.py
@@ -413,6 +413,15 @@ class TestCloseTask:
         with pytest.raises(TaskNotFoundError):
             provider.close_task("999")
 
+    def test_close_ignores_reason(self, config_factory) -> None:
+        """Markdown has no close-reason concept — reason is accepted and ignored."""
+        from wade.models.task import CloseReason
+
+        provider = config_factory(SAMPLE_FILE)
+        task = provider.close_task("1", reason=CloseReason.NOT_PLANNED)
+        assert task.state == TaskState.CLOSED
+        assert provider.read_task("1").state == TaskState.CLOSED
+
     def test_preserves_existing_file_mode(self, config_factory) -> None:
         # Atomic write must not silently strip group/other perms.
         provider = config_factory(SAMPLE_FILE)

--- a/tests/unit/test_services/test_plan_service.py
+++ b/tests/unit/test_services/test_plan_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -10,11 +11,14 @@ import pytest
 from crossby.models.ai import TokenUsage
 
 from wade.models.config import AIConfig, ProjectConfig
-from wade.models.task import PlanFile
+from wade.models.task import CloseReason, PlanFile, Task
 from wade.services.ai_resolution import resolve_ai_tool, resolve_model
 from wade.services.plan_service import (
+    _attach_plan_to_existing_issue,
     _finalize_issues,
     _offer_to_implement,
+    _supersede_issue_with_plans,
+    _with_supersede_banner,
     discover_plan_files,
     get_plan_prompt_template,
     plan,
@@ -737,7 +741,10 @@ class TestPlanOrchestrator:
                 return_value=TokenUsage(total_tokens=123),
             ),
             patch("wade.services.plan_service.validate_plan_files", return_value=[plan_file]),
-            patch("wade.services.plan_service._create_issues_from_plans", return_value=["101"]),
+            patch(
+                "wade.services.plan_service._create_issues_from_plans",
+                return_value=(["101"], []),
+            ),
             patch(
                 "wade.services.plan_service._finalize_issues", return_value=None
             ) as mock_finalize,
@@ -901,3 +908,339 @@ class TestFinalizeIssuesHints:
             mock_offer.assert_not_called()
             mock_console.detail.assert_called_with("wade implement-batch 1 2 3")
             assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _attach_plan_to_existing_issue — single PlanFile
+# ---------------------------------------------------------------------------
+
+
+class TestAttachPlanToExistingIssue:
+    def test_attaches_single_plan_file_preserving_original_body(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        issue = Task(id="42", title="Some issue", body="Original body")
+        plan_path = tmp_path / "PLAN.md"
+        plan_path.write_text("# feat: thing\n\n## Tasks\n- Do it\n")
+        plan_file = PlanFile.from_markdown(plan_path)
+
+        with (
+            patch(
+                "wade.services.plan_service.bootstrap_draft_pr",
+                return_value={"number": 99, "url": "https://example.com/pr/99"},
+            ),
+            patch("wade.services.plan_service.add_complexity_label"),
+            patch("wade.services.plan_service.console"),
+        ):
+            _attach_plan_to_existing_issue(
+                provider=provider,
+                config=ProjectConfig(),
+                issue=issue,
+                plan_file=plan_file,
+                repo_root=tmp_path,
+            )
+
+        provider.update_task.assert_called_once()
+        updated_body = provider.update_task.call_args.kwargs["body"]
+        assert "Original body" in updated_body
+        assert "PR #99" in updated_body
+
+
+# ---------------------------------------------------------------------------
+# _with_supersede_banner — banner idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestWithSupersedeBanner:
+    def test_prepends_banner_to_body(self) -> None:
+        result = _with_supersede_banner("Original content", "#1, #2")
+        assert result == "> **Superseded by #1, #2**\n\nOriginal content"
+
+    def test_replaces_existing_banner_instead_of_stacking(self) -> None:
+        body = "> **Superseded by #1, #2**\n\nOriginal content"
+        result = _with_supersede_banner(body, "#1, #2, #3")
+        assert result.count("Superseded by") == 1
+        assert "#1, #2, #3" in result
+        assert "Original content" in result
+
+    def test_empty_body_returns_banner_only(self) -> None:
+        result = _with_supersede_banner("", "#1, #2")
+        assert result == "> **Superseded by #1, #2**"
+
+
+# ---------------------------------------------------------------------------
+# _supersede_issue_with_plans
+# ---------------------------------------------------------------------------
+
+
+class TestSupersedeIssueWithPlans:
+    def _make_plan_files(self, tmp_path: Path, n: int) -> list[PlanFile]:
+        files = []
+        for i in range(n):
+            p = tmp_path / f"PLAN-{i}.md"
+            p.write_text(f"# feat: part {i}\n\n## Tasks\n- Do {i}\n")
+            files.append(PlanFile.from_markdown(p))
+        return files
+
+    def test_full_success_closes_original_as_not_planned(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        issue = Task(id="330", title="Big feature", body="Original body")
+        plan_files = self._make_plan_files(tmp_path, 3)
+
+        with (
+            patch(
+                "wade.services.plan_service._create_issues_from_plans",
+                return_value=(["101", "102", "103"], []),
+            ),
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console"),
+        ):
+            mock_prompts.confirm.return_value = True
+
+            result = _supersede_issue_with_plans(
+                provider=provider,
+                config=ProjectConfig(),
+                issue=issue,
+                plan_files=plan_files,
+                repo_root=None,
+                yolo=False,
+            )
+
+        assert result == ["101", "102", "103"]
+
+        provider.comment_on_task.assert_called_once()
+        comment_body = provider.comment_on_task.call_args.args[1]
+        assert "#101, #102, #103" in comment_body
+
+        provider.update_task.assert_called_once()
+        updated_body = provider.update_task.call_args.kwargs["body"]
+        assert "Superseded by #101, #102, #103" in updated_body
+        assert "Original body" in updated_body
+
+        provider.close_task.assert_called_once_with("330", reason=CloseReason.NOT_PLANNED)
+
+    def test_partial_failure_leaves_issue_open(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        issue = Task(id="330", title="Big feature", body="Original body")
+        plan_files = self._make_plan_files(tmp_path, 3)
+
+        with (
+            patch(
+                "wade.services.plan_service._create_issues_from_plans",
+                return_value=(["101", "102"], ["PLAN-2.md"]),
+            ),
+            patch("wade.services.plan_service.console") as mock_console,
+        ):
+            result = _supersede_issue_with_plans(
+                provider=provider,
+                config=ProjectConfig(),
+                issue=issue,
+                plan_files=plan_files,
+                repo_root=None,
+                yolo=True,
+            )
+
+        assert result == ["101", "102"]
+        provider.comment_on_task.assert_not_called()
+        provider.update_task.assert_not_called()
+        provider.close_task.assert_not_called()
+        mock_console.warn.assert_called_once()
+        assert "PLAN-2.md" in mock_console.warn.call_args.args[0]
+
+    def test_yolo_skips_confirmation_prompt(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        issue = Task(id="330", title="Big feature", body="")
+        plan_files = self._make_plan_files(tmp_path, 2)
+
+        with (
+            patch(
+                "wade.services.plan_service._create_issues_from_plans",
+                return_value=(["101", "102"], []),
+            ),
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console"),
+        ):
+            _supersede_issue_with_plans(
+                provider=provider,
+                config=ProjectConfig(),
+                issue=issue,
+                plan_files=plan_files,
+                repo_root=None,
+                yolo=True,
+            )
+
+        mock_prompts.confirm.assert_not_called()
+        provider.close_task.assert_called_once_with("330", reason=CloseReason.NOT_PLANNED)
+
+    def test_user_declines_close_leaves_issue_open(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        issue = Task(id="330", title="Big feature", body="")
+        plan_files = self._make_plan_files(tmp_path, 2)
+
+        with (
+            patch(
+                "wade.services.plan_service._create_issues_from_plans",
+                return_value=(["101", "102"], []),
+            ),
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console"),
+        ):
+            mock_prompts.confirm.return_value = False
+
+            result = _supersede_issue_with_plans(
+                provider=provider,
+                config=ProjectConfig(),
+                issue=issue,
+                plan_files=plan_files,
+                repo_root=None,
+                yolo=False,
+            )
+
+        assert result == ["101", "102"]
+        provider.close_task.assert_not_called()
+        # Comment and banner are applied regardless of the close decision.
+        provider.comment_on_task.assert_called_once()
+        provider.update_task.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# plan() — existing-issue branch: attach vs supersede
+# ---------------------------------------------------------------------------
+
+
+class TestPlanExistingIssueBranch:
+    def _base_patches(
+        self,
+        tmp_path: Path,
+        provider: MagicMock,
+        adapter: MagicMock,
+        plan_files: list[PlanFile],
+    ) -> list[contextlib.AbstractContextManager[MagicMock]]:
+        return [
+            patch(
+                "wade.services.plan_service.load_config",
+                return_value=ProjectConfig(ai=AIConfig(default_tool="claude")),
+            ),
+            patch("wade.services.plan_service.get_provider", return_value=provider),
+            patch("wade.services.plan_service.resolve_ai_tool", return_value="claude"),
+            patch("wade.services.plan_service.resolve_model", return_value=None),
+            patch(
+                "wade.services.plan_service.confirm_ai_selection",
+                return_value=("claude", None, None, False),
+            ),
+            patch("wade.services.plan_service.ensure_task_label"),
+            patch("wade.services.plan_service.run_ai_planning_session", return_value=0),
+            patch("wade.services.plan_service.AbstractAITool.get", return_value=adapter),
+            patch(
+                "wade.services.plan_service._extract_token_usage",
+                return_value=TokenUsage(total_tokens=123),
+            ),
+            patch("wade.services.plan_service.validate_plan_files", return_value=plan_files),
+            patch("wade.services.plan_service._cleanup_plan_dir_or_worktree"),
+            patch("wade.services.plan_service.set_terminal_title"),
+            patch("wade.services.plan_service.start_title_keeper"),
+            patch("wade.services.plan_service.stop_title_keeper"),
+            patch("wade.git.repo.get_repo_root", return_value=tmp_path),
+        ]
+
+    def test_single_plan_file_attaches_and_issue_stays_open(self, tmp_path: Path) -> None:
+        """--issue N with exactly one plan file keeps today's attach behavior."""
+        provider = MagicMock()
+        existing_issue = Task(id="330", title="Some bug", body="Original body")
+        provider.read_task.return_value = existing_issue
+        adapter = MagicMock()
+        adapter.capabilities.return_value = MagicMock(blocks_until_exit=True)
+
+        plan_path = tmp_path / "PLAN.md"
+        plan_path.write_text("# feat: thing\n\n## Tasks\n- Do it\n")
+        plan_file = PlanFile.from_markdown(plan_path)
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, [plan_file]):
+                stack.enter_context(p)
+            mock_attach = stack.enter_context(
+                patch("wade.services.plan_service._attach_plan_to_existing_issue")
+            )
+            mock_supersede = stack.enter_context(
+                patch("wade.services.plan_service._supersede_issue_with_plans")
+            )
+            mock_finalize = stack.enter_context(
+                patch("wade.services.plan_service._finalize_issues", return_value=None)
+            )
+
+            assert plan(project_root=tmp_path, issue_id="330") is True
+
+        mock_attach.assert_called_once()
+        assert mock_attach.call_args.kwargs["plan_file"] is plan_file
+        assert mock_attach.call_args.kwargs["issue"] is existing_issue
+        mock_supersede.assert_not_called()
+
+        mock_finalize.assert_called_once()
+        assert mock_finalize.call_args.kwargs["issue_numbers"] == ["330"]
+
+    def test_multi_plan_files_supersede_and_finalize_only_new_issues(self, tmp_path: Path) -> None:
+        """--issue N with 2+ plan files supersedes #N; only new issues are finalized."""
+        provider = MagicMock()
+        existing_issue = Task(id="330", title="Split me", body="Original body")
+        provider.read_task.return_value = existing_issue
+        adapter = MagicMock()
+        adapter.capabilities.return_value = MagicMock(blocks_until_exit=True)
+
+        plan_files = []
+        for i in range(2):
+            p = tmp_path / f"PLAN-{i}.md"
+            p.write_text(f"# feat: part {i}\n\n## Tasks\n- Do {i}\n")
+            plan_files.append(PlanFile.from_markdown(p))
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, plan_files):
+                stack.enter_context(p)
+            mock_attach = stack.enter_context(
+                patch("wade.services.plan_service._attach_plan_to_existing_issue")
+            )
+            mock_supersede = stack.enter_context(
+                patch(
+                    "wade.services.plan_service._supersede_issue_with_plans",
+                    return_value=["101", "102"],
+                )
+            )
+            mock_finalize = stack.enter_context(
+                patch("wade.services.plan_service._finalize_issues", return_value=None)
+            )
+
+            assert plan(project_root=tmp_path, issue_id="330") is True
+
+        mock_attach.assert_not_called()
+        mock_supersede.assert_called_once()
+        assert mock_supersede.call_args.kwargs["issue"] is existing_issue
+        assert mock_supersede.call_args.kwargs["plan_files"] == plan_files
+
+        mock_finalize.assert_called_once()
+        assert mock_finalize.call_args.kwargs["issue_numbers"] == ["101", "102"]
+
+    def test_supersede_with_no_created_issues_skips_finalize(self, tmp_path: Path) -> None:
+        """If supersede created nothing at all, plan() must not call _finalize_issues."""
+        provider = MagicMock()
+        existing_issue = Task(id="330", title="Split me", body="Original body")
+        provider.read_task.return_value = existing_issue
+        adapter = MagicMock()
+        adapter.capabilities.return_value = MagicMock(blocks_until_exit=True)
+
+        plan_files = []
+        for i in range(2):
+            p = tmp_path / f"PLAN-{i}.md"
+            p.write_text(f"# feat: part {i}\n\n## Tasks\n- Do {i}\n")
+            plan_files.append(PlanFile.from_markdown(p))
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, plan_files):
+                stack.enter_context(p)
+            stack.enter_context(
+                patch("wade.services.plan_service._supersede_issue_with_plans", return_value=[])
+            )
+            mock_finalize = stack.enter_context(
+                patch("wade.services.plan_service._finalize_issues")
+            )
+
+            assert plan(project_root=tmp_path, issue_id="330") is False
+
+        mock_finalize.assert_not_called()

--- a/tests/unit/test_services/test_plan_service.py
+++ b/tests/unit/test_services/test_plan_service.py
@@ -966,6 +966,13 @@ class TestWithSupersedeBanner:
         result = _with_supersede_banner("", "#1, #2")
         assert result == "> **Superseded by #1, #2**"
 
+    def test_replaces_existing_banner_with_leading_whitespace(self) -> None:
+        body = "\n> **Superseded by #1, #2**\n\nOriginal content"
+        result = _with_supersede_banner(body, "#1, #2, #3")
+        assert result.count("Superseded by") == 1
+        assert "#1, #2, #3" in result
+        assert "Original content" in result
+
 
 # ---------------------------------------------------------------------------
 # _supersede_issue_with_plans


### PR DESCRIPTION
Closes #330

<!-- wade:plan:start -->

## Complexity
complex

## Context / Problem
`wade plan --issue N` (the existing-issue path) calls `_attach_plan_to_existing_issue()`
in `src/wade/services/plan_service.py`, which keeps only `plan_files[0]`, attaches it to
issue #N, and warns `Multiple plan files found — using '...', ignoring N other(s).`
(`plan_service.py:739-743`). When the planning session decides the work should be split
into several independent pieces, every plan file after the first is silently discarded.

Observed impact: a real session generated **3 plan files** but produced **only 1 issue**
(`Found 3 plan file(s)` → `ignoring 2 other(s)` → `Created 1 issue(s) #195`). The two extra
plans were lost.

The multi-issue machinery already exists and works: the no-`--issue` path
(`_create_issues_from_plans`) loops over **all** plan files and creates one issue + draft PR
per file. It is simply never reached from the `--issue` path.

Leaving issue #N open as an implicit "parent" of the new issues is also confusing. When a
single issue is split during planning, the original should be **clearly superseded** —
closed and pointing at its successors — not left dangling with an ambiguous relationship.

## Proposed Solution
Rewrite the existing-issue branch of `plan()` to branch on the number of plan files the
session produced:

- **Exactly 1 plan file** → unchanged behavior: attach/refine issue #N via
  `_attach_plan_to_existing_issue` (the issue is being detailed, not split).
- **2 or more plan files** → treat #N as **split & superseded**:
  1. Create a new lightweight issue + draft PR for **every** plan file by reusing
     `_create_issues_from_plans` (the already-working loop).
  2. Post a comment on #N summarizing the split, e.g.
     `🔀 Superseded during planning — split into #A, #B, #C.`
  3. Prepend a banner to #N's body: `> **Superseded by #A, #B, #C**` (preserving the
     original body below it).
  4. Close #N as **not planned** (grey "tombstone" close, not "completed"), gated behind a
     confirmation prompt. Under `--yolo` or a non-interactive session, auto-proceed without
     prompting.
  5. Run `_finalize_issues` on the **new** issue numbers only, so token-usage allocation,
     planned-by labels, and auto-dependency analysis operate on the split issues rather than
     the closed original.

To render the "superseded" close cleanly, extend the provider `close_task` API with an
optional, **typed** close reason so GitHub can close as "not planned":

- Add a typed reason (e.g. `CloseReason = Literal["completed", "not planned"] | None`, or an
  equivalent `StrEnum` alongside the task models) rather than a bare string — the project
  convention is typed models everywhere, and this keeps the provider-agnostic interface from
  leaking GitHub-specific string semantics.
- Add `reason: CloseReason = None` to `AbstractTaskProvider.close_task` and all
  implementations (GitHub, ClickUp, Markdown).
- GitHub maps `reason="not planned"` → `gh issue close <id> --reason "not planned"`.
  When `reason` is `None`, behavior is identical to today (`gh issue close <id>`).
- Non-GitHub providers accept and ignore the parameter (backward compatible).

Also simplify `_attach_plan_to_existing_issue` to accept a single `PlanFile` instead of a
list, and delete the `ignoring N other(s)` warning branch — that silent-drop path no longer
exists, since multi-plan sessions now go through the supersede path.

### Robustness / non-atomicity
The supersede steps (create issues → comment → banner → close) are separate network calls
and are **not transactional**. The helper must degrade safely:
- **Partial issue-creation failure**: `_create_issues_from_plans` already catches and logs a
  failed `create_task` and continues (`plan_service.py:687-689`). If it returns fewer issues
  than there were plan files, **do not close #N** — warn loudly, name the plan file(s) that
  failed, and leave #N open (superseding based on a partial set would reintroduce the exact
  silent-drop bug this issue fixes).
- **Banner idempotency**: check for an existing `Superseded by` banner before prepending, so
  a re-run (or a failure between the banner and close steps) does not stack duplicate banners.

### Design defaults (confirmed with user)
- Original issue is closed as **not planned**, not "completed".
- The close is **confirmed via prompt** unless `--yolo`/non-interactive. Use the existing
  helper: `proceed = yolo or prompts.confirm(msg, default=True)` — `prompts.confirm` already
  returns its `default` when stdin is not a TTY (`ui/prompts.py`), so non-interactive
  sessions auto-proceed with no extra detection logic.

### Out of scope
- The `task_service.close_task` wrapper (`task_service.py`) and its CLI callers
  (`cli/task.py`) are **not** changed: the new `reason` parameter is optional and defaults to
  today's behavior, so those call sites keep working unchanged.

## Tasks
- [ ] Add a typed `CloseReason` (Literal or `StrEnum`) and extend
      `AbstractTaskProvider.close_task` with `reason: CloseReason = None`; update the GitHub,
      ClickUp, and Markdown implementations. GitHub passes `--reason "not planned"` when
      `reason == "not planned"`; the default (`None`) call is unchanged. Leave the
      `task_service.close_task` wrapper and `cli/task.py` callers untouched (optional param).
- [ ] Add `_supersede_issue_with_plans(provider, config, issue, plan_files, repo_root, yolo)`
      in `plan_service.py`: create issues from all plan files via `_create_issues_from_plans`,
      then (only if every plan file became an issue) comment on + prepend a supersede banner
      to the original body and close the original as "not planned"; return the list of new
      issue numbers.
- [ ] Partial-failure guard: if `_create_issues_from_plans` returns fewer issue numbers than
      there were plan files, do **not** close #N — emit a loud warning naming the failed plan
      file(s) and leave #N open. Return the successfully-created numbers so they still get
      finalized.
- [ ] Banner idempotency: before prepending the `> **Superseded by ...**` banner, check the
      current body for an existing supersede banner and skip/replace rather than stacking.
- [ ] Add a confirmation before closing the original using the existing helper:
      `proceed = yolo or prompts.confirm(msg, default=True)` (non-interactive stdin returns
      the default automatically — no separate TTY detection).
- [ ] Rewrite the `existing_issue is not None` branch in `plan()`: for a single plan file,
      keep the current attach-to-existing flow; for 2+ plan files, call the new supersede
      helper and pass the returned new issue numbers to `_finalize_issues`.
- [ ] Simplify `_attach_plan_to_existing_issue` to take a single `PlanFile` and remove the
      `Multiple plan files found — ... ignoring N other(s).` warning.
- [ ] Ensure `_finalize_issues` receives only the **new** issue numbers in the supersede
      case, so auto-dependency analysis links the split issues (not the closed original).
- [ ] Unit tests in `tests/unit/test_services/test_plan_service.py` — note this path has
      **no existing coverage**, so this is first-time coverage, not a diff against a baseline:
      single-plan `--issue` attaches to #N (issue stays open); multi-plan `--issue` supersede
      creates N issues, comments on the original, closes it as "not planned", and finalizes
      only the new numbers; partial-creation failure leaves #N open with a warning; `--yolo`
      skips the close prompt.
- [ ] Provider test: `close_task(reason="not planned")` builds
      `gh issue close <id> --reason "not planned"`; `close_task()` without a reason is
      unchanged.
- [ ] Update `README.md` and relevant `docs/dev/` reference for the new supersede behavior;
      re-check the `plan-session` skill wording for accuracy (no rule change expected).
- [ ] Run `./scripts/test.sh` and `./scripts/check.sh` (or `./scripts/check-all.sh`) — both
      must pass.

## Acceptance Criteria
- [ ] `wade plan --issue N` that produces 3 plan files results in 3 new issues, each with a
      draft PR, and issue #N is closed as **not planned** with a comment listing the
      successor issue numbers.
- [ ] The closed original issue's body shows a `> **Superseded by #A, #B, #C**` banner above
      its original content.
- [ ] `wade plan --issue N` that produces exactly 1 plan file behaves exactly as today: the
      plan is attached to #N and #N remains open.
- [ ] If any plan file fails to become an issue during supersession, #N is **not** closed and
      a warning names the failed plan file(s); the issues that were created still get finalized.
- [ ] Re-running the supersede path does not stack duplicate `Superseded by ...` banners on
      the original issue body.
- [ ] The `Multiple plan files found — ... ignoring N other(s).` silent-drop path no longer
      exists in the codebase.
- [ ] Auto-dependency analysis runs across the new (split) issues and never references the
      closed original.
- [ ] Under `--yolo` or a non-interactive session, the original issue is closed without a
      confirmation prompt.
- [ ] `close_task(reason="not planned")` invokes `gh issue close <id> --reason "not planned"`;
      `close_task()` with no reason produces the same command as before this change.
- [ ] `./scripts/test.sh` and `./scripts/check.sh` pass.

<!-- wade:plan:end -->


## What was done

`wade plan --issue N` used to keep only the first plan file when a planning
session produced several, silently discarding the rest (`Multiple plan files
found — ... ignoring N other(s)`). This PR makes the existing-issue path
branch on plan-file count: a single plan file still attaches to `#N` as
before, but 2+ plan files now supersede `#N` — creating a new issue + draft PR
per plan file and closing the original as "not planned" with a comment and
banner pointing at its successors.

## Changes

- Added `CloseReason` (`StrEnum`: `completed` / `not planned`) to
  `models/task.py` and extended `AbstractTaskProvider.close_task` with an
  optional `reason` parameter across GitHub, ClickUp, and Markdown providers.
  GitHub maps `reason="not planned"` to `gh issue close <id> --reason "not
  planned"`; other providers accept and ignore it. `task_service.close_task`
  and its CLI callers are untouched (optional param, default unchanged).
- Added `_supersede_issue_with_plans()` in `plan_service.py`: reuses the
  existing `_create_issues_from_plans` loop to create one issue + draft PR per
  plan file, then comments on and closes the original issue as "not planned"
  — but only if every plan file became an issue. A partial failure leaves the
  original open with a loud warning naming the failed file(s), and the
  successfully created issues are still returned for finalization.
- Added `_with_supersede_banner()` — prepends (or replaces, never stacks) a
  `> **Superseded by #A, #B, #C**` banner on the original issue body.
- The close is gated behind `proceed = yolo or prompts.confirm(msg,
  default=True)` — auto-proceeds under `--yolo` or a non-interactive session.
- `_create_issues_from_plans` now returns `(created_ids, failed_plan_names)`
  instead of just a list, so the supersede path can name exactly which plan
  file(s) failed (not just "some number failed").
- Simplified `_attach_plan_to_existing_issue` to take a single `PlanFile`
  instead of `list[PlanFile]`; removed the `ignoring N other(s)` silent-drop
  branch entirely.
- Rewrote the `existing_issue is not None` branch of `plan()` to dispatch on
  plan-file count and pass only the relevant issue numbers (existing issue for
  the single-file case, new issues for the supersede case) to
  `_finalize_issues`.

## Testing

- New unit tests in `tests/unit/test_services/test_plan_service.py`: banner
  idempotency (prepend / replace / empty-body), `_supersede_issue_with_plans`
  (full success, partial failure, `--yolo` skip, user-decline), and
  `plan()`-level branch selection (single-file attach, multi-file supersede,
  all-failed skips finalize).
- New provider tests: GitHub `close_task(reason="not planned")` builds
  `gh issue close <id> --reason "not planned"`; ClickUp/Markdown
  `close_task(reason=...)` accepts and ignores the reason.
- `./scripts/test.sh` — 2250 passed.
- `./scripts/check.sh` (ruff + mypy --strict) — clean.
- `wade review implementation` — no bugs found; addressed the one actionable
  note (added ignored-reason coverage for ClickUp/Markdown).

## Notes for reviewers

- The supersede sequence (create issues → comment → banner → close) is not
  transactional by design — each step is independently try/excepted so a
  failure in one doesn't block the others, and the close only happens after
  every plan file became an issue.
- `README.md` gained a short paragraph under the Commands table describing
  the new `--issue` supersede behavior. The `plan-session` skill needed no
  wording changes (it already describes multi-file planning generically).

## Summary

## What was done

`wade plan --issue N` used to keep only the first plan file when a planning
session produced several, silently discarding the rest (`Multiple plan files
found — ... ignoring N other(s)`). This PR makes the existing-issue path
branch on plan-file count: a single plan file still attaches to `#N` as
before, but 2+ plan files now supersede `#N` — creating a new issue + draft PR
per plan file and closing the original as "not planned" with a comment and
banner pointing at its successors.

## Changes

- Added `CloseReason` (`StrEnum`: `completed` / `not planned`) to
  `models/task.py` and extended `AbstractTaskProvider.close_task` with an
  optional `reason` parameter across GitHub, ClickUp, and Markdown providers.
  GitHub maps `reason="not planned"` to `gh issue close <id> --reason "not
  planned"`; other providers accept and ignore it. `task_service.close_task`
  and its CLI callers are untouched (optional param, default unchanged).
- Added `_supersede_issue_with_plans()` in `plan_service.py`: reuses the
  existing `_create_issues_from_plans` loop to create one issue + draft PR per
  plan file, then comments on and closes the original issue as "not planned"
  — but only if every plan file became an issue. A partial failure leaves the
  original open with a loud warning naming the failed file(s), and the
  successfully created issues are still returned for finalization.
- Added `_with_supersede_banner()` — prepends (or replaces, never stacks) a
  `> **Superseded by #A, #B, #C**` banner on the original issue body.
- The close is gated behind `proceed = yolo or prompts.confirm(msg,
  default=True)` — auto-proceeds under `--yolo` or a non-interactive session.
- `_create_issues_from_plans` now returns `(created_ids, failed_plan_names)`
  instead of just a list, so the supersede path can name exactly which plan
  file(s) failed (not just "some number failed").
- Simplified `_attach_plan_to_existing_issue` to take a single `PlanFile`
  instead of `list[PlanFile]`; removed the `ignoring N other(s)` silent-drop
  branch entirely.
- Rewrote the `existing_issue is not None` branch of `plan()` to dispatch on
  plan-file count and pass only the relevant issue numbers (existing issue for
  the single-file case, new issues for the supersede case) to
  `_finalize_issues`.

## Testing

- New unit tests in `tests/unit/test_services/test_plan_service.py`: banner
  idempotency (prepend / replace / empty-body), `_supersede_issue_with_plans`
  (full success, partial failure, `--yolo` skip, user-decline), and
  `plan()`-level branch selection (single-file attach, multi-file supersede,
  all-failed skips finalize).
- New provider tests: GitHub `close_task(reason="not planned")` builds
  `gh issue close <id> --reason "not planned"`; ClickUp/Markdown
  `close_task(reason=...)` accepts and ignores the reason.
- `./scripts/test.sh` — 2250 passed.
- `./scripts/check.sh` (ruff + mypy --strict) — clean.
- `wade review implementation` — no bugs found; addressed the one actionable
  note (added ignored-reason coverage for ClickUp/Markdown).

## Notes for reviewers

- The supersede sequence (create issues → comment → banner → close) is not
  transactional by design — each step is independently try/excepted so a
  failure in one doesn't block the others, and the close only happens after
  every plan file became an issue.
- `README.md` gained a short paragraph under the Commands table describing
  the new `--issue` supersede behavior. The `plan-session` skill needed no
  wording changes (it already describes multi-file planning generically).

## What was addressed (review round)

CodeRabbit flagged that the `KNOWLEDGE.md` entry on `wade/ui/prompts.py`
(added by this PR) overstated the non-TTY default behavior.

## Changes (review round)

- `KNOWLEDGE.md`: narrowed the claim that prompt helpers return a configured
  default when stdin is not a TTY to the helpers that actually do
  (`confirm`, `input_prompt`, `select`, `menu`), and added an explicit note
  that `multi_select` instead returns all item indices. Also dropped a
  reference to a non-existent `choice` helper (the actual name is `select`).
- `plan_service.py`: broadened `_SUPERSEDE_BANNER_RE` to tolerate leading
  whitespace before an existing `> **Superseded by ...**` banner (was
  anchored at `\A>` with no `\s*` allowance), so a banner preceded by stray
  whitespace no longer gets stacked instead of replaced. Found via an
  independent ad-hoc code review, verified with a repro before fixing, and
  covered by a new regression test.

## Remaining

None — the one unresolved thread was addressed and resolved.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | **244,700** |
| Input tokens | **242,800** |
| Output tokens | **1,900** |

<!-- wade:impl-usage:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | *unavailable* |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `b728059f-5856-4abd-9768-8e308ae11757` |
| Review | `claude` | `6f95f0a2-7f6d-405f-9682-c0ad9870f3a2` |

<!-- wade:sessions:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for re-planning existing issues with multiple plan files, creating separate issues and draft pull requests.
  * Existing issues can now be marked as superseded and closed as “not planned” after confirmation.
  * Added close-reason support for providers that support it.

* **Documentation**
  * Documented re-planning behavior and non-interactive prompt defaults.
  * Added guidance for sharing test patch contexts safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->