### PR TITLE
fix: --mode headless still blocks on TTY AI-selection confirm prompt

### DIFF
--- a/src/wade/models/delegation.py
+++ b/src/wade/models/delegation.py
@@ -25,7 +25,7 @@ class DelegationRequest(BaseModel):
     model: str | None = None
     effort: str | None = None
     cwd: Path | None = None
-    timeout: int = 120
+    timeout: int = 300
     output_file: Path | None = None
     trusted_dirs: list[str] = Field(default_factory=list)
     allowed_commands: list[str] = Field(default_factory=list)

--- a/src/wade/services/ai_resolution.py
+++ b/src/wade/services/ai_resolution.py
@@ -23,6 +23,7 @@ from crossby.ai_tools import AbstractAITool
 from crossby.models.ai import AIToolID, EffortLevel
 
 from wade.models.config import AICommandConfig, ProjectConfig
+from wade.models.delegation import DelegationMode
 
 logger = structlog.get_logger()
 
@@ -221,22 +222,30 @@ def confirm_ai_selection(
     effort_explicit: bool = False,
     resolved_yolo: bool = False,
     yolo_explicit: bool = True,
+    mode: DelegationMode | None = None,
 ) -> tuple[str | None, str | None, EffortLevel | None, bool]:
     """Interactively confirm (and optionally change) the resolved AI tool/model/effort/yolo.
 
     Fires only when stdin is a TTY and at least one of the flags was not
     explicitly provided by the caller.  When all flags are explicit (e.g.
     because ``wade implement-batch`` passes ``--ai``/``--model``/``--effort`` to
-    child calls), this is a no-op.
+    child calls), this is a no-op. Also a no-op when *mode* is
+    ``DelegationMode.HEADLESS``: headless mode is defined as unattended, so it
+    must never block on a TTY prompt even when one happens to be attached.
 
     Returns the (tool, model, effort, yolo) tuple after any user-driven changes.
     """
     from wade.ui import prompts
     from wade.ui.console import console
 
-    # Skip when non-TTY, no tool resolved, or all flags were explicit.
+    # Skip when non-TTY, no tool resolved, all flags were explicit, or headless.
     all_explicit = tool_explicit and model_explicit and effort_explicit and yolo_explicit
-    if not prompts.is_tty() or resolved_tool is None or all_explicit:
+    if (
+        not prompts.is_tty()
+        or resolved_tool is None
+        or all_explicit
+        or mode == DelegationMode.HEADLESS
+    ):
         return resolved_tool, resolved_model, resolved_effort, resolved_yolo
 
     tool = resolved_tool

--- a/src/wade/services/deps_service.py
+++ b/src/wade/services/deps_service.py
@@ -432,6 +432,7 @@ def analyze_deps(
             model_explicit=model_explicit,
             resolved_effort=resolved_effort,
             effort_explicit=effort_explicit,
+            mode=delegation_mode,
         )
         if not resolved_tool:
             console.error("No AI tool selected.")

--- a/src/wade/services/deps_service.py
+++ b/src/wade/services/deps_service.py
@@ -328,6 +328,7 @@ def _run_delegation(
     effort: str | None = None,
     allowed_commands: list[str] | None = None,
     cwd: Path | None = None,
+    timeout: int | None = None,
 ) -> str | None:
     """Run dependency analysis via the generic delegation infrastructure.
 
@@ -341,6 +342,7 @@ def _run_delegation(
         effort=effort,
         cwd=cwd,
         allowed_commands=allowed_commands or [],
+        **({"timeout": timeout} if timeout is not None else {}),
     )
     result = delegate(request)
     if result.success and result.feedback:
@@ -504,6 +506,7 @@ def analyze_deps(
         effort=effort_str,
         allowed_commands=config.permissions.allowed_commands,
         cwd=deps_cwd,
+        timeout=cmd_config.timeout,
     )
 
     if delegation_mode == DelegationMode.PROMPT:

--- a/src/wade/services/review_delegation_service.py
+++ b/src/wade/services/review_delegation_service.py
@@ -100,6 +100,7 @@ def _run_review_delegation(
             model_explicit=model_explicit,
             resolved_effort=resolved_effort,
             effort_explicit=effort_explicit,
+            mode=delegation_mode,
         )
 
     effort_str = resolved_effort.value if isinstance(resolved_effort, EffortLevel) else None

--- a/tests/unit/test_models/test_delegation.py
+++ b/tests/unit/test_models/test_delegation.py
@@ -26,7 +26,7 @@ class TestDelegationRequest:
         assert req.prompt == "Review this"
         assert req.ai_tool is None
         assert req.model is None
-        assert req.timeout == 120
+        assert req.timeout == 300
         assert req.trusted_dirs == []
         assert req.allowed_commands == []
         assert req.yolo is False

--- a/tests/unit/test_services/test_ai_resolution.py
+++ b/tests/unit/test_services/test_ai_resolution.py
@@ -8,6 +8,7 @@ import crossby.ai_tools  # noqa: F401 — registers all adapters via __init_subc
 from crossby.models.ai import EffortLevel
 
 from wade.models.config import AICommandConfig, AIConfig, ComplexityModelMapping, ProjectConfig
+from wade.models.delegation import DelegationMode
 from wade.services.ai_resolution import confirm_ai_selection, resolve_effort
 
 # ---------------------------------------------------------------------------
@@ -73,6 +74,20 @@ class TestConfirmAiSelectionEarlyExit:
         with patch(_IS_TTY, return_value=True), patch(_SELECT) as mock_select:
             result = confirm_ai_selection(None, None, tool_explicit=False, model_explicit=False)
         assert result == (None, None, None, False)
+        mock_select.assert_not_called()
+
+    def test_headless_mode_skips_prompt_even_on_tty(self) -> None:
+        """Headless mode is unattended by definition — never block on a TTY prompt,
+        even when a TTY is attached and flags weren't explicit."""
+        with patch(_IS_TTY, return_value=True), patch(_SELECT) as mock_select:
+            result = confirm_ai_selection(
+                _CLAUDE,
+                _MODEL_A,
+                tool_explicit=False,
+                model_explicit=False,
+                mode=DelegationMode.HEADLESS,
+            )
+        assert result == (_CLAUDE, _MODEL_A, None, False)
         mock_select.assert_not_called()
 
 

--- a/tests/unit/test_services/test_deps_service.py
+++ b/tests/unit/test_services/test_deps_service.py
@@ -511,3 +511,56 @@ class TestAnalyzeDepsMode:
         assert len(result.edges) == 1
         call_args = mock_delegate.call_args[0][0]
         assert call_args.mode == DelegationMode.HEADLESS
+
+    @patch("wade.services.deps_service.create_tracking_issue")
+    @patch("wade.services.deps_service.apply_deps_to_issues")
+    @patch("wade.services.deps_service.delegate")
+    @patch("wade.services.deps_service.confirm_ai_selection")
+    @patch("wade.services.deps_service.resolve_effort")
+    @patch("wade.services.deps_service.resolve_model")
+    @patch("wade.services.deps_service.resolve_ai_tool")
+    @patch("wade.services.deps_service.get_provider")
+    @patch("wade.services.deps_service.load_config")
+    def test_headless_timeout_is_forwarded(
+        self,
+        mock_config: MagicMock,
+        mock_provider: MagicMock,
+        mock_resolve_tool: MagicMock,
+        mock_resolve_model: MagicMock,
+        mock_resolve_effort: MagicMock,
+        mock_confirm: MagicMock,
+        mock_delegate: MagicMock,
+        mock_apply: MagicMock,
+        mock_tracking: MagicMock,
+    ) -> None:
+        """ai.deps.timeout should be forwarded into the DelegationRequest."""
+        from wade.models.config import AICommandConfig, AIConfig
+
+        mock_config.return_value = ProjectConfig(
+            ai=AIConfig(deps=AICommandConfig(tool="claude", mode="headless", timeout=300))
+        )
+        provider = MagicMock()
+        provider.read_task.side_effect = [
+            Task(id="1", title="Auth", body="Login"),
+            Task(id="2", title="DB", body="Schema"),
+            Task(id="1", title="Auth", body="Login"),
+            Task(id="2", title="DB", body="Schema"),
+        ]
+        mock_provider.return_value = provider
+        mock_resolve_tool.return_value = "claude"
+        mock_resolve_model.return_value = None
+        mock_resolve_effort.return_value = None
+        mock_confirm.return_value = ("claude", None, None, False)
+        mock_delegate.return_value = DelegationResult(
+            success=True,
+            feedback="1 -> 2 # auth before UI",
+            mode=DelegationMode.HEADLESS,
+        )
+        mock_apply.return_value = 2
+        mock_tracking.return_value = "10"
+
+        result = analyze_deps(["1", "2"])
+        assert result is not None
+        call_args = mock_delegate.call_args[0][0]
+        assert call_args.mode == DelegationMode.HEADLESS
+        assert call_args.timeout == 300


### PR DESCRIPTION
## Summary
- `confirm_ai_selection()` gated the interactive "Confirm AI selection" menu on TTY-ness and explicit flags only — it never looked at the resolved delegation mode, so `wade review plan/implementation/batch --mode headless` (and `wade task deps`, which defaults to headless) would still block on the interactive menu whenever stdin happened to be a TTY, contradicting headless mode's "runs AI non-interactively" contract.
- `confirm_ai_selection` now takes an optional `mode: DelegationMode | None` and short-circuits whenever `mode == DelegationMode.HEADLESS`.
- Wired `mode=delegation_mode` through the two call sites that support headless (`review_delegation_service.py`, `deps_service.py`). `plan`/`implement`/`implement-batch` don't expose `--mode` at all, so those call sites are unchanged.
- Raised the default headless timeout (`DelegationRequest.timeout`) from 120s to 300s — 2 minutes is often too short for a real headless AI review/analysis pass on a nontrivial diff.
- Wired `ai.deps.timeout` through `deps_service.py`'s `DelegationRequest` — it was already accepted by config validation but silently ignored at the call site, unlike the review commands.

## Test plan
- [x] Added `test_headless_mode_skips_prompt_even_on_tty` in `test_ai_resolution.py`
- [x] Added `test_headless_timeout_is_forwarded` in `test_deps_service.py`
- [x] Updated stale `test_minimal_request` default-timeout assertion in `test_delegation.py`
- [x] Full suite: `uv run pytest -q` — 2240 passed, 5 skipped
- [x] `uv run mypy src/ --strict` — clean
- [x] `uv run ruff check` / `ruff format --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headless delegation support that skips interactive confirmation prompts, even when a terminal is available.
  * Applied headless behavior consistently to dependency analysis and review workflows.

* **Bug Fixes**
  * Prevented unnecessary interactive prompts during automated or non-interactive operations.

* **Tests**
  * Added coverage verifying headless mode preserves the selected tool and model without prompting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->