### PR TITLE
fix: allow shell reads outside the worktree, block only writes

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -327,3 +327,21 @@ tests/e2e/mock_gh_script.py _handle_pr "view" must print a "no pull requests fou
 crossby 0.17.1+ adds AIToolCapabilities.supported_efforts: tuple[EffortLevel, ...], defaulting to the FULL 5-tuple for every tool; only antigravity-cli restricts it to (low, medium, high). wade's four effort-PROMPT sites (prompts_ai._prompt_ai_section/_prompt_model_mapping, prompts_setup._ask_effort_and_permission_mode, ai_resolution._prompt_effort_selection) now offer only these via ai_resolution.valid_effort_levels(tool); autocomplete.py (tool-agnostic completion) and check_service.py (config validation) legitimately still use the full EffortLevel enum. Test gotcha: AbstractAITool.get is patched on the SHARED class (a patch in any test module affects it everywhere), and a bare MagicMock caps makes list(caps.supported_efforts) == [] (MagicMock.__iter__ yields empty) — collapsing offered levels to none, so capability mocks MUST set supported_efforts explicitly (None falls back to all five).
 
 ---
+
+## c164ea0c | 2026-08-05 | implementation | tags: testing, crossby, gotcha | Issue #359
+
+tests/unit/test_services/test_bootstrap_allowlist.py::TestBootstrapPlanMode::test_cursor_write_guard_is_fail_closed fails with KeyError: "preToolUse" in the current dev venv (crossby 0.12.x) — the installed crossby cursor-hooks writer emits a .cursor/hooks.json shape without a top-level "preToolUse" key, while the test expects one. This is unrelated to wade-side changes: it fails identically on a clean base checkout (verified via git stash). Before assuming your change caused a bootstrap/allowlist test failure, re-run it against the stashed base; the fix belongs in crossby (or a pin bump), not wade.
+
+---
+
+## 4f9e5c6c | 2026-08-05 | plan | tags: hooks, worktree-safety, gotcha
+
+shell_containment's generic path-arg containment (rule 4 in src/wade/hooks/policies.py) checks BOTH reads and writes, which incidentally MASKS that the write enumerations are incomplete: _PLAN_WRITE_COMMANDS lacks mkdir and _GIT_WRITE_SUBCOMMANDS lacks clone/init/worktree, and spaced 'git -C <outside> <write-subcmd>' has no dedicated handling. Any change that stops containing reads (to allow reading siblings like ../crossby) MUST first complete those write enumerations and buffer 'git -C' (deny only when a write subcommand follows in the same segment) or they become silent write-escapes — 'git worktree add /outside' is the worst, a literal worktree escape. 'find <root> -delete/-exec' stays a documented gap because find's positional arg is normally a read root, so blanket-listing find would re-block legitimate reads.
+
+---
+
+## 6f3be049 | 2026-08-05 | implementation | tags: hooks, worktree-safety, gotcha | Issue #372
+
+shell_containment (src/wade/hooks/policies.py) now ALLOWS reads outside the worktree and contains only writes: a read command's path operand is skipped entirely; only output redirects, cd/pushd targets, and operands of _PLAN_WRITE_COMMANDS (incl. mkdir) / _GIT_WRITE_SUBCOMMANDS (incl. clone/init/worktree) / in-place editors are checked. Two shapes a tokenizer can't classify positionally get special handling: in-place editors (sed -i) set is_write_command in BOTH modes (was plan-only), and spaced 'git -C DIR' is buffered and denied only when a git write subcommand follows in the same segment (git -C SIBLING log stays allowed). Accepted residual write-escapes, documented NOT fixed: WRAPPED writers (sudo rm, env cp, xargs rm — the wrapper becomes command_name, hiding the real writer), UNENUMERATED writers (zip, git bundle create, git format-patch -o), spaced output flags (curl -o OUTSIDE), tar -C / unzip -d / make -C, and find -delete/-exec — only enumerated writers (_PLAN_WRITE_COMMANDS / _GIT_WRITE_SUBCOMMANDS / in-place editors) and the GLUED flag forms (-oOUTSIDE, git -COUTSIDE via _embedded_path) stay contained. The guard is best-effort defense-in-depth, NOT a security boundary (python -c / eval / $(...) also escape).
+
+---

--- a/KNOWLEDGE.ratings.yml
+++ b/KNOWLEDGE.ratings.yml
@@ -13,7 +13,7 @@
 '13459084':
   down: 0
   stale: 0
-  up: 3
+  up: 4
 164c355e:
   down: 0
   stale: 0
@@ -25,7 +25,7 @@
 235fb8e8:
   down: 0
   stale: 0
-  up: 1
+  up: 2
 271cf18f:
   down: 0
   stale: 0
@@ -49,7 +49,7 @@
 443a71b3:
   down: 0
   stale: 0
-  up: 1
+  up: 2
 455476d6:
   down: 0
   stale: 0
@@ -78,7 +78,7 @@
   down: 0
   stale: 0
   superseded_by: a15045c3
-  up: 2
+  up: 3
 97d81e85:
   down: 0
   stale: 0
@@ -101,6 +101,14 @@ a24d65b0:
   superseded_by: c71d1a70
   up: 1
 ae5df2be:
+  down: 0
+  stale: 0
+  up: 3
+b2fd3ce3:
+  down: 0
+  stale: 0
+  up: 1
+b545203e:
   down: 0
   stale: 0
   up: 1

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -176,20 +176,44 @@ A write reaches the guard through one of two channels, and both must be covered:
   `shell_containment` instead.
 
 `shell_containment` tokenizes with `shlex.split` (failing **closed** on
-unbalanced quotes) and denies redirect targets, `cd`/`pushd` targets, and
-path arguments that resolve outside the worktree — plus, in plan mode,
-redirects/in-place edits/`tee` aimed at non-artifacts.
+unbalanced quotes) and contains **writes** while allowing **reads** anywhere:
+reading a sibling repo (`cat ../crossby/x`, `grep -r foo ../crossby`,
+`git -C ../crossby log`) never mutates state, so a read operand may resolve
+outside the worktree. It denies output redirect targets (`>`, `>>`, `2>`), `<`
+input redirects excepted (a read); `cd`/`pushd` targets; and operands of *write*
+commands — `_PLAN_WRITE_COMMANDS` (`tee`/`cp`/`mv`/`touch`/`mkdir` …), git write
+subcommands `_GIT_WRITE_SUBCOMMANDS` (`checkout`/`clean`/`clone`/`init`/`worktree`
+…), and in-place editors (`sed -i`, `perl -i`) — that resolve outside. In plan
+mode it additionally rejects those same writes when aimed at non-artifacts, and
+denies the in-place `-i` flag outright.
 
-It also unglues paths from flags (`--output=/tmp/x`, `-o/tmp/x`, `of=/tmp/x`),
-treats bash's `>&file` as a write while skipping true fd duplication (`2>&1`),
-denies a bare `cd` (it lands in `$HOME`), and exempts character devices so
-`>/dev/null 2>&1` still works.
+Spaced `git -C <dir>` is buffered: `git -C ../crossby log` (a read subcommand) is
+allowed, but a git *write* subcommand after an outside `-C` (`git -C /outside
+clean -fd`, `git -C /outside checkout -- file`) is denied — there is no later path
+operand to catch it otherwise. It also unglues paths from flags
+(`--output=/tmp/x`, `-o/tmp/x`, `of=/tmp/x`, `git -C/tmp/other`) and keeps those
+**glued** forms contained in every mode (a tokenizer cannot tell a glued read flag
+from a glued write flag, so a few glued reads are denied too), treats bash's
+`>&file` as a write while skipping true fd duplication (`2>&1`), denies a bare
+`cd` (it lands in `$HOME`), and exempts character devices so `>/dev/null 2>&1`
+still works.
 
 **It is defense-in-depth, not a completeness guarantee.** It stops the
 non-obfuscated cases an agent actually produces. Documented residual gaps
 (see the function docstring): env-var indirection (`$HOME/x`), command
 substitution, subshells, here-docs, `$IFS` tricks, `eval`, symlinks created
-within the same command, and interpreters given inline code (`python -c`).
+within the same command, and interpreters given inline code (`python -c`). The
+read relaxation gives up a few more write-escapes rather than re-block the
+sibling-repo reads it exists to allow: **wrapped** write commands (`sudo rm
+/outside`, `env FOO=bar cp a /outside`, `xargs rm` — the wrapper hides the real
+writer), **unenumerated** write commands (`zip`, `git bundle create /outside`,
+`git format-patch -o /outside`), **spaced** output flags on non-write commands
+(`curl -o /outside`), directory-context flags on non-git extractors/builders
+(`tar -C /outside`, `unzip -d /outside`, `make -C /outside`), and conditional-write
+`find` (`find ../outside -delete`). Only enumerated writers
+(`_PLAN_WRITE_COMMANDS` / `_GIT_WRITE_SUBCOMMANDS` / in-place editors) and the
+**glued** output-flag forms stay caught — the guard is best-effort defense-in-depth
+against the writes an agent actually produces, not a security boundary.
 
 ### Per-tool capability matrix
 

--- a/src/wade/hooks/policies.py
+++ b/src/wade/hooks/policies.py
@@ -239,11 +239,13 @@ _IN_PLACE_COMMANDS = frozenset({"sed", "gsed", "perl", "ruby", "yq"})
 # common shell idiom an agent emits, and denying it breaks ordinary sessions.
 _ALWAYS_ALLOWED_PATH_PREFIXES = ("/dev/",)
 
-# Commands that write their path operands. In plan mode those operands must be plan
+# Commands whose path operands are *writes*, so their operands stay contained even
+# after the read relaxation. In plan mode those operands must additionally be plan
 # artifacts, otherwise `cp PLAN.md src/app.py` edits source without a write tool.
 # Deletion counts as a write: `rm src/app.py` destroys source just as surely as
 # overwriting it, and omitting it left the mildest command (`touch`) guarded while
-# the most destructive one was not.
+# the most destructive one was not. `mkdir` is here for the same reason — it
+# creates a directory, a write, and `mkdir /outside/dir` must not escape.
 _PLAN_WRITE_COMMANDS = frozenset(
     {
         "tee",
@@ -260,10 +262,16 @@ _PLAN_WRITE_COMMANDS = frozenset(
         "rmdir",
         "unlink",
         "shred",
+        "mkdir",
     }
 )
-# `git <sub> -- <path>` forms that overwrite working-tree files.
-_GIT_WRITE_SUBCOMMANDS = frozenset({"checkout", "restore", "apply", "mv", "rm", "clean"})
+# git subcommands that write the working tree or filesystem. `checkout`/`restore`/
+# `apply`/`mv`/`rm`/`clean` overwrite or delete tracked files; `clone`/`init`/
+# `worktree` create files at a positional target (`git worktree add /outside` is a
+# literal worktree escape — exactly what this guard exists to prevent).
+_GIT_WRITE_SUBCOMMANDS = frozenset(
+    {"checkout", "restore", "apply", "mv", "rm", "clean", "clone", "init", "worktree"}
+)
 
 
 def _tokenize(command: str) -> list[str]:
@@ -399,26 +407,44 @@ def shell_containment(
     :func:`plan_artifact_only` never inspect them. Without this predicate a single
     ``printf ... > ../main-repo/src/app.py`` defeats both guards.
 
+    **Reads outside the worktree are allowed; only writes are contained.** Reading
+    a sibling repo (``cat ../crossby/x``, ``grep -r foo ../crossby``,
+    ``git -C ../crossby log``) never mutates state, so a read operand may resolve
+    anywhere. The guard's job is to keep *writes* inside the root.
+
     Rules, in order (any match denies):
 
     1. The command does not tokenize (unbalanced quotes) — **fail closed**.
-    2. A redirect target (``>``, ``>>``, ``2>``, ``>&file``, glued or spaced)
-       resolves outside the root. Pure fd duplication (``2>&1``, ``>&-``) names no
-       file and is skipped.
+    2. An *output* redirect target (``>``, ``>>``, ``2>``, ``>&file``, glued or
+       spaced) resolves outside the root. An *input* redirect (``< target``) only
+       reads, so its target may live anywhere. Pure fd duplication (``2>&1``,
+       ``>&-``) names no file and is skipped.
     3. ``cd`` / ``pushd`` targets a path outside the root — it would rebase every
        later relative write in the same command. A *bare* ``cd`` (or ``cd -``)
        counts: it lands in ``$HOME``/``$OLDPWD``, equally outside.
-    4. Any remaining path-like argument resolves outside the root, including a path
-       glued to a flag or operand (``--output=/tmp/x``, ``-o/tmp/x``, ``of=/tmp/x``).
-       The *executable* position of each segment is exempt, since binaries
-       legitimately live in ``/usr/bin``, ``/bin``, ``/opt/homebrew/bin`` and denying
-       those breaks every session. Character devices (``/dev/null``) are exempt too —
-       ``>/dev/null 2>&1`` is not an escape.
-    5. In plan mode only: any redirect, an in-place edit flag (``sed -i``,
+    4. An operand of a *write* command resolves outside the root. Write commands
+       are :data:`_PLAN_WRITE_COMMANDS` (``tee``/``cp``/``mv``/``touch``/``mkdir``
+       …), git write subcommands (:data:`_GIT_WRITE_SUBCOMMANDS`:
+       ``checkout``/``clean``/``clone``/``init``/``worktree`` …), and in-place
+       editors (:data:`_IN_PLACE_COMMANDS` carrying an ``-i`` flag). A *read*
+       command's path operand is not checked — reads may resolve anywhere. The
+       *executable* position of each segment is exempt, since binaries legitimately
+       live in ``/usr/bin``, ``/bin``, ``/opt/homebrew/bin`` and denying those
+       breaks every session. Character devices (``/dev/null``) are exempt too.
+    5. A path glued to a flag or operand (``--output=/tmp/x``, ``-o/tmp/x``,
+       ``of=/tmp/x``, ``git -C/tmp/other``) resolves outside the root. The glued
+       form is contained in *all* modes: a tokenizer cannot tell a glued read flag
+       from a glued write flag, so both are denied — this conservatively denies a
+       few glued *reads* too (e.g. ``git -C/tmp/other log``).
+    6. Spaced ``git -C <dir>`` where ``<dir>`` is outside the root **and** a git
+       write subcommand (:data:`_GIT_WRITE_SUBCOMMANDS`) follows in the same
+       segment. ``git -C <outside> log``/``show``/``status``/``diff`` (read
+       subcommands) stay allowed; ``git -C <outside> clean`` would otherwise delete
+       untracked files outside with no later path operand to catch it.
+    7. In plan mode only: any output redirect, an in-place edit flag (``sed -i``,
        ``--in-place``) on a command that *has* one (:data:`_IN_PLACE_COMMANDS` —
        ``grep -i`` and ``ls -i`` are ordinary read flags), or an operand of a write
-       command (``tee``, ``cp``, ``mv``, ``touch``, ``git checkout --`` …) whose
-       path is not a plan artifact.
+       command whose path is not a plan artifact.
 
     **This is defense-in-depth, not a completeness guarantee.** It stops the
     non-obfuscated cases — the ones an agent actually produces — and is trivially
@@ -435,11 +461,39 @@ def shell_containment(
       them, so a symlinked *target* is caught, but a symlink created earlier in the
       same command is not.
     - **Interpreters given inline code** — ``python -c 'open("/etc/x","w")'``.
-    - **Plan mode only:** a write command outside :data:`_PLAN_WRITE_COMMANDS`
-      (the list covers ``tee``/``cp``/``mv``/``touch``/``git checkout --`` and
-      friends), or an in-place editor outside :data:`_IN_PLACE_COMMANDS`. The
-      *worktree* rules still apply to both, so neither can escape the root — they
-      can only write a non-artifact inside it.
+    - **Wrapped write commands** — ``sudo rm /outside``, ``env FOO=bar cp a /outside``,
+      ``xargs rm``, ``nice``/``nohup``/``time``/``command``/``doas``/``timeout`` …
+      The wrapper becomes the detected ``command_name``, so the real writer behind it
+      is invisible and its operands read as *reads*. Unwrapping is a clean fix (it
+      would not re-block any read), but is deliberately not done here — the guard is
+      best-effort, and unwrapping a partial wrapper list gives a false sense of
+      completeness while ``python -c`` and the writers below still escape.
+    - **Unenumerated write commands** — ``zip /outside/a.zip``, ``gzip``, ``split``,
+      ``git bundle create /outside``, ``git format-patch -o /outside``,
+      ``git archive -o /outside``. Only :data:`_PLAN_WRITE_COMMANDS` /
+      :data:`_GIT_WRITE_SUBCOMMANDS` are contained; a writer outside those sets has
+      its operands treated as reads. The sets cover the commands an agent actually
+      produces; some others (``git bundle``/``git worktree`` have read *and* write
+      subcommands) cannot be blanket-added without re-blocking their read forms.
+    - **Spaced output flags on non-write commands** — ``curl -o /outside``,
+      ``gcc -o /outside``, ``wget -O /outside``, ``sort --output /outside``. The
+      *glued* forms stay caught by rule 5; the spaced form is a genuine write-escape
+      the relaxation gives up, because a token after ``-o`` is a read as often as a
+      write (``ls -o ../dir``) and a blanket "``-o`` value is a write target" rule
+      would re-block the reads this guard now allows.
+    - **Directory-context flags on non-git extractors/builders** —
+      ``tar -C /outside -xf a.tar``, ``unzip -d /outside a.zip``, ``make -C /outside``.
+      ``git -C`` is fixed (rule 6) only because git's write subcommands are
+      enumerated; these have no create-vs-extract enumeration to key on.
+    - **Conditional-write ``find``** — ``find ../outside -delete`` /
+      ``-exec rm {} +``. ``find``'s positional argument is normally a *read* root
+      (``find ../crossby -name '*.py'``), so listing ``find`` as a write command
+      would re-block the reads this guard now allows; the write targets are the
+      *found* files, not a single operand, so there is no cheap buffered fix.
+    - **Plan mode only:** a write command outside :data:`_PLAN_WRITE_COMMANDS`, or
+      an in-place editor outside :data:`_IN_PLACE_COMMANDS`. Neither can escape the
+      root (rule 4 still contains enumerated writes) — they can only write a
+      non-artifact inside it.
 
     Args:
         event: Normalized hook event; only :attr:`HookEvent.command` is read.
@@ -470,17 +524,20 @@ def shell_containment(
     def deny_outside(what: str, token: str) -> HookDecision:
         return HookDecision.deny(
             f"BLOCKED by worktree guard: the shell command's {what} ('{token}') resolves "
-            f"outside the worktree at '{root}'. Run commands that read or write only "
-            "inside your worktree."
+            f"outside the worktree at '{root}' — only paths inside the worktree can be "
+            "verified as safe write targets. Reads outside are fine; rewrite this as a "
+            "read, or keep the write inside your worktree."
         )
 
     def check_redirect_target(target: str, op: str) -> HookDecision | None:
-        """Containment (always) + plan-artifact (plan mode, writes only) for a target."""
+        """Containment (writes) + plan-artifact (plan mode) for an output redirect."""
+        # ``<`` only reads its target, so a ``<`` outside the worktree is fine.
+        if op == "<":
+            return None
         resolved = _resolve_shell_path(target, base=base)
         if resolved is None or not _contained(resolved, root):
             return deny_outside("redirect target", target)
-        # ``<`` only reads, so the plan-artifact allowlist does not apply to it.
-        if plan_mode and op != "<" and not _is_plan_artifact_path(resolved, root):
+        if plan_mode and not _is_plan_artifact_path(resolved, root):
             return HookDecision.deny(
                 f"BLOCKED by plan-session guard: redirecting output to '{target}' "
                 "would write a non-artifact file without going through a write tool. "
@@ -506,6 +563,11 @@ def shell_containment(
     is_write_command = False
     awaiting_cd_target = False
     pending_redirect: str | None = None
+    # Spaced ``git -C <dir>``: the next token is the directory (awaiting flag), and
+    # once seen we remember it here iff it resolves outside the root. A read like
+    # ``git -C <outside> log`` is fine; only a later git *write* subcommand denies.
+    awaiting_git_c_dir = False
+    git_c_outside_token: str | None = None
 
     def end_segment() -> HookDecision | None:
         """A segment that ended while `cd` still wanted a target went to $HOME."""
@@ -527,6 +589,8 @@ def shell_containment(
             is_write_command = False
             awaiting_cd_target = False
             pending_redirect = None
+            awaiting_git_c_dir = False
+            git_c_outside_token = None
             continue
 
         redirect = _REDIRECT_RE.match(token)
@@ -578,18 +642,47 @@ def shell_containment(
                 return deny_outside(f"{command_name} target", token)
             continue
 
-        if plan_mode and command_name in _IN_PLACE_COMMANDS and _IN_PLACE_FLAG_RE.match(token):
-            return HookDecision.deny(
-                f"BLOCKED by plan-session guard: in-place editing ('{token}') is not "
-                "allowed in plan mode — it rewrites a file without going through a "
-                "write tool. Only plan artifacts may be written."
-            )
+        # Spaced ``git -C <dir>``: buffer the directory. A read through it is fine
+        # (``git -C ../crossby log``); a later git *write* subcommand in the same
+        # segment turns a buffered *outside* dir into a denial. The glued
+        # ``-C/outside`` form is caught by `_embedded_path` below in every mode.
+        if awaiting_git_c_dir:
+            awaiting_git_c_dir = False
+            resolved = _resolve_shell_path(token, base=base)
+            if resolved is None or not _contained(resolved, root):
+                git_c_outside_token = token
+            continue
+
+        if command_name == "git" and token == "-C":
+            awaiting_git_c_dir = True
+            continue
+
+        # In-place editors (`sed -i`, `perl -i`, `yq -i`, …) rewrite their operands.
+        # Plan mode denies the flag outright; *every* mode marks the command a writer
+        # so its later operands are contained — otherwise the read relaxation would
+        # let `sed -i '' s/a/b/ ../main/file` write outside in implementation mode.
+        if command_name in _IN_PLACE_COMMANDS and _IN_PLACE_FLAG_RE.match(token):
+            if plan_mode:
+                return HookDecision.deny(
+                    f"BLOCKED by plan-session guard: in-place editing ('{token}') is not "
+                    "allowed in plan mode — it rewrites a file without going through a "
+                    "write tool. Only plan artifacts may be written."
+                )
+            is_write_command = True
+            continue
 
         if command_name == "git" and token in _GIT_WRITE_SUBCOMMANDS:
             is_write_command = True
+            # A git write subcommand after a spaced ``-C`` pointing outside the root
+            # (``git -C /outside clean -fd``) writes outside with no later path
+            # operand to catch it — deny on the buffered directory.
+            if git_c_outside_token is not None:
+                return deny_outside("git -C directory", git_c_outside_token)
 
-        # A path glued to a flag or operand (``--output=/tmp/x``, ``of=/tmp/x``) is
-        # invisible to `_looks_like_path`, and `of=/tmp/x` would resolve *relative*.
+        # A path glued to a flag or operand (``--output=/tmp/x``, ``of=/tmp/x``,
+        # ``git -C/tmp/other``) is invisible to `_looks_like_path`, and `of=/tmp/x`
+        # would resolve *relative*. Contained in every mode: a tokenizer cannot tell
+        # a glued read flag from a glued write flag, so both are denied.
         embedded = _embedded_path(token)
         if embedded is not None:
             resolved = _resolve_shell_path(embedded, base=base)
@@ -601,16 +694,17 @@ def shell_containment(
                     return denial
             continue
 
-        if _looks_like_path(token) or (is_write_command and not token.startswith("-")):
-            # A write command's operands are checked even without a `/` — plan mode
-            # must catch `tee app.py`, not just `tee src/app.py`.
+        if is_write_command and not token.startswith("-"):
+            # Only a *write* command's operands are contained; a read command's path
+            # operand may resolve anywhere — reading a sibling repo never mutates
+            # state. Path-like or not: plan mode must catch `tee app.py`, not just
+            # `tee src/app.py`.
             resolved = _resolve_shell_path(token, base=base)
             if resolved is None or not _contained(resolved, root):
                 return deny_outside("path argument", token)
-            if is_write_command:
-                denial = check_non_artifact(f"'{command_name}'", token, resolved)
-                if denial is not None:
-                    return denial
+            denial = check_non_artifact(f"'{command_name}'", token, resolved)
+            if denial is not None:
+                return denial
 
     return end_segment() or HookDecision.allow()
 

--- a/tests/unit/test_hooks/test_policies.py
+++ b/tests/unit/test_hooks/test_policies.py
@@ -89,16 +89,41 @@ class TestShellContainment:
             "cd ../../elsewhere",
             "cp a /tmp/b",
             "git checkout -- ../main-repo/x",
-            "cat ~/secrets",  # ~ is expanded (shlex does not)
             "echo a | tee /etc/p",
-            "sed -i '' s/a/b/ ../main/file",
+            "sed -i '' s/a/b/ ../main/file",  # in-place edit outside (impl mode)
             "true; cp a /tmp/b",  # ;-chained segment
             "true && cp a /tmp/b",  # &&-chained segment
-            "cat < /etc/passwd",
+            "mkdir /tmp/outside-dir",  # mkdir creates outside
+            "git clone https://example.com/r.git /tmp/outside",  # positional write
+            "git init /tmp/outside",
+            "git worktree add /tmp/outside main",  # literal worktree escape
+            "git -C /tmp/outside clean -fd",  # spaced -C + git write subcommand
+            "git -C /tmp/outside checkout -- file",
         ],
     )
     def test_outside_worktree_denied(self, command: str) -> None:
         assert shell_containment(_shell(command), worktree_root=WT).action == "deny"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat ../crossby/x.py",  # reading a sibling repo never mutates state
+            "grep -r foo ../crossby",
+            "rg foo ../crossby",
+            "ls ../crossby",
+            "head ../sib/f",
+            "git -C ../crossby log",  # read subcommand through an outside -C dir
+            "diff ../a ../b",
+            "cat ~/secrets",  # ~ expands outside, but a read is fine
+            "cat < /etc/passwd",  # input redirect only reads its target
+        ],
+    )
+    def test_reads_outside_worktree_allowed(self, command: str) -> None:
+        """Reads outside the worktree are allowed — only writes are contained."""
+        assert shell_containment(_shell(command), worktree_root=WT).action == "allow"
+        # ...and equally in plan mode (which still blocks every non-artifact write).
+        plan = shell_containment(_shell(command), worktree_root=WT, plan_mode=True)
+        assert plan.action == "allow"
 
     @pytest.mark.parametrize("command", ['echo "unterminated', "echo 'unbalanced"])
     def test_unparseable_fails_closed(self, command: str) -> None:
@@ -139,7 +164,21 @@ class TestShellContainment:
         ],
     )
     def test_paths_glued_to_flags_denied(self, command: str) -> None:
-        """A path attached to a flag or operand is still a path."""
+        """A path attached to a flag or operand is still a path.
+
+        These are the *glued* forms, kept contained in every mode because a
+        tokenizer cannot tell a glued read flag from a glued write flag.
+
+        The *spaced* counterparts are accepted residual write-escape risks (not
+        asserted here, documented in the ``shell_containment`` docstring): spaced
+        output flags on non-write commands (``curl -o /outside``,
+        ``sort --output /outside``), directory-context flags on non-git
+        extractors/builders (``tar -C /outside -xf a.tar``, ``unzip -d /outside``,
+        ``make -C /outside``), and conditional-write ``find`` (``find ../outside
+        -delete`` / ``-exec rm {} +``). Each is skipped rather than fixed because a
+        blanket rule would re-block the sibling-repo reads this relaxation exists to
+        allow (``ls -o ../dir``, ``find ../crossby -name '*.py'``).
+        """
         assert shell_containment(_shell(command), worktree_root=WT).action == "deny"
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #372

<!-- wade:plan:start -->

## Complexity
complex

## Context / Problem

The worktree guard blocks legitimate **reads** of paths outside the worktree.
During a real implementation session (worktree
`feat-359-h4-drift-amp-layering-agents-md-architecture-md`), a command
referencing the sibling `crossby` package was denied:

```
Error: BLOCKED by worktree guard: the shell command's path argument
('../crossby') resolves outside the worktree ... Run commands that read or
write only inside your worktree.
```

Reading sibling repositories (e.g. the external `crossby` dependency that lives
next to the WADE checkout) is a normal, safe operation — reads never mutate
state. The guard's job is to prevent **writes** escaping the worktree, not
reads.

### Where the block actually lives

- **Tool-call reads already work.** `worktree_containment`
  (`src/wade/hooks/policies.py`) allows any non-write tool call, so `Read` /
  `Grep` on `../crossby` is already fine.
- **The block is only in `shell_containment`.** crossby reports
  `is_write=False` for shell tool names, so the guard must parse the command
  itself. Its generic path-argument rule ("rule 4") currently contains **every**
  path-like argument — read or write — which is what denied `../crossby`. Its
  input-redirect handling (`<`) also enforces containment even though `<` only
  reads.

### Why a safe relaxation is possible

Every existing write-escape test is caught by a channel **other** than the
generic read-operand rule:

- `curl -o/tmp/pwn`, `sort --output=/tmp/pwn`, `dd of=/tmp/pwn`,
  `tar --file=/tmp/pwn.tar`, `git -C/tmp/other init` — caught by the **glued
  flag** path (`_embedded_path`).
- `printf x > /tmp/out`, `cp a /tmp/b`, `git checkout -- ../main/x`,
  `echo a | tee /etc/p` — caught by **redirect** / **write-command** rules.

So containment can be dropped for read operands while keeping every write
channel enforced.

### Two correctness traps the relaxation must not open

Dropping the blanket rule-4 containment removes an *incidental* protection two
command shapes currently rely on. Both must be handled, or the "reads allowed"
change silently regresses **write** protection:

1. **In-place editors** — `sed -i '' s/a/b/ ../main/file` is blocked today
   **only** by rule 4. `sed` is not a write command, and the in-place (`-i`)
   detection runs **plan-mode only** today. Naively allowing read operands
   outside would let `sed -i ../outside/file` write outside in **implementation**
   mode. Fix: promote in-place editors to write-operand containment in **both**
   modes.

2. **Directory-context flag `git -C <dir>`** — `git -C /outside clean -fd` and
   `git -C /outside checkout -- file` are blocked today **only** because
   `/outside` is caught as a generic bare path arg by rule 4. Under a naive
   relaxation the spaced `-C /outside` is classified as a read and skipped: at
   the moment `-C` is seen, `is_write_command` is still `False` (the write
   subcommand appears later), so `/outside` is never checked. For
   `git -C /outside clean -fd` there is no later path operand at all — the whole
   command passes and untracked files **outside** the worktree are deleted
   silently. For `git -C /outside checkout -- file`, the `file` operand is
   resolved against the worktree `base`, not `/outside`, so the check passes
   while the real write lands outside (a false-negative pass). This is a genuine
   regression, more serious than a spaced-output-flag gap, and is cleanly
   fixable — see implementation note 3. (The **glued** form `git -C/outside …`
   stays caught by `_embedded_path`.)

### Scope decisions (confirmed with the user)

- **Sessions:** apply to **both** plan and implementation sessions. The reported
  error was an implementation session, and reads are equally safe in plan mode
  (which already blocks every non-artifact write).
- **Breadth:** **broad** — allow any shell path argument outside unless it is a
  detected write target. This still fixes `git -C ../crossby log` (read).

## Proposed Solution

Relax `shell_containment` in `src/wade/hooks/policies.py` so that **reads**
outside the worktree are allowed while every **write** channel stays enforced.
This applies in both plan mode and implementation mode (the change is to the
shared containment logic, not gated on `plan_mode`).

### Behavior contract

**Now allowed outside the worktree (reads):**

- Bare path operands of non-write commands — `cat ../crossby/x`,
  `grep -r foo ../crossby`, `rg foo ../crossby`, `ls ../crossby`,
  `head ../sib/f`, `git -C ../crossby log`, `cat ~/notes`.
- Input redirects — `cat < /etc/passwd` (a `<` target is always a read).

**Still blocked outside the worktree (writes) — unchanged behavior:**

- Output redirects (`>`, `>>`, `>|`, and bash `>&file`).
- `cd` / `pushd` targets (they rebase later relative writes), including bare
  `cd`.
- Operands of write commands (`_PLAN_WRITE_COMMANDS`: `tee`, `cp`, `mv`,
  `touch`, `install`, `ln`, `dd`, `truncate`, `patch`, `rsync`, `rm`, `rmdir`,
  `unlink`, `shred`, **and newly `mkdir`**) and git write subcommands
  (`checkout`, `restore`, `apply`, `mv`, `rm`, `clean`, **and newly `clone`,
  `init`, `worktree`**).
- **Glued** output/context flags via `_embedded_path` (`curl -o/tmp/x`,
  `sort --output=/tmp/x`, `dd of=/tmp/x`, `git -C/tmp/other …`) — kept
  conservatively contained.

**New — closes the regressions the blanket rule-4 check was masking:**

- In-place editors (`sed`, `gsed`, `perl`, `ruby`, `yq`) with an in-place flag
  (`-i`, `-i.bak`, `--in-place`) now contain their operands in **both** plan and
  implementation mode (previously plan-mode only). Plan mode continues to deny
  the `-i` flag outright.
- Spaced `git -C <dir>` where `<dir>` is outside the worktree **and** a git
  write subcommand (`_GIT_WRITE_SUBCOMMANDS`) appears in the same segment is
  denied. `git -C <outside> log` / `show` / `status` / `diff` (read
  subcommands) remain allowed.
- **Completed write-command enumerations** — `mkdir` joins `_PLAN_WRITE_COMMANDS`
  and `clone` / `init` / `worktree` join `_GIT_WRITE_SUBCOMMANDS`. These take
  unambiguous **positional** write targets, exactly like the already-enumerated
  `cp` / `mv` / `touch` / `git checkout --` cases, so enumerating them carries no
  risk of false-denying a read. This blocks `mkdir /outside/dir`,
  `git clone <url> /outside`, `git init /outside`, and — most importantly —
  `git worktree add /outside <branch>` (a literal worktree escape, the exact
  thing this guard exists to prevent), all of which the blanket rule-4 check was
  incidentally catching before the relaxation.

**Documented residual risk (accepted — not fixed):**

Clearly higher-severity than "cosmetic," and explicitly *not* folded into a
minor gap: for a handful of command shapes a tokenizer cannot classify without
executing the command, the relaxation gives up the *incidental* containment that
blanket rule-4 provided. All of these are **spaced** forms only — the **glued**
forms stay caught by `_embedded_path`:

- Spaced output flags on non-write commands — `curl -o /outside`,
  `gcc -o /outside`, `wget -O /outside`, `sort --output /outside`.
- Directory-context flags on non-git extractors/builders —
  `tar -C /outside -xf a.tar`, `unzip -d /outside a.zip`, `make -C /outside`.
- Conditional-write flags on `find` — `find ../outside -delete`,
  `find ../outside -exec rm {} \;`. `find`'s positional argument is normally a
  **read** root (`find ../crossby -name '*.py'`), so blanket-adding `find` to
  the write-command set would re-block exactly the reads this change exists to
  allow. It only becomes a write when `-delete` / `-exec` appears later, making
  it a conditional-write shape like `git -C` — but, unlike `git -C`, the write
  targets are the *found* files (potentially anywhere under the root), not a
  single operand, so a cheap buffered fix is not available. Deferred as
  documented risk rather than fixed.

A generic "the token after `-o`/`-C` is a write target" rule is deliberately
**rejected**: it would falsely re-block reads such as `ls -o ../dir` and
`find ../dir -o …`, which is exactly the false-denial this change exists to
remove. The `git -C` case is fixed above precisely because git's write
subcommands are already enumerated (`_GIT_WRITE_SUBCOMMANDS`), so it can be
resolved without guessing. `tar` / `unzip` / `make` and `find -delete` have no
such enumeration (or ambiguous create-vs-extract / read-vs-delete semantics), so
they stay documented risk. These join the existing "defense-in-depth, not a
completeness guarantee" gap list in the `shell_containment` docstring, called out
at their real severity.

### Implementation notes

In `shell_containment` (`src/wade/hooks/policies.py`):

1. **Input redirect `<` reads outside** — in `check_redirect_target`, return
   early (allow) when `op == "<"` before the containment check. `<` only reads
   its target, so a `<` outside the worktree is fine. Output redirects keep the
   existing containment + plan-artifact behavior.
2. **Read operands allowed outside; gate the operand check on `is_write_command`**
   — replace the bare-operand branch condition
   (`if _looks_like_path(token) or (is_write_command and not token.startswith("-"))`)
   so containment / plan-artifact checks run **only** when `is_write_command` is
   true (a write command's operands, path-like or not, must be contained). For a
   non-write command's path operand, no check runs — it is a read. This also
   removes the now-dead branch where `_looks_like_path` entered the block and
   immediately no-op'd for non-write commands.
3. **`git -C <dir>` buffering** — when `command_name == "git"` and the token is
   exactly `-C`, treat the next token as a directory (buffer it, like the
   `cd`/`pushd` handling); resolve it and record whether it is outside the root.
   When a `_GIT_WRITE_SUBCOMMANDS` token later appears in the same segment (this
   already sets `is_write_command = True`), if a buffered outside `-C` target
   exists, deny. Reset the buffer on each segment separator alongside the other
   per-segment state. This preserves `git -C ../crossby log` (no write
   subcommand → no deny) while blocking `git -C /outside clean -fd` and
   `git -C /outside checkout -- file`. The glued `-C/outside` form is already
   handled by `_embedded_path`.
4. **In-place editors contained in both modes** — when
   `command_name in _IN_PLACE_COMMANDS` and the token matches
   `_IN_PLACE_FLAG_RE`: in plan mode, deny outright (existing behavior); in all
   modes, set `is_write_command = True` so subsequent operands are contained.
   Keeps `sed -i '' s/a/b/ ../main/file` denied in implementation mode.
5. **Complete write-command enumerations** — add `mkdir` to
   `_PLAN_WRITE_COMMANDS` and `clone` / `init` / `worktree` to
   `_GIT_WRITE_SUBCOMMANDS`. No control-flow change is needed beyond the set
   membership: once enumerated, their positional operands are contained by the
   same `is_write_command` path as `cp` / `mv` / `git checkout --`. This restores
   the containment the blanket rule-4 check was providing incidentally for
   `mkdir /outside`, `git clone <url> /outside`, `git init /outside`, and
   `git worktree add /outside <branch>`.
6. **`_embedded_path` (glued flags) unchanged** — still contained in all modes,
   preserving the glued write-flag protection (the safe default for the
   ambiguous glued-flag case).
7. **Messages & docstring** — soften the `deny_outside` message so it stays
   accurate for **both** channels: it must not claim "reads outside are always
   allowed," because the glued-flag path (`_embedded_path`) still denies some
   reads (e.g. `git -C/tmp/other log`). Use wording like "resolves outside the
   worktree — only paths inside the worktree can be verified as safe write
   targets" rather than "run commands that read or write only inside your
   worktree." Update the `shell_containment` docstring "Rules, in order" list for
   the read/write split, document the `git -C` handling, and add the spaced
   output-flag / directory-context-flag residual risks (at their real severity)
   to the "Known residual gaps" list.

## Tasks

- [ ] In `check_redirect_target`: allow `<` input redirects to resolve outside
      the worktree (return early before the containment check); keep output
      redirects contained + plan-artifact-checked.
- [ ] In the bare-operand branch: gate containment + plan-artifact checks on
      `is_write_command` (write-command operands only); skip all checks for a
      non-write command's path operand; remove the now-dead `_looks_like_path`
      entry condition.
- [ ] Add `git -C <dir>` buffering: remember a spaced `-C` target and whether it
      is outside the root; deny when a `_GIT_WRITE_SUBCOMMANDS` token follows in
      the same segment and a buffered outside `-C` target exists; reset on
      segment separators.
- [ ] Promote in-place editors (`_IN_PLACE_COMMANDS` + `_IN_PLACE_FLAG_RE`) to
      set `is_write_command = True` in both modes (keep the plan-mode outright
      deny of the `-i` flag).
- [ ] Add `mkdir` to `_PLAN_WRITE_COMMANDS` and `clone` / `init` / `worktree` to
      `_GIT_WRITE_SUBCOMMANDS` so their positional write targets stay contained
      after the relaxation.
- [ ] Soften the `deny_outside` message so it is accurate for both the
      write-target and glued-flag channels (do not claim reads are always
      allowed outside).
- [ ] Update the `shell_containment` docstring: revise the "Rules, in order"
      list for the read/write split, document the `git -C` handling, and add the
      spaced output-flag / directory-context-flag residual risks to the "Known
      residual gaps" list at their real severity.
- [ ] In `tests/unit/test_hooks/test_policies.py`: move `cat ~/secrets` and
      `cat < /etc/passwd` from `test_outside_worktree_denied` to an
      allowed-reads test.
- [ ] Add read-outside-allowed cases (both plan and implementation mode):
      `cat ../crossby/x.py`, `grep -r foo ../crossby`, `rg foo ../crossby`,
      `ls ../crossby`, `head ../sib/f`, `git -C ../crossby log`, `diff ../a ../b`,
      `cat < /etc/passwd`.
- [ ] Add write-outside-still-denied regression cases: `sed -i '' s/a/b/
      ../main/file` in **implementation** mode; `git -C /outside clean -fd` and
      `git -C /outside checkout -- file` (spaced `-C` + write subcommand);
      `mkdir /outside/dir`, `git clone <url> /outside`, `git init /outside`, and
      `git worktree add /outside main` (positional write targets); plus the
      existing redirect / write-command / glued-flag denials.
- [ ] Add a comment (not a passing assertion) documenting the accepted residual
      risks (spaced output flags; `tar -C` / `unzip -d` / `make -C`;
      `find ../outside -delete` / `-exec`) next to the glued-flag denial test.
- [ ] Update `docs/dev/architecture.md` (the `shell_containment` description
      around lines 178-186) to state reads outside are allowed and only writes
      are contained; note the `git -C` handling and the residual spaced-flag
      risks.
- [ ] Capture a knowledge entry (tags: `hooks`, `worktree-safety`, `gotcha`)
      recording the read/write contract, the in-place-editor and `git -C`
      promotions, and the residual spaced-flag risks.
- [ ] Run `./scripts/test.sh` and `./scripts/check.sh` (or `./scripts/check-all.sh`).

## Acceptance Criteria

- [ ] `shell_containment` **allows** reads outside the worktree in both plan and
      implementation mode: `cat ../crossby/x`, `grep -r foo ../crossby`,
      `rg foo ../crossby`, `ls ../crossby`, `git -C ../crossby log`,
      `cat ~/notes`, and `cat < /etc/passwd`.
- [ ] `shell_containment` **still denies** every existing write-escape case:
      output redirects outside (`printf x > /tmp/out`), `cd` outside, write
      commands outside (`cp a /tmp/b`, `tee /etc/p`, `git checkout -- ../main/x`),
      and glued output flags outside (`curl -o/tmp/pwn`, `sort --output=/tmp/pwn`,
      `dd of=/tmp/pwn`, `git -C/tmp/other init`).
- [ ] `git -C /outside clean -fd` and `git -C /outside checkout -- file` (spaced
      `-C` + git write subcommand) are **denied**, while `git -C ../crossby log`
      is **allowed**.
- [ ] `mkdir /outside/dir`, `git clone <url> /outside`, `git init /outside`, and
      `git worktree add /outside main` are **denied** (positional write targets
      outside the worktree).
- [ ] `sed -i '' s/a/b/ ../main/file` is denied in **implementation** mode (not
      only plan mode).
- [ ] Plan-mode behavior is unchanged for writes: non-artifact writes and
      in-place `-i` edits are still denied; artifact writes and reads are still
      allowed.
- [ ] The `deny_outside` message no longer claims reads must stay inside the
      worktree, and stays accurate when the glued-flag channel denies a read.
- [ ] The `shell_containment` docstring and `docs/dev/architecture.md` describe
      the read/write split, the `git -C` handling, and the residual spaced-flag
      risks at their real severity.
- [ ] `./scripts/test.sh` and `./scripts/check.sh` pass.

<!-- wade:plan:end -->

## Summary

## What was done

Relaxed `shell_containment` (`src/wade/hooks/policies.py`) so shell commands may
**read** paths outside the worktree (e.g. the sibling `crossby` package) while
every **write** channel stays contained. This fixes the false denial that blocked
legitimate reads like `cat ../crossby/x`, `grep -r foo ../crossby`, and
`git -C ../crossby log`. Applies to both plan and implementation sessions.

## Why these changes

The worktree guard exists to stop *writes* escaping the worktree, but its generic
path-argument rule (rule 4) contained **every** path-like operand — read or write.
Reading a sibling repo never mutates state, so those reads were denied for no
safety benefit (issue #372).

## Changes

- **Reads allowed outside; writes still contained** — the bare-operand check now
  runs only for *write* commands (`_PLAN_WRITE_COMMANDS`, git write subcommands,
  in-place editors). A read command's path operand is skipped.
- **Input redirects (`<`) allowed outside** — a `<` target is only read.
- **Closed the regressions the blanket rule-4 check was masking:**
  - In-place editors (`sed -i`, `perl -i`, …) now set write-containment in **both**
    plan and implementation mode (was plan-only) — `sed -i '' s/a/b/ ../main/file`
    stays denied in implementation mode.
  - Spaced `git -C <dir>` is buffered and denied only when a git **write**
    subcommand follows in the same segment (`git -C /outside clean -fd`,
    `git -C /outside checkout -- file`); `git -C ../crossby log` stays allowed.
  - Completed the write-command enumerations: `mkdir` → `_PLAN_WRITE_COMMANDS`;
    `clone`/`init`/`worktree` → `_GIT_WRITE_SUBCOMMANDS` (blocks the literal
    worktree escape `git worktree add /outside <branch>`).
- **Softened the `deny_outside` message** so it stays accurate for both the
  write-target and glued-flag channels (no longer claims reads must stay inside).
- **Docstring + `docs/dev/architecture.md`** updated for the read/write split, the
  `git -C` handling, and the residual spaced-flag risks.

## Key technical decisions

- **Breadth: broad, deliberate defense-in-depth.** The guard is explicitly *not* a
  security boundary (its docstring already lists `python -c`, `eval`, `$(...)`,
  env-var indirection as accepted escapes). It stops the write shapes an agent
  actually produces (`cp`/`mv`/`rm`/`mkdir`/redirects/`sed -i`/git write
  subcommands), not a determined adversary.
- **Glued flags stay contained in all modes** (`curl -o/tmp/x`, `git -C/tmp/other`)
  — a tokenizer can't tell a glued read flag from a glued write flag, so both are
  denied (this conservatively denies a few glued *reads* too).
- **Documented residual write-escapes rather than over-fixing.** The review
  surfaced that wrapped writers (`sudo rm`, `env cp`, `xargs rm`) and unenumerated
  writers (`zip`, `git bundle create`, `git format-patch -o`) also escape now.
  These are disclosed in the docstring/architecture "residual gaps" list at their
  real severity. Chasing them (e.g. unwrapping `sudo`, enumerating every writer)
  was rejected: it would give a false sense of completeness while other escapes
  remain, and a naive fallback would re-block the sibling-repo reads this change
  exists to allow.

## Testing

- Added `test_reads_outside_worktree_allowed` (both plan and implementation mode):
  `cat ../crossby/x.py`, `grep -r foo ../crossby`, `rg foo ../crossby`,
  `ls ../crossby`, `head ../sib/f`, `git -C ../crossby log`, `diff ../a ../b`,
  `cat ~/secrets`, `cat < /etc/passwd`.
- Added write-outside-still-denied regressions: `sed -i '' … ../main/file` (impl
  mode), `git -C /outside clean -fd`, `git -C /outside checkout -- file`,
  `mkdir /outside`, `git clone … /outside`, `git init /outside`,
  `git worktree add /outside main`.
- Documented the accepted residual risks in a comment next to the glued-flag test.
- `./scripts/test.sh` — 2565 passed, 1 xfailed. `./scripts/check.sh` — ruff,
  format, and strict mypy all pass.

## Notes for reviewers

The relaxation intentionally trades some incidental write-containment for the
reads it enables. The review flagged wrapped/unenumerated writers (`sudo rm`,
`zip`, `git bundle`) as newly escaping; this was a deliberate **document-not-fix**
decision (confirmed in-session) consistent with the guard's stated
"defense-in-depth, not a completeness guarantee" design — see the expanded
"Known residual gaps" list in the `shell_containment` docstring.

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **188,100** |
| Input tokens | **187,000** |
| Output tokens | **1,100** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `5c4121d7-c003-45d5-87e7-c6175b8aa97b` |

<!-- wade:sessions:end -->
