### PR TITLE
chore: bump crossby to v0.11.0 and adopt newer models (Opus 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Conventional Commits](https://conventionalcommits.org/).
 
+## [v0.35.2] — 2026-07-24
+
+### Bug Fixes
+
+- exclude scaffold-branch commits from generated changelog (c40a9ca)
+
+### Chores
+
+- bump crossby to v0.11.0 and adopt newer models (Opus 5) (ff0ab48)
+
 ## [v0.35.1] — 2026-07-24
 
 ### Bug Fixes

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -231,3 +231,9 @@ wade never branches on crossby's AIToolType/tool_type (only re-exported in wade.
 To unit-test a crossby GUI adapter launch command (Antigravity IDE, VS Code), patch `crossby.ai_tools.<module>.run_with_transcript` (e.g. crossby.ai_tools.antigravity.run_with_transcript) and read call_args[0][0] — GUI adapters build the cmd and call crossby's run_with_transcript directly, so patching wade.utils.process/subprocess never fires. The Antigravity IDE cmd is exactly ["antigravity", str(working_dir)] (explicit dir, not ".").
 
 ---
+
+## ae5df2be | 2026-07-24 | plan | tags: crossby, ai-tools, model-registry, dependencies
+
+To add or refresh supported AI models in wade (e.g. a new Opus), bump the crossby dependency — there is no wade-side model list to edit. The model registry (crossby.data.MODELS / get_models_for_tool), the complexity-tier defaults used by `wade init` (crossby.config.defaults.get_defaults), and EffortLevel all live in crossby; wade's _resolve_models and _suggest_model_for_tool (init_service/config_io.py, prompts_ai.py), ai_resolution.py, and cli/autocomplete.py are thin pass-throughs. Because the pyproject pin uses an exclusive upper bound (e.g. crossby<0.11.0), each new crossby minor needs an explicit pin bump plus a verification pass across those four import sites.
+
+---

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -36,7 +36,7 @@
   up: 4
 54326c98:
   down: 1
-  stale: 0
+  stale: 1
   up: 0
 6e38b3aa:
   down: 0
@@ -65,6 +65,10 @@ b61e247e:
   superseded_by: bcfa4bb3
   up: 4
 b6a3a637:
+  down: 0
+  stale: 0
+  up: 1
+b6ca74e5:
   down: 0
   stale: 0
   up: 1

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -127,7 +127,7 @@ src/wade/
 
 ## AI Tool Layer (external: crossby)
 
-AI tool adapters, model/effort resolution primitives, the model registry, and per-tool config (allowlists, hooks, defaults) are **not** part of this repo. They live in the external [`crossby`](https://github.com/ivanviragine/crossby) package, pinned in `pyproject.toml` (`crossby>=0.10.2,<0.11.0`). This replaced wade's formerly-internal `ai_tools/` and parts of `config/` and `data/` (see `feat: replace internal AI tool layer with the crossby dependency (#215)`).
+AI tool adapters, model/effort resolution primitives, the model registry, and per-tool config (allowlists, hooks, defaults) are **not** part of this repo. They live in the external [`crossby`](https://github.com/ivanviragine/crossby) package, pinned in `pyproject.toml` (`crossby>=0.11.0,<0.12.0`). This replaced wade's formerly-internal `ai_tools/` and parts of `config/` and `data/` (see `feat: replace internal AI tool layer with the crossby dependency (#215)`).
 
 | What | Lives in crossby | Used from wade via |
 |------|-------------------|---------------------|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wade-cli"
-version = "0.35.1"
+version = "0.35.2"
 description = "WADE — Workflow for AI-Driven Engineering"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Version Control :: Git",
 ]
 dependencies = [
-    "crossby>=0.10.2,<0.11.0",
+    "crossby>=0.11.0,<0.12.0",
     "typer>=0.12,<0.26",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -66,7 +66,8 @@ def get_tags() -> list[str]:
 def get_commits(commit_range: str) -> list[tuple[str, str]]:
     """Get commits in a range as (subject, hash) pairs.
 
-    Filters out version-bump noise.
+    Filters out version-bump and branch-scaffold noise — both are
+    wade-generated commits that carry no user-facing release content.
     """
     raw = git("log", commit_range, "--pretty=format:%s|%h", "--no-merges")
     if not raw:
@@ -76,7 +77,7 @@ def get_commits(commit_range: str) -> list[tuple[str, str]]:
         if "|" not in line:
             continue
         subject, sha = line.rsplit("|", 1)
-        if subject.startswith("chore: bump version"):
+        if subject.startswith(("chore: bump version", "chore: scaffold branch")):
             continue
         commits.append((subject.strip(), sha.strip()))
     return commits

--- a/src/wade/__init__.py
+++ b/src/wade/__init__.py
@@ -1,3 +1,3 @@
 """WADE (Workflow for AI-Driven Engineering) — AI-agent-driven git workflow management CLI."""
 
-__version__ = "0.35.1"
+__version__ = "0.35.2"


### PR DESCRIPTION
Closes #344

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem
WADE delegates its entire AI-model surface to the external **crossby** package.
The model registry (`crossby.data.MODELS` / `get_models_for_tool`), the
complexity-tier defaults (`crossby.config.defaults.get_defaults`), and the
effort levels (`crossby.models.ai.EffortLevel`) all live in crossby — wade keeps
no model list of its own.

The dependency is currently pinned `crossby>=0.10.2,<0.11.0` in `pyproject.toml`,
which deliberately *excludes* 0.11.0. As a result, newer Claude models — notably
**Opus 5** — are unavailable to inited projects: the installed 0.10.2 registry
tops out at `claude-opus-4.8` / `claude-sonnet-5` / `claude-fable-5`. Bumping
crossby to 0.11.0 is the mechanism that surfaces these models across
`wade init`, autocomplete, and model/effort resolution — there is no separate
wade-side model list to edit.

## Proposed Solution
Start by reading crossby's actual `0.10.2 → 0.11.0` diff — crossby is the
maintainer's own repo (`github.com/ivanviragine/crossby`), so the release notes
and tag diff are directly inspectable rather than a black box. That turns the
verification steps from trial-and-error into targeted checks against a known
diff, and reveals up front whether 0.11.0 is a clean additive bump or carries
renamed/removed APIs.

If the diff is additive: raise the pin to `>=0.11.0,<0.12.0`, regenerate the
lockfile, and run a verification pass across every wade → crossby seam. Confirm
that Opus 5 and the other new models flow through the init wizard, autocomplete,
the complexity-tier defaults, effort resolution, and the model-compatibility
gate; then update the documented pin string and refresh only the genuinely
affected test fixtures. No new wade model list is introduced — the models arrive
via crossby.

If the diff turns up **breaking** API changes (renamed/removed symbols on the
imported surface) rather than pure additions: stop and re-scope this as a larger
task instead of forcing a patch-sized PR through with workarounds.

## Tasks
- [ ] **Read the crossby `0.10.2 → 0.11.0` diff first** (`gh release view` / `gh api` / tag diff on `ivanviragine/crossby`); confirm whether the bump is additive or breaking before touching the pin. If breaking (renamed/removed symbols on the imported surface), stop and re-scope rather than continuing this task
- [ ] Bump the crossby pin in `pyproject.toml` from `crossby>=0.10.2,<0.11.0` to `crossby>=0.11.0,<0.12.0`
- [ ] Regenerate `uv.lock` (`uv lock`) and reinstall the dev environment (`uv pip install -e ".[dev]"`)
- [ ] Verify the crossby import surface still resolves against 0.11.0 (`crossby.data.MODELS` / `get_models_for_tool`, `crossby.config.defaults.get_defaults`, `crossby.models.ai.{AIToolID, EffortLevel, ModelTier}`, `crossby.ai_tools`); fix any breakage in `src/wade/services/init_service/config_io.py`, `src/wade/services/init_service/prompts_ai.py`, `src/wade/services/ai_resolution.py`, and `src/wade/cli/autocomplete.py`
- [ ] Confirm `get_models_for_tool("claude")` now lists **Opus 5**, and that `get_defaults("claude")` maps the complexity tiers (easy/medium/complex/very_complex) to sensible current models
- [ ] Verify effort resolution: `resolve_effort` (`ai_resolution.py`) constructs `EffortLevel(resolved)` generically and the picker enumerates `EffortLevel` — so any new level in 0.11.0 flows through with no code change. This is verification-only (low risk), not a new code path; just confirm a new level, if any, resolves cleanly
- [ ] Confirm the compatibility gate (`AbstractAITool.is_model_compatible`) accepts Opus 5 through `resolve_model`, and that `_normalize_model` dot-notation handling remains correct for the new IDs
- [ ] Update the documented pin string in `docs/dev/architecture.md` (line ~130) to `>=0.11.0,<0.12.0`, and check `README.md` for any crossby version references to refresh
- [ ] Scope test-fixture updates precisely: `grep` `tests/` for the small number of tests that assert against the **live** registry (`crossby.data.MODELS` / `get_models_for_tool`, e.g. `test_init` and autocomplete tests) and update those. Leave synthetic model-ID fixtures in resolver tests (e.g. `test_effort.py`, `test_ai_resolution.py`) alone unless `./scripts/test.sh` actually fails on them
- [ ] Run `./scripts/test.sh` and `./scripts/check.sh` (or `./scripts/check-all.sh`) until green
- [ ] Bump the wade version via `uv run python scripts/auto_version.py patch` (auto-generates CHANGELOG entry + git tag)

## Acceptance Criteria
- [ ] The crossby `0.10.2 → 0.11.0` diff was reviewed and confirmed additive (or, if breaking, the task was re-scoped rather than force-fit into a patch)
- [ ] `pyproject.toml` and `uv.lock` pin crossby `>=0.11.0,<0.12.0`, and the dev environment installs cleanly
- [ ] `wade init` model wizard, `wade` shell autocomplete, and complexity-tier model resolution surface Opus 5 and the other crossby 0.11.0 models
- [ ] `resolve_model` / `resolve_effort` accept Opus 5 (and any newly introduced effort level) without emitting incompatibility/invalid warnings for a valid selection
- [ ] `docs/dev/architecture.md` (and any other version-string references) reflect the new pin
- [ ] `./scripts/test.sh` and `./scripts/check.sh` pass
- [ ] Wade version is bumped with a `chore:`-style CHANGELOG entry generated by `auto_version.py`

<!-- wade:plan:end -->


## What was done

Bumped the `crossby` dependency pin from `>=0.10.2,<0.11.0` to
`>=0.11.0,<0.12.0` so the refreshed crossby model registry — most notably
**Claude Opus 5** — becomes available to inited projects. WADE keeps no
model list of its own; the entire AI-model surface is delegated to crossby, so
raising the pin is the sole mechanism that surfaces the new models across
`wade init`, autocomplete, complexity-tier defaults, effort resolution, and the
model-compatibility gate.

## Why these changes

Issue #344: the previous exclusive upper bound (`<0.11.0`) deliberately
excluded crossby 0.11.0, capping inited projects at `claude-opus-4.8` /
`claude-sonnet-5` / `claude-fable-5`. crossby 0.11.0 (PR #79) adds Opus 5 and
other newly-released models plus refreshes the complexity-tier defaults.

## Changes

- **`pyproject.toml`** — crossby pin raised to `>=0.11.0,<0.12.0`.
- **`docs/dev/architecture.md`** — documented pin string updated to match.
- **`KNOWLEDGE.md` / `KNOWLEDGE.ratings.yml`** — captured a release-workflow
  gotcha (commit descriptive changes before running `auto_version.py`, else the
  CHANGELOG misses them) and rated relevant entries.
- **Version bump** — `auto_version.py patch` → v0.35.2 (CHANGELOG + tag).

No `src/wade/` code changes were needed: the crossby `0.10.2 → 0.11.0` diff is
**purely additive** on wade's imported surface. It only adds models to
`data/models.json`, retargets `config.defaults` `very_complex` to
`claude-opus-5`, and touches internal dicts wade never imports
(`hooks/runtime.py`, `sync/translation.py`). No renamed or removed public
symbols.

## Testing

- **Reviewed the crossby diff first** (`gh api .../compare/v0.10.2...v0.11.0`) —
  confirmed additive, not breaking, before touching the pin.
- **Import surface** resolves against 0.11.0: `crossby.data.MODELS` /
  `get_models_for_tool`, `config.defaults.get_defaults`,
  `models.ai.{AIToolID, EffortLevel, ModelTier}`, `crossby.ai_tools`.
- **Opus 5 surfaces**: `get_models_for_tool("claude")` lists `claude-opus-5`;
  `get_defaults("claude").very_complex == "claude-opus-5"`.
- **Resolver seams** (verification-only, the four thin pass-throughs in
  `config_io.py`, `prompts_ai.py`, `ai_resolution.py`, `autocomplete.py`):
  - `resolve_model("claude-opus-5", tool="claude")` → `claude-opus-5`; rejected
    (`None`) for `codex` as expected.
  - `is_model_compatible("claude-opus-5")` → `True`;
    `normalize_model_format` handles the new IDs correctly.
  - `resolve_effort` accepts every `EffortLevel` (unchanged in 0.11.0:
    low/medium/high/xhigh/max — no new level, so nothing new to route).
- `./scripts/test.sh` — **2302 passed**. No fixture updates were needed:
  live-registry callers mock `get_models_for_tool`, and synthetic model-ID
  fixtures are unaffected.
- `./scripts/check.sh` — ruff + format + strict mypy all pass.

## Notes for reviewers

- `uv.lock` is gitignored in this repo, so only the `pyproject.toml` pin is
  committed; the lock was regenerated locally (`uv lock` → crossby 0.11.0) and
  the dev env reinstalled.
- Self-review flagged that the crossby change initially rode inside the
  version-bump commit, so the CHANGELOG omitted it. Fixed by landing the change
  as a descriptive `chore:` commit **before** re-running `auto_version.py` — the
  v0.35.2 CHANGELOG entry now reads "bump crossby to v0.11.0 and adopt newer
  models (Opus 5)".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application to version **0.35.2**.

* **Improvements**
  * Added support for newer AI models through the updated AI tooling integration.

* **Documentation**
  * Updated architecture and knowledge documentation with guidance for supported model updates and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

## What was done

Bumped the `crossby` dependency pin from `>=0.10.2,<0.11.0` to
`>=0.11.0,<0.12.0` so the refreshed crossby model registry — most notably
**Claude Opus 5** — becomes available to inited projects. WADE keeps no
model list of its own; the entire AI-model surface is delegated to crossby, so
raising the pin is the sole mechanism that surfaces the new models across
`wade init`, autocomplete, complexity-tier defaults, effort resolution, and the
model-compatibility gate.

## Why these changes

Issue #344: the previous exclusive upper bound (`<0.11.0`) deliberately
excluded crossby 0.11.0, capping inited projects at `claude-opus-4.8` /
`claude-sonnet-5` / `claude-fable-5`. crossby 0.11.0 (PR #79) adds Opus 5 and
other newly-released models plus refreshes the complexity-tier defaults.

## Changes

- **`pyproject.toml`** — crossby pin raised to `>=0.11.0,<0.12.0`.
- **`docs/dev/architecture.md`** — documented pin string updated to match.
- **`scripts/changelog.py`** — `get_commits()` now also filters the
  wade-generated `chore: scaffold branch for #<n>` marker (an empty commit),
  alongside the existing `chore: bump version` filter, so it no longer leaks
  into any release's notes.
- **`KNOWLEDGE.md` / `KNOWLEDGE.ratings.yml`** — captured a release-workflow
  gotcha (commit descriptive changes before running `auto_version.py`, else the
  CHANGELOG misses them) and rated relevant entries.
- **Version bump** — `auto_version.py patch` → v0.35.2 (CHANGELOG + tag).

No `src/wade/` code changes were needed: the crossby `0.10.2 → 0.11.0` diff is
**purely additive** on wade's imported surface. It only adds models to
`data/models.json`, retargets `config.defaults` `very_complex` to
`claude-opus-5`, and touches internal dicts wade never imports
(`hooks/runtime.py`, `sync/translation.py`). No renamed or removed public
symbols.

## Testing

- **Reviewed the crossby diff first** (`gh api .../compare/v0.10.2...v0.11.0`) —
  confirmed additive, not breaking, before touching the pin.
- **Import surface** resolves against 0.11.0: `crossby.data.MODELS` /
  `get_models_for_tool`, `config.defaults.get_defaults`,
  `models.ai.{AIToolID, EffortLevel, ModelTier}`, `crossby.ai_tools`.
- **Opus 5 surfaces**: `get_models_for_tool("claude")` lists `claude-opus-5`;
  `get_defaults("claude").very_complex == "claude-opus-5"`.
- **Resolver seams** (verification-only, the four thin pass-throughs in
  `config_io.py`, `prompts_ai.py`, `ai_resolution.py`, `autocomplete.py`):
  - `resolve_model("claude-opus-5", tool="claude")` → `claude-opus-5`; rejected
    (`None`) for `codex` as expected.
  - `is_model_compatible("claude-opus-5")` → `True`;
    `normalize_model_format` handles the new IDs correctly.
  - `resolve_effort` accepts every `EffortLevel` (unchanged in 0.11.0:
    low/medium/high/xhigh/max — no new level, so nothing new to route).
- `./scripts/test.sh` — **2302 passed**. No fixture updates were needed:
  live-registry callers mock `get_models_for_tool`, and synthetic model-ID
  fixtures are unaffected.
- `./scripts/check.sh` — ruff + format + strict mypy all pass.

## Notes for reviewers

- `uv.lock` is gitignored in this repo, so only the `pyproject.toml` pin is
  committed; the lock was regenerated locally (`uv lock` → crossby 0.11.0) and
  the dev env reinstalled.
- Self-review flagged that the crossby change initially rode inside the
  version-bump commit, so the CHANGELOG omitted it. Fixed by landing the change
  as a descriptive `chore:` commit **before** re-running `auto_version.py` — the
  v0.35.2 CHANGELOG entry now reads "bump crossby to v0.11.0 and adopt newer
  models (Opus 5)".

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **184,400** |
| Input tokens | **183,200** |
| Output tokens | **1,200** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `65fae283-3bc8-4485-aa27-be23941d6644` |

<!-- wade:sessions:end -->
