### PR TITLE
feat: announce headless review timeout so orchestrators don't kill it early

### DIFF
--- a/src/wade/services/review_delegation_service.py
+++ b/src/wade/services/review_delegation_service.py
@@ -114,7 +114,19 @@ def _run_review_delegation(
         **({"timeout": cmd_config.timeout} if cmd_config.timeout is not None else {}),
     )
 
-    if delegation_mode in (DelegationMode.INTERACTIVE, DelegationMode.HEADLESS):
+    if delegation_mode == DelegationMode.HEADLESS:
+        # This spawns an external AI subprocess bounded by ``request.timeout``.
+        # Announce that budget so the orchestrator driving wade (Claude Code,
+        # Cursor, Copilot, …) allows more than its own shell/tool timeout before
+        # killing the call — otherwise it aborts the review before wade's own
+        # timeout can fire. Configure the budget via ``ai.<command>.timeout``.
+        console.info(
+            "Launching headless AI review — this runs an external AI subprocess "
+            f"that can take up to {request.timeout}s. Keep it in the foreground and "
+            f"allow more than {request.timeout}s before timing out (raise your "
+            "shell/tool timeout if needed). Do not move it to the background."
+        )
+    elif delegation_mode == DelegationMode.INTERACTIVE:
         console.info(
             "Launching external AI review session — "
             "please wait, do not move this to the background."

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -11,6 +11,14 @@ Run `wade review implementation` to review your changes and check the exit code:
 
 For staged-only review: `wade review implementation --staged`.
 
+**Headless review can be slow.** When `review_implementation.mode` is `headless`,
+this launches an external AI subprocess that may run for a few minutes. wade
+prints the exact budget when it starts ("can take up to Ns"). Keep the command in
+the foreground and allow more than that before timing out — raise your shell/tool
+timeout if needed. Do not kill it early or move it to the background; a premature
+kill is an infra timeout, not a review result. The budget is
+`ai.review_implementation.timeout` in `.wade.yml` (default 300s).
+
 **Run at most 2 times total**:
 - If findings are **minor** (style, small fixes): Address them and proceed to
   Step 2; no re-review needed.

--- a/tests/unit/test_services/test_review_delegation_service.py
+++ b/tests/unit/test_services/test_review_delegation_service.py
@@ -225,6 +225,74 @@ class TestReviewPlan:
         assert call_args.mode == DelegationMode.HEADLESS
         assert call_args.timeout == 300
 
+    @patch("wade.services.review_delegation_service.console")
+    @patch("wade.services.review_delegation_service.delegate")
+    @patch("wade.services.review_delegation_service.load_config")
+    @patch("wade.services.review_delegation_service.load_prompt_template")
+    def test_headless_launch_notice_announces_timeout(
+        self,
+        mock_template: MagicMock,
+        mock_config: MagicMock,
+        mock_delegate: MagicMock,
+        mock_console: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """The pre-launch notice must tell the orchestrator how long to wait.
+
+        Without the budget in the message, the AI tool driving wade kills the
+        headless subprocess at its own (shorter) shell timeout before wade's
+        own timeout can fire.
+        """
+        plan_file = tmp_path / "PLAN.md"
+        plan_file.write_text("# Plan")
+        mock_template.return_value = "{plan_content}"
+        mock_config.return_value = _review_config(
+            review_plan_enabled=True,
+            review_plan_mode="headless",
+            review_plan_timeout=420,
+        )
+        mock_delegate.return_value = DelegationResult(
+            success=True, feedback="ok", mode=DelegationMode.HEADLESS
+        )
+
+        review_plan(str(plan_file))
+
+        notices = " ".join(
+            str(call.args[0]) for call in mock_console.info.call_args_list if call.args
+        )
+        assert "420" in notices
+        assert "background" in notices.lower()
+
+    @patch("wade.services.review_delegation_service.console")
+    @patch("wade.services.review_delegation_service.delegate")
+    @patch("wade.services.review_delegation_service.load_config")
+    @patch("wade.services.review_delegation_service.load_prompt_template")
+    def test_prompt_mode_emits_no_launch_notice(
+        self,
+        mock_template: MagicMock,
+        mock_config: MagicMock,
+        mock_delegate: MagicMock,
+        mock_console: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Prompt mode returns instantly — no subprocess, so no wait notice."""
+        plan_file = tmp_path / "PLAN.md"
+        plan_file.write_text("# Plan")
+        mock_template.return_value = "{plan_content}"
+        mock_config.return_value = _review_config(
+            review_plan_enabled=True, review_plan_mode="prompt"
+        )
+        mock_delegate.return_value = DelegationResult(
+            success=True, feedback="ok", mode=DelegationMode.PROMPT
+        )
+
+        review_plan(str(plan_file))
+
+        notices = " ".join(
+            str(call.args[0]) for call in mock_console.info.call_args_list if call.args
+        )
+        assert "background" not in notices.lower()
+
 
 # ---------------------------------------------------------------------------
 # review_implementation


### PR DESCRIPTION
## Problem

In headless mode, `wade review` spawns an external AI subprocess bounded by
wade's own timeout (`ai.<command>.timeout`, default 300s). But the AI tool
*driving* wade — Claude Code, Cursor, Copilot, Antigravity — runs `wade review`
through **its own** shell/tool timeout, which is often shorter (Claude Code's
default is 2 min). When that shorter timeout fires first, the orchestrator kills
the review mid-flight and the infra timeout looks like a review result. The
pre-launch notice said "please wait, do not move this to the background" but gave
no duration, so the orchestrator had nothing to size its timeout against.

## Change

- **`review_delegation_service.py`** — the headless launch notice now states the
  exact budget (`request.timeout`) and tells the orchestrator to allow *more than*
  that before timing out. It lives in the shared review pipeline, so it covers
  `review_plan`, `review_implementation`, and `review_batch`. Interactive/prompt
  modes are unchanged (no subprocess timeout applies there).
- **`review-implementation-closing-step.md`** skill partial — adds a "headless
  review can be slow" note pointing at `ai.review_implementation.timeout`. Because
  wade installs skills cross-tool (`.claude` / `.cursor` / `.github` / `.agents`),
  this reaches every supported AI tool — the tool-agnostic complement to a
  per-orchestrator setting like `BASH_DEFAULT_TIMEOUT_MS`.
- **Tests** — headless notice announces the timeout; prompt mode stays quiet.

The per-command, all-tools timeout knob (`.wade.yml` → `ai.<command>.timeout`)
already existed; this PR adds the missing piece — telling the orchestrator how
long to wait.

## Testing

- `ruff check`, `ruff format --check`, `mypy` — clean
- `pytest tests/unit` — 2098 passed

## Follow-up

#346 tracks the separate session-lifecycle hooks + review-confirmation marker
work (the unconditional "Review not confirmed" reminder in `done`).
