### PR TITLE
E1: Make `done` the authoritative completion gate (+ pre-push backstop, + realign Stop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,13 @@ enough to pick up improvements, with no re-init or migration.
 |-------|----------------|
 | Worktree containment | Writes that land outside your worktree |
 | Plan-artifact | During `wade plan`, writes to anything but plan artifacts |
-| Session completion | Finishing a session with `PR-SUMMARY.md` missing (nudges once) |
+| Session completion | Finishing a session with unfinished work not yet run through `done` (nudges once) |
+
+The session-completion guard keys on the same fact `done` records — a sha-keyed
+`.wade/done@<HEAD>` marker written when `done`'s gates pass — so it nudges only
+when the branch has commits ahead of its base **and** `done` has not finalized
+the current commit. An early "stopping to ask a question" turn (no commits ahead)
+never triggers it.
 
 Both write guards cover **shell commands** as well as file edits, so a redirect
 like `printf x > ../other-repo/app.py` is blocked, not just an `Edit` call. Shell
@@ -226,6 +232,28 @@ deliberate obfuscation (variable indirection, command substitution, subshells).
 The remaining supported tools (OpenCode, VS Code, Antigravity IDE) expose no hook
 mechanism WADE can install into, so they receive neither guard — session rules
 there rest on the skill files alone.
+
+### Completion gates
+
+`wade implementation-session done` (and `review-pr-comments-session done`) is the
+authoritative completion gate: it refuses to finalize until the work is actually
+ready, then writes the `.wade/done@<HEAD>` marker and pushes. Each gate has an
+escape hatch under a `done:` block in `.wade.yml` (all default on):
+
+| Gate | Refuses when… | Hatch |
+|------|---------------|-------|
+| PR-SUMMARY | `PR-SUMMARY.md` is missing, empty, or still a template placeholder (implementation only) | `done.require_pr_summary: false` |
+| Sync | the branch is behind main — auto-syncs first, refuses only on conflict (implementation only) | `done.require_sync: false` |
+| Review ran | `wade review implementation` did not run for the current commit | `--skip-review`, `done.require_review: false` (auto-off when `ai.review_implementation.enabled: false`) |
+| Resolved threads | unresolved PR review threads remain (review-comments only) | `done.require_resolved_threads: false` |
+
+A **pre-push git hook** (`done.pre_push_backstop`, default on) backs the gate up:
+a push of the session branch without a current `.wade/done@<sha>` marker is
+refused, so committing-and-pushing straight past `done` doesn't work. It is
+worktree-scoped (never touches your main checkout or sibling worktrees) and
+chains to any pre-existing `pre-push` hook. **Honesty:** `git push --no-verify`
+bypasses the backstop in one flag — this is a quality/backstop layer that makes
+the gate hard to skip, not an airtight boundary.
 
 ## Task Providers
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -127,7 +127,7 @@ src/wade/
 > `templates/hooks/pre-push` is the completion-gate backstop script installed
 > per-worktree at `.wade/githooks/pre-push` (see *Completion Gates & the
 > `done`-marker* below).
-
+>
 > **The `db/` package is unused scaffolding** — deliberately omitted from the
 > tree above. No code path under `services/` or `cli/` writes
 > session/worktree/PR rows, so its sole reader
@@ -270,13 +270,14 @@ it and runs in a **fixed order** (a clean main-merge in the sync step advances
 HEAD, so any sha-keyed check must precede it):
 
 1. **PR-SUMMARY** (implementation) — present, non-empty, non-placeholder.
-2. **review-ran** (both) — `marker_present(worktree, "reviewed", pre-sync HEAD)`.
+2. **unresolved-threads** (review-pr-comments only, runs *first* for that
+   session type) — a transient provider error is non-blocking.
+3. **review-ran** (both) — `marker_present(worktree, "reviewed", pre-sync HEAD)`.
    Checked against the pre-sync HEAD so a clean main-merge doesn't invalidate the
    review just performed.
-3. **sync** (implementation) — auto-sync via the existing `do_sync` service when
-   `behind > 0`, refuse only on conflict. Also runs the **unresolved-threads**
-   gate for review sessions (a transient provider error is non-blocking).
-4. `_done_via_pr` writes `.wade/done@<post-sync HEAD>` immediately before pushing.
+4. **sync** (implementation only) — auto-sync via the existing `do_sync` service
+   when `behind > 0`, refuse only on conflict.
+5. `_done_via_pr` writes `.wade/done@<post-sync HEAD>` immediately before pushing.
 
 The **done-marker primitive** lives in `utils/markers.py` — a pure-stdlib leaf
 (so the lean `wade-hook` can import it cheaply). A marker is a zero-byte file

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -119,9 +119,14 @@ src/wade/
     ├── markdown.py      # Plan file parsing
     ├── process.py       # Subprocess helpers
     ├── http.py          # HTTPClient for REST API providers
+    ├── markers.py       # sha-keyed .wade/<name>@<sha> completion markers (done, reviewed, stop-nudged)
     ├── update_check.py  # Version checking, self-upgrade hints
     └── install.py       # Self-upgrade helpers (venv/source detection, re-exec)
 ```
+
+> `templates/hooks/pre-push` is the completion-gate backstop script installed
+> per-worktree at `.wade/githooks/pre-push` (see *Completion Gates & the
+> `done`-marker* below).
 
 > **The `db/` package is unused scaffolding** — deliberately omitted from the
 > tree above. No code path under `services/` or `cli/` writes
@@ -166,11 +171,15 @@ trusting the agent to follow the skill. The split across the two repos:
 |-------|-------|--------------|--------|
 | `worktree` | PreToolUse | **closed** (deny) | Writes resolving outside the worktree |
 | `plan` | PreToolUse | **closed** (deny) | Writes to anything but plan artifacts |
-| `session-complete` | Stop | **open** (allow) | Ending a turn with `PR-SUMMARY.md` missing (once) |
+| `session-complete` | Stop | **open** (allow) | Ending a turn with commits ahead of base and no current `done` marker (once) |
 
 The asymmetry is deliberate and must not regress: a write guard that allows on
 error is worse than useless, while a Stop guard that blocks on error traps the
-agent in a session it cannot exit.
+agent in a session it cannot exit. `session-complete` (`hooks/policies.py`) is a
+pure predicate over `commits_ahead` + `done_marker_present`; the git facts are
+computed in `hooks/cli.py`'s Stop branch via **raw `subprocess`** (never the
+`wade.git` layer, whose `structlog` output would corrupt the lean entry's
+decision-JSON contract) and any failure fails open.
 
 ### Two write channels
 
@@ -252,6 +261,52 @@ So an existing inited project picks up corrected guards automatically on its
 next `wade implement` / `wade plan` session once wade (and transitively crossby)
 is upgraded — **no re-init, resync, or migration is needed.**
 
+## Completion Gates & the `done`-marker
+
+`done` (`implementation_service/done.py`) is the authoritative completion gate.
+Both `implementation-session done` and `review-pr-comments-session done` call the
+same `done()` service, parameterized by `session_type`; the gate set branches on
+it and runs in a **fixed order** (a clean main-merge in the sync step advances
+HEAD, so any sha-keyed check must precede it):
+
+1. **PR-SUMMARY** (implementation) — present, non-empty, non-placeholder.
+2. **review-ran** (both) — `marker_present(worktree, "reviewed", pre-sync HEAD)`.
+   Checked against the pre-sync HEAD so a clean main-merge doesn't invalidate the
+   review just performed.
+3. **sync** (implementation) — auto-sync via the existing `do_sync` service when
+   `behind > 0`, refuse only on conflict. Also runs the **unresolved-threads**
+   gate for review sessions (a transient provider error is non-blocking).
+4. `_done_via_pr` writes `.wade/done@<post-sync HEAD>` immediately before pushing.
+
+The **done-marker primitive** lives in `utils/markers.py` — a pure-stdlib leaf
+(so the lean `wade-hook` can import it cheaply). A marker is a zero-byte file
+`.wade/<name>@<sha>` meaning "the `<name>` gates passed for `<sha>`"; a new commit
+changes the sha and invalidates every prior marker (**missing/stale ⇒ not done**).
+All reads/writes go through an `O_DIRECTORY | O_NOFOLLOW` handle on `.wade` so a
+symlinked `.wade` can never redirect them — there is deliberately **no** path-based
+fallback (following the symlink is worse than not writing). The same module backs
+the single-shot `.wade/stop-nudged` flag (`flag_marker_*`), so the Stop-nudge and
+done-marker implementations can't drift.
+
+⚠ **`commits_ahead` argument order differs by call site** and is pinned by a test:
+the sync gate's behind-count is `commits_ahead(repo, origin/<main>, branch)`
+(base in the *branch* position); the Stop hook's ahead-count puts the session
+branch in the branch position. Inverting either is a silent bug.
+
+The **pre-push backstop** (`templates/hooks/pre-push`, installed by
+`skills/installer.py:install_worktree_git_hook`) makes the gate hard to skip: git
+runs it with cwd at the worktree top, so it tests `[[ -f ".wade/done@${sha}" ]]`
+in pure shell. It is wired per-worktree via `extensions.worktreeConfig` +
+`git config --worktree core.hooksPath .wade/githooks` (git ≥ 2.20; **graceful
+degrade** to warn-and-skip otherwise), so it never leaks to the main checkout or
+sibling worktrees. Because `core.hooksPath` *replaces* `.git/hooks`, the installer
+detects any pre-existing hook once at first install, persists it to
+`.wade/githooks/.chain`, and the wade hook **chains** to it (re-emitting the exact
+buffered stdin) rather than silently shadowing it. The reusable installer core is
+designed for #352 to add `pre-commit`/`commit-msg` hooks. **Honesty:**
+`git push --no-verify` bypasses it in one flag — a quality/backstop layer, not a
+boundary.
+
 ## Command Dispatch
 
 `src/wade/cli/main.py` is the root Typer application. It registers subcommand groups (`task`, `worktree`, `plan-session`, `implementation-session`, `review-pr-comments-session`, `review`) and admin commands (`init`, `update`, `deinit`, `check-config`, `shell-init`). The `tasks` alias is registered as a hidden Typer group pointing to the same `task_app`. The `wade` entry point (defined in `pyproject.toml` as `wade.cli.main:cli_main`) invokes the root app.
@@ -298,7 +353,20 @@ hooks:
 knowledge:
   enabled: true
   path: KNOWLEDGE.md
+done:                        # completion-gate toggles (all default true)
+  require_pr_summary: true
+  require_sync: true
+  require_review: true
+  require_resolved_threads: true
+  pre_push_backstop: true
 ```
+
+**`done` section** (`DoneConfig`): completion-gate escape hatches, all default
+on. Per knowledge `ca245d6a`, config-key validity lives in **three** places that
+can drift — the Pydantic model (`models/config.py`), the loader
+(`config/loader.py`), and the `check_service.py` validator. The `done` validator
+allowlist is **derived** from `DoneConfig.model_fields`, so a new field is
+accepted automatically.
 
 **Model complexity mapping**: The `models` section maps AI tool names to complexity-tiered model IDs (`easy`, `medium`, `complex`, `very_complex`). When `wade implement` is invoked, the service reads the `complexity:X` label from the issue (falling back to `## Complexity` in the body), maps it to the appropriate configured model, and passes it as `--model` to the AI tool — unless the user explicitly passed `--model` themselves.
 

--- a/src/wade/cli/implementation_session.py
+++ b/src/wade/cli/implementation_session.py
@@ -111,8 +111,11 @@ def done(
     plan: str | None = typer.Option(None, "--plan", help="Plan file to resolve worktree from."),
     no_close: bool = typer.Option(False, "--no-close", help="Don't close the issue on merge."),
     draft: bool = typer.Option(False, "--draft", help="Create PR as draft."),
+    skip_review: bool = typer.Option(
+        False, "--skip-review", help="Skip the review-ran completion gate."
+    ),
 ) -> None:
-    """Finalize implementation — push branch and create/update the PR."""
+    """Finalize implementation — run the completion gates, push, and update the PR."""
     from wade.services.implementation_service import done as do_done
 
     success = do_done(
@@ -120,25 +123,16 @@ def done(
         plan_file=Path(plan) if plan else None,
         no_close=no_close,
         draft=draft,
+        session_type="implementation",
+        skip_review=skip_review,
     )
     if success:
         from wade.cli.session_shared import DOC_PASS_ADVISORY
         from wade.ui.console import console
 
-        # Remind agent to review if reviews are enabled. Advisory only —
-        # must never turn a successful completion into a failure.
-        try:
-            from wade.config.loader import load_config
-
-            config = load_config()
-            if config.ai.review_implementation.enabled is not False:
-                console.warn(
-                    "Review not confirmed — run `wade review implementation` now "
-                    "if you haven't already, then present results to the user."
-                )
-        except Exception:  # Advisory — must never break a successful completion
-            pass
-
+        # The review-ran gate now enforces that `wade review implementation` ran
+        # for this sha before `done` succeeds, so the old post-done "review not
+        # confirmed" advisory is redundant (and would contradict the gate).
         console.warn(DOC_PASS_ADVISORY)
 
         console.info(

--- a/src/wade/cli/review_pr_comments_session.py
+++ b/src/wade/cli/review_pr_comments_session.py
@@ -62,8 +62,11 @@ def done(
     plan: str | None = typer.Option(None, "--plan", help="Plan file to resolve worktree from."),
     no_close: bool = typer.Option(False, "--no-close", help="Don't close the issue on merge."),
     draft: bool = typer.Option(False, "--draft", help="Create PR as draft."),
+    skip_review: bool = typer.Option(
+        False, "--skip-review", help="Skip the review-ran completion gate."
+    ),
 ) -> None:
-    """Finalize review — push branch and update PR."""
+    """Finalize review — run the completion gates, push, and update the PR."""
     from wade.services.implementation_service import done as do_done
 
     success = do_done(
@@ -71,6 +74,8 @@ def done(
         plan_file=Path(plan) if plan else None,
         no_close=no_close,
         draft=draft,
+        session_type="review-pr-comments",
+        skip_review=skip_review,
     )
     if success:
         from wade.cli.session_shared import DOC_PASS_ADVISORY

--- a/src/wade/config/loader.py
+++ b/src/wade/config/loader.py
@@ -259,14 +259,23 @@ def _build_config(raw: dict[str, Any], config_path: Path) -> ProjectConfig:
         path=knowledge_raw.get("path", "KNOWLEDGE.md"),
     )
 
-    # Parse done section (completion gates). All gates default on.
+    # Parse done section (completion gates). All gates default on. A key present
+    # but null (e.g. `require_sync:` with no value → None) is normalized to the
+    # default so DoneConfig's non-optional bool fields never receive None, which
+    # would raise a cryptic Pydantic error here. `wade check` still flags an
+    # explicit null as invalid via _validate_done_section.
     done_raw = _section_mapping(raw, "done")
+
+    def _done_flag(key: str) -> Any:
+        value = done_raw.get(key, True)
+        return True if value is None else value
+
     done = DoneConfig(
-        require_pr_summary=done_raw.get("require_pr_summary", True),
-        require_sync=done_raw.get("require_sync", True),
-        require_review=done_raw.get("require_review", True),
-        require_resolved_threads=done_raw.get("require_resolved_threads", True),
-        pre_push_backstop=done_raw.get("pre_push_backstop", True),
+        require_pr_summary=_done_flag("require_pr_summary"),
+        require_sync=_done_flag("require_sync"),
+        require_review=_done_flag("require_review"),
+        require_resolved_threads=_done_flag("require_resolved_threads"),
+        pre_push_backstop=_done_flag("pre_push_backstop"),
     )
 
     return ProjectConfig(

--- a/src/wade/config/loader.py
+++ b/src/wade/config/loader.py
@@ -14,6 +14,7 @@ from wade.models.config import (
     AICommandConfig,
     AIConfig,
     ComplexityModelMapping,
+    DoneConfig,
     HooksConfig,
     KnowledgeConfig,
     PermissionsConfig,
@@ -258,6 +259,16 @@ def _build_config(raw: dict[str, Any], config_path: Path) -> ProjectConfig:
         path=knowledge_raw.get("path", "KNOWLEDGE.md"),
     )
 
+    # Parse done section (completion gates). All gates default on.
+    done_raw = _section_mapping(raw, "done")
+    done = DoneConfig(
+        require_pr_summary=done_raw.get("require_pr_summary", True),
+        require_sync=done_raw.get("require_sync", True),
+        require_review=done_raw.get("require_review", True),
+        require_resolved_threads=done_raw.get("require_resolved_threads", True),
+        pre_push_backstop=done_raw.get("pre_push_backstop", True),
+    )
+
     return ProjectConfig(
         version=version,
         project=project,
@@ -267,6 +278,7 @@ def _build_config(raw: dict[str, Any], config_path: Path) -> ProjectConfig:
         permissions=permissions,
         hooks=hooks,
         knowledge=knowledge,
+        done=done,
         config_path=str(config_path),
         project_root=str(config_path.parent),
     )

--- a/src/wade/git/repo.py
+++ b/src/wade/git/repo.py
@@ -678,3 +678,19 @@ def set_config_value(path: Path, key: str, value: str, *, worktree: bool = False
     args.extend([key, value])
     result = _run_git(*args, cwd=path, check=False)
     return result.returncode == 0
+
+
+def unset_config_value(path: Path, key: str, *, worktree: bool = False) -> bool:
+    """Unset a git config value (``git config --unset``); return success.
+
+    With ``worktree=True`` targets the ``--worktree`` scope. Never raises —
+    returns False on any failure (including the key already being absent, which
+    git reports as exit code 5), so callers can best-effort roll back an optional
+    config change without extra guarding.
+    """
+    args = ["config"]
+    if worktree:
+        args.append("--worktree")
+    args.extend(["--unset", key])
+    result = _run_git(*args, cwd=path, check=False)
+    return result.returncode == 0

--- a/src/wade/git/repo.py
+++ b/src/wade/git/repo.py
@@ -632,3 +632,49 @@ def upstream_tracking_status(repo_root: Path, branch: str) -> str | None:
     )
     status = result.stdout.strip()
     return status if status else None
+
+
+def get_git_common_dir(path: Path) -> str | None:
+    """Return the *common* git directory for *path*, or None on failure.
+
+    Unlike :func:`get_git_dir` (which in a linked worktree returns that
+    worktree's private git dir), this returns the shared common dir — the main
+    repo's ``.git`` — where common hooks live (``<common-dir>/hooks``). The
+    result may be relative to *path*; callers resolve it against the worktree.
+    """
+    result = _run_git("rev-parse", "--git-common-dir", cwd=path, check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def get_config_value(path: Path, key: str, *, worktree: bool = False) -> str | None:
+    """Return a git config value, or None if unset/unreadable.
+
+    With ``worktree=True`` reads the ``--worktree`` scope, which requires
+    ``extensions.worktreeConfig`` to be enabled — when it is not, git errors and
+    this returns None (treated as "unset").
+    """
+    args = ["config"]
+    if worktree:
+        args.append("--worktree")
+    args.extend(["--get", key])
+    result = _run_git(*args, cwd=path, check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def set_config_value(path: Path, key: str, value: str, *, worktree: bool = False) -> bool:
+    """Set a git config value; return whether it succeeded.
+
+    With ``worktree=True`` writes the ``--worktree`` scope (requires
+    ``extensions.worktreeConfig``). Never raises — returns False on any failure
+    so callers can gracefully skip an optional feature on old/locked-down git.
+    """
+    args = ["config"]
+    if worktree:
+        args.append("--worktree")
+    args.extend([key, value])
+    result = _run_git(*args, cwd=path, check=False)
+    return result.returncode == 0

--- a/src/wade/hooks/cli.py
+++ b/src/wade/hooks/cli.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -44,9 +43,9 @@ from wade.hooks.policies import (
     plan_artifact_only,
     session_complete,
     shell_containment,
-    stop_nudge_marker_path,
     worktree_containment,
 )
+from wade.utils import markers
 
 # Static ``tool id -> output dialect`` map, mirroring each crossby adapter's
 # ``capabilities().hook_output_dialect``. Inlined so the hot per-edit path never
@@ -154,35 +153,100 @@ def _is_stop_event(event: str, ev: object) -> bool:
 def _mark_stop_nudged(worktree_root: Path) -> None:
     """Write the single-shot Stop marker; best-effort and race-safe against symlinks.
 
-    Opens ``.wade`` itself with ``O_DIRECTORY | O_NOFOLLOW`` and creates the
-    marker *relative to that directory handle*, so a repo-controlled symlink
-    swapped in for ``.wade`` can neither redirect the write outside the worktree
-    nor slip through a TOCTOU window between checking and creating (the parent
-    handle is the trusted anchor). A failed or unsupported write is harmless — we
-    simply nudge again next time.
+    Delegates to :func:`wade.utils.markers.write_flag_marker`, which creates the
+    marker relative to an ``O_DIRECTORY | O_NOFOLLOW`` handle on ``.wade`` so a
+    repo-controlled symlink swapped in for ``.wade`` can neither redirect the
+    write outside the worktree nor slip through a TOCTOU window. A failed or
+    unsupported write is harmless — we simply nudge again next time.
     """
-    if not (hasattr(os, "O_DIRECTORY") and os.open in os.supports_dir_fd):
-        return  # no atomic no-follow path available; skip rather than risk a follow
-    marker = stop_nudge_marker_path(worktree_root)
+    markers.write_flag_marker(worktree_root, "stop-nudged")
+
+
+def _git_out(root: Path, *args: str) -> str | None:
+    """Run a read-only ``git`` command in ``root``; return stripped stdout or None.
+
+    Deliberately a raw ``subprocess`` call rather than the ``wade.git`` layer: it
+    runs on the Stop path and must stay cheap and dependency-light. Any failure
+    (non-zero exit, missing git, timeout) returns ``None`` so the caller can fail
+    open.
+    """
+    import subprocess
+
     try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        return
-    dir_fd = None
-    try:
-        dir_fd = os.open(marker.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
-        fd = os.open(
-            marker.name,
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
-            0o600,
-            dir_fd=dir_fd,
+        proc = subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
         )
-        os.close(fd)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def _resolve_stop_base_ref(root: Path) -> str | None:
+    """Resolve the base ref the session branch is measured against, or None.
+
+    Honors a stacked ``.wade/base_branch`` when present; otherwise detects
+    ``main``/``master`` (preferring the ``origin/`` remote-tracking ref). Returns
+    ``None`` when nothing resolves so the caller fails open.
+    """
+    base_name: str | None = None
+    base_file = root / ".wade" / "base_branch"
+    try:
+        if base_file.is_file():
+            content = base_file.read_text(encoding="utf-8").strip()
+            if content:
+                base_name = content
     except OSError:
-        pass  # a failed write just means we nudge again next time — still safe
-    finally:
-        if dir_fd is not None:
-            os.close(dir_fd)
+        base_name = None
+
+    if base_name:
+        candidates = [f"origin/{base_name}", base_name]
+    else:
+        candidates = ["origin/main", "origin/master", "main", "master"]
+
+    for ref in candidates:
+        if ref and _git_out(root, "rev-parse", "--verify", "--quiet", ref) is not None:
+            return ref
+    return None
+
+
+def _stop_git_facts(root: Path) -> tuple[int, bool]:
+    """Compute ``(commits_ahead_of_base, done_marker_present)`` for the Stop guard.
+
+    All git calls go through :func:`_git_out` (raw ``subprocess``), NOT the
+    ``wade.git`` layer: this runs in the lean entry point, which deliberately
+    leaves ``structlog`` unconfigured, so a ``wade.git`` call's ``git.run`` debug
+    line would print to stdout and corrupt the decision-JSON contract.
+
+    ⚠ The ahead-count is ``git rev-list --count <base>..HEAD`` — commits on the
+    session branch (HEAD) not on base — equivalent to
+    ``commits_ahead(root, branch, base)`` with the **session branch in the branch
+    position**. That is the *opposite* role assignment from the sync gate's
+    behind-count (:func:`wade.services.implementation_service.done._behind_count`),
+    which passes ``origin/<main>`` in the branch position. The ``done`` marker is
+    checked against the current HEAD sha.
+
+    Raises on any failure (detached HEAD, unresolvable base, git error) so the
+    Stop branch can fail open — a Stop guard must never trap the agent.
+    """
+    head = _git_out(root, "rev-parse", "HEAD")
+    if head is None:
+        raise RuntimeError("cannot resolve HEAD")
+    if _git_out(root, "symbolic-ref", "-q", "HEAD") is None:
+        raise RuntimeError("detached HEAD")  # no session branch to finalize
+    base_ref = _resolve_stop_base_ref(root)
+    if base_ref is None:
+        raise RuntimeError("cannot resolve base ref")
+    count = _git_out(root, "rev-list", "--count", f"{base_ref}..HEAD")
+    if count is None:
+        raise RuntimeError("cannot count commits")
+    done_present = markers.marker_present(root, "done", head)
+    return int(count), done_present
 
 
 def _run(event: str, guard: str, tool: str, root: str) -> HookEmission:
@@ -238,7 +302,17 @@ def _run(event: str, guard: str, tool: str, root: str) -> HookEmission:
             # trap the agent, which a Stop guard must never do.
             return emit_stop_decision(False, "", stop_dialect)
         try:
-            decision = session_complete(ev, worktree_root=Path(root))
+            # Git facts feed the predicate: nudge only when the branch has
+            # authored work (commits ahead of base) and no current done marker.
+            # Computed here (lazy subprocess) to keep the predicate pure; any
+            # failure raises and falls through to the fail-open handler below.
+            commits_ahead, done_present = _stop_git_facts(Path(root))
+            decision = session_complete(
+                ev,
+                worktree_root=Path(root),
+                commits_ahead=commits_ahead,
+                done_marker_present=done_present,
+            )
             should_block = decision.action == "deny"
             reason = decision.reason
             if should_block:

--- a/src/wade/hooks/policies.py
+++ b/src/wade/hooks/policies.py
@@ -26,10 +26,11 @@ import os
 import posixpath
 import re
 import shlex
-import stat as stat_module
 from pathlib import Path
 
 from crossby.hooks.runtime import HookDecision, HookEvent
+
+from wade.utils import markers
 
 __all__ = [
     "GUARD_NAMES",
@@ -44,48 +45,33 @@ __all__ = [
 # are PreToolUse write guards; ``session-complete`` is a Stop guard.
 GUARD_NAMES = ("worktree", "plan", "session-complete")
 
-# Relative path of the marker that records the Stop guard already nudged this
-# worktree. Lives under ``.wade/`` (gitignored per-session). The read side lives
-# in :func:`session_complete`; the ``wade-hook`` CLI writes it after a block so
-# the nudge is single-shot for *every* tool — not only Claude, which is the only
-# tool that sends ``stop_hook_active``.
-_STOP_NUDGE_MARKER = ".wade/stop-nudged"
+# Name of the single-shot flag marker (under ``.wade/``, gitignored per-session)
+# that records the Stop guard already nudged this worktree. Unlike the sha-keyed
+# ``done`` marker it is a plain single-shot flag, so it rides the generic
+# ``flag_marker_*`` primitives in :mod:`wade.utils.markers` — sharing the
+# race-safe dir-fd handling so the two implementations cannot drift. The read
+# side lives in :func:`session_complete`; the ``wade-hook`` CLI writes it after a
+# block so the nudge is single-shot for *every* tool — not only Claude, which is
+# the only tool that sends ``stop_hook_active``.
+_STOP_NUDGE_NAME = "stop-nudged"
 
 
 def stop_nudge_marker_path(worktree_root: Path) -> Path:
     """Absolute path of the Stop-guard single-shot marker for ``worktree_root``."""
-    return worktree_root / _STOP_NUDGE_MARKER
-
-
-def _dir_fd_supported() -> bool:
-    """True when the platform can open a no-follow dir handle for ``*at`` calls."""
-    return hasattr(os, "O_DIRECTORY") and os.stat in os.supports_dir_fd
+    return markers.flag_marker_path(worktree_root, _STOP_NUDGE_NAME)
 
 
 def stop_nudge_present(worktree_root: Path) -> bool:
     """True if a *trusted* single-shot marker exists — race-safe against symlinks.
 
-    Opens ``.wade`` itself with ``O_DIRECTORY | O_NOFOLLOW`` (so a symlinked
-    ``.wade`` fails outright) and stats the marker relative to that directory
-    handle without following symlinks. Using a handle rather than re-resolving
-    the path closes the TOCTOU window where ``.wade`` is swapped for a symlink
-    between the check and the read. On platforms without ``dir_fd`` support the
-    marker is ignored (treated as absent) rather than followed unsafely — a
-    missed marker only costs one extra nudge, which is harmless.
+    Delegates to :func:`wade.utils.markers.flag_marker_present`, which opens
+    ``.wade`` with ``O_DIRECTORY | O_NOFOLLOW`` and stats the marker relative to
+    that handle without following symlinks (a symlinked ``.wade`` fails
+    outright). On platforms without ``dir_fd`` support the marker is treated as
+    absent rather than followed unsafely — a missed marker only costs one extra
+    nudge, which is harmless.
     """
-    if not _dir_fd_supported():
-        return False
-    marker = stop_nudge_marker_path(worktree_root)
-    dir_fd = None
-    try:
-        dir_fd = os.open(marker.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
-        st = os.stat(marker.name, dir_fd=dir_fd, follow_symlinks=False)
-    except OSError:
-        return False
-    finally:
-        if dir_fd is not None:
-            os.close(dir_fd)
-    return stat_module.S_ISREG(st.st_mode)
+    return markers.flag_marker_present(worktree_root, _STOP_NUDGE_NAME)
 
 
 # Plan-session artifacts an agent may write while planning (basenames + globs).
@@ -718,22 +704,40 @@ def _is_plan_artifact_path(resolved: Path, root: Path) -> bool:
     return _is_plan_artifact(relative.as_posix())
 
 
-def session_complete(event: HookEvent, *, worktree_root: Path) -> HookDecision:
-    """Stop-hook guard: nudge (once) if the session's closing artifacts are absent.
+def session_complete(
+    event: HookEvent,
+    *,
+    worktree_root: Path,
+    commits_ahead: int = 0,
+    done_marker_present: bool = False,
+) -> HookDecision:
+    """Stop-hook guard: nudge (once) to finalize via ``done`` when work is unfinished.
 
     Returns a ``deny`` decision — which the Stop path renders as *block the stop
-    and feed the reason back* — when ``PR-SUMMARY.md`` is missing from the
-    worktree, so the workflow's closing steps are enforced rather than merely
-    requested by the skill. Otherwise allow.
+    and feed the reason back* — when the branch has commits ahead of its base yet
+    no current ``done`` marker exists, so the workflow's closing step (running
+    ``done``) is enforced rather than merely requested by the skill. Otherwise
+    allow.
 
-    **Single-shot** (never loop the session), via two independent signals:
+    Keyed on the **same completion fact** the ``done`` command writes — the
+    sha-keyed ``.wade/done@<HEAD>`` marker — so there is no split-brain between
+    "did the closing artifact exist" (the old PR-SUMMARY check) and "did the
+    session actually finalize". The git facts (``commits_ahead`` /
+    ``done_marker_present``) are computed by the ``wade-hook`` CLI and passed in,
+    keeping this predicate pure and off the hot per-edit import path.
+
+    Allow conditions, in order:
 
     - ``event.stop_hook_active`` — Claude sets this once its Stop hook has fired
-      and blocked; other tools do not send it.
-    - the ``.wade/stop-nudged`` marker (see :func:`stop_nudge_marker_path`) — the
-      ``wade-hook`` CLI writes it after this guard blocks, so the second Stop is
-      allowed on *any* tool, not just Claude. This predicate only *reads* the
-      marker; the CLI owns the write (keeping this a side-effect-free decision).
+      and blocked; other tools do not send it. Prevents looping.
+    - ``commits_ahead == 0`` — no authored work to finalize (adopts #318's
+      higher-signal condition, so an early "stopping to ask a question" turn does
+      not trigger the nudge).
+    - ``done_marker_present`` — the session was already finalized via ``done``.
+    - the ``.wade/stop-nudged`` single-shot marker — the ``wade-hook`` CLI writes
+      it after this guard blocks, so the second Stop is allowed on *any* tool,
+      not just Claude. This predicate only *reads* the marker; the CLI owns the
+      write (keeping this a side-effect-free decision).
 
     The message is deliberately ignorable so a legitimate pause (e.g. stopping to
     ask the user a question) costs at most one gentle nudge.
@@ -744,16 +748,18 @@ def session_complete(event: HookEvent, *, worktree_root: Path) -> HookDecision:
     if event.stop_hook_active:
         return HookDecision.allow()
 
-    if (worktree_root / "PR-SUMMARY.md").is_file():
-        return HookDecision.allow()
+    if commits_ahead == 0:
+        return HookDecision.allow()  # no work to finalize (#318 signal)
+
+    if done_marker_present:
+        return HookDecision.allow()  # completed via done
 
     if stop_nudge_present(worktree_root):
         return HookDecision.allow()  # already nudged once this worktree
 
     return HookDecision.deny(
-        "Before finishing: PR-SUMMARY.md is not present in the worktree. If your work "
-        "is complete, write PR-SUMMARY.md and run the session's `done` command "
-        "(`wade implementation-session done` or `wade review-pr-comments-session done`) "
-        "to sync, push, and open/update the PR. If you are pausing to ask a question "
-        "or are still mid-task, disregard this and continue."
+        "Before finishing: run `wade implementation-session done` (or "
+        "`wade review-pr-comments-session done`) to sync, push, and finalize the "
+        "PR. If you are pausing to ask a question or are still mid-task, disregard "
+        "this and continue."
     )

--- a/src/wade/models/config.py
+++ b/src/wade/models/config.py
@@ -156,6 +156,32 @@ class HooksConfig(BaseModel):
     copy_to_worktree: list[str] = []
 
 
+class DoneConfig(BaseModel):
+    """Completion-gate toggles for the session ``done`` command (#349).
+
+    Every gate defaults **on** — enforcing a complete workflow is the point of
+    the ``done`` gate. Each field is an escape hatch a project can flip off in
+    ``.wade.yml`` when a gate does not fit its flow:
+
+    - ``require_pr_summary`` — refuse when ``PR-SUMMARY.md`` is missing, empty, or
+      still a template placeholder (implementation sessions).
+    - ``require_sync`` — auto-sync a branch behind main, refuse only on conflict
+      (implementation sessions).
+    - ``require_review`` — refuse unless ``wade review implementation`` ran for
+      the current sha (both session types).
+    - ``require_resolved_threads`` — refuse on unresolved PR review threads
+      (review-pr-comments sessions).
+    - ``pre_push_backstop`` — install the per-worktree pre-push git hook that
+      refuses a push lacking a current ``.wade/done@<sha>`` marker.
+    """
+
+    require_pr_summary: bool = True
+    require_sync: bool = True
+    require_review: bool = True
+    require_resolved_threads: bool = True
+    pre_push_backstop: bool = True
+
+
 class ProjectSettings(BaseModel):
     """Core project settings section."""
 
@@ -182,6 +208,7 @@ class ProjectConfig(BaseModel):
     permissions: PermissionsConfig = PermissionsConfig()
     hooks: HooksConfig = HooksConfig()
     knowledge: KnowledgeConfig = KnowledgeConfig()
+    done: DoneConfig = DoneConfig()
 
     # Resolved values (set after loading, not in YAML)
     config_path: str | None = Field(default=None, exclude=True)

--- a/src/wade/services/check_service.py
+++ b/src/wade/services/check_service.py
@@ -23,6 +23,7 @@ from wade.models.config import (
     LEGACY_AI_COMMAND_ALIASES,
     AICommandConfig,
     AIConfig,
+    DoneConfig,
     ProjectConfig,
 )
 from wade.models.delegation import DelegationMode
@@ -259,6 +260,11 @@ _VALID_AI_TOP_LEVEL_KEYS = frozenset(
     {*_VALID_AI_SCALAR_KEYS, *AI_COMMAND_NAMES, *LEGACY_AI_COMMAND_ALIASES}
 )
 
+# Valid keys for the ``done`` section, derived from the Pydantic model so the
+# validator can't drift from the schema (per knowledge ca245d6a — config-key
+# validity lives in three places; deriving keeps them in sync automatically).
+_VALID_DONE_KEYS = frozenset(DoneConfig.model_fields)
+
 
 def validate_config(cwd: Path | None = None) -> ConfigCheckResult:
     """Validate the project's .wade.yml config.
@@ -379,6 +385,14 @@ def _validate_config_file(config_path: Path) -> list[str]:
         else:
             _validate_knowledge_section(knowledge, config_path, errors)
 
+    # Validate done section
+    done = raw.get("done")
+    if done is not None:
+        if not isinstance(done, dict):
+            errors.append("done: must be a mapping")
+        else:
+            _validate_done_section(done, errors)
+
     # Check for unsupported top-level keys
     supported_keys = {
         "version",
@@ -389,6 +403,7 @@ def _validate_config_file(config_path: Path) -> list[str]:
         "permissions",
         "hooks",
         "knowledge",
+        "done",
     }
     for key in raw:
         if key not in supported_keys:
@@ -637,3 +652,15 @@ def _validate_knowledge_section(
     for key in knowledge:
         if key not in valid_keys:
             errors.append(f"knowledge.{key}: unsupported key")
+
+
+def _validate_done_section(done: dict[str, Any], errors: list[str]) -> None:
+    """Validate the ``done`` completion-gate section (all fields are booleans)."""
+    for key, value in done.items():
+        if key not in _VALID_DONE_KEYS:
+            errors.append(
+                f"done.{key}: unsupported key. "
+                f"Supported keys: {', '.join(sorted(_VALID_DONE_KEYS))}"
+            )
+        elif value is not None and not isinstance(value, bool):
+            errors.append(f"done.{key}: must be true or false")

--- a/src/wade/services/check_service.py
+++ b/src/wade/services/check_service.py
@@ -655,12 +655,18 @@ def _validate_knowledge_section(
 
 
 def _validate_done_section(done: dict[str, Any], errors: list[str]) -> None:
-    """Validate the ``done`` completion-gate section (all fields are booleans)."""
+    """Validate the ``done`` completion-gate section (all fields are booleans).
+
+    Iterating ``done.items()`` only sees keys the user explicitly wrote, so an
+    explicit null (``require_sync:`` with no value) is a user mistake, not an
+    "unset" default — reject it. This keeps `wade check` aligned with the loader,
+    which normalizes such a null to the documented default rather than crashing.
+    """
     for key, value in done.items():
         if key not in _VALID_DONE_KEYS:
             errors.append(
                 f"done.{key}: unsupported key. "
                 f"Supported keys: {', '.join(sorted(_VALID_DONE_KEYS))}"
             )
-        elif value is not None and not isinstance(value, bool):
+        elif not isinstance(value, bool):
             errors.append(f"done.{key}: must be true or false")

--- a/src/wade/services/implementation_service/bootstrap.py
+++ b/src/wade/services/implementation_service/bootstrap.py
@@ -313,8 +313,9 @@ def _install_guard_hooks(
 def _install_stop_hook(worktree_path: Path) -> None:
     """Install a Stop-hook workflow-completion reminder into each capable tool.
 
-    On session Stop, ``wade hook stop --guard session-complete`` nudges (once) if
-    ``PR-SUMMARY.md`` is missing — enforcing the closing steps rather than relying
+    On session Stop, ``wade hook stop --guard session-complete`` nudges (once)
+    when the session branch has commits ahead of its base and no current
+    ``.wade/done@<HEAD>`` marker — enforcing the closing steps rather than relying
     on the skill checklist. Installed only for tools that fire a blocking Stop
     hook (``supports_stop_hook``), which as of crossby 0.13 is every tool wade
     drives: Copilot joined once its ``agentStop`` event and blocking

--- a/src/wade/services/implementation_service/bootstrap.py
+++ b/src/wade/services/implementation_service/bootstrap.py
@@ -660,9 +660,26 @@ def bootstrap_worktree(
     _install_guard_hooks(worktree_path, guard_type="plan" if plan_mode else "worktree")
 
     # Implement/review sessions (not plan) also get a Stop-hook completion
-    # reminder that enforces writing PR-SUMMARY.md + running `done` before exit.
+    # reminder that nudges the agent to run `done` before exit.
     if not plan_mode:
         _install_stop_hook(worktree_path)
+
+        # ...and the pre-push backstop that makes the `done` gate hard to skip:
+        # a push without a current `.wade/done@<sha>` marker is refused. Optional
+        # (gated on config, graceful-degrades on old git) — must never crash
+        # bootstrap, so any failure is swallowed to a warning.
+        if config.done.pre_push_backstop:
+            from wade.skills.installer import install_pre_push_backstop
+
+            try:
+                if not install_pre_push_backstop(worktree_path):
+                    logger.info("implementation.pre_push_backstop_skipped", path=str(worktree_path))
+            except Exception:
+                logger.warning(
+                    "implementation.pre_push_backstop_error",
+                    path=str(worktree_path),
+                    exc_info=True,
+                )
 
     # Write worktree gitignore block AFTER all file generation so the entry
     # list is complete (skills, hooks, settings, pointer are all in place).

--- a/src/wade/services/implementation_service/done.py
+++ b/src/wade/services/implementation_service/done.py
@@ -237,10 +237,14 @@ def done(
     # The review-ran gate checks the sha the agent actually reviewed — the
     # PRE-SYNC HEAD. Capturing it before the (impl-only) auto-sync means a clean
     # main-merge does not spuriously invalidate the review just performed.
+    # Resolve ``branch`` (not ``cwd``'s HEAD), matching ``_write_done_marker``: a
+    # ``done <target>`` run from the main checkout leaves ``cwd`` there, where
+    # HEAD is not the branch tip — resolving the branch ref keeps both shas
+    # consistent so the gate compares against the same commit the marker keys to.
     try:
-        pre_sync_head = git_repo.rev_parse(cwd, "HEAD")
+        pre_sync_head = git_repo.rev_parse(cwd, branch)
     except GitError:
-        console.error("Cannot resolve HEAD to run the completion gates.")
+        console.error("Cannot resolve the branch tip to run the completion gates.")
         return False
 
     if not _run_completion_gates(

--- a/src/wade/services/implementation_service/done.py
+++ b/src/wade/services/implementation_service/done.py
@@ -14,6 +14,7 @@ from wade.git import repo as git_repo
 from wade.git import sync as git_sync
 from wade.git.repo import GitError
 from wade.models.config import ProjectConfig
+from wade.providers.base import AbstractTaskProvider
 from wade.providers.registry import get_provider
 from wade.services.implementation_service._shared import (
     extract_issue_from_branch,
@@ -38,6 +39,7 @@ from wade.services.implementation_service.usage_tracking import IMPL_USAGE_MARKE
 from wade.services.task_service import remove_in_progress_label
 from wade.ui import prompts
 from wade.ui.console import console
+from wade.utils import markers
 from wade.utils.body_markers import build_marked_block, update_body_preserving_markers
 from wade.utils.markdown import remove_marker_block
 
@@ -48,6 +50,10 @@ __all__ = [
     "done",
 ]
 
+# Placeholder sentinels from templates/skills/.../reference/pr-summary-format.md.
+# Their presence means the file is still the template stub, not a real summary.
+_PR_SUMMARY_PLACEHOLDERS = ("[high-level summary", "[optional:")
+
 
 def done(
     target: str | None = None,
@@ -55,12 +61,26 @@ def done(
     no_close: bool = False,
     draft: bool = False,
     project_root: Path | None = None,
+    *,
+    session_type: str = "implementation",
+    skip_review: bool = False,
 ) -> bool:
-    """Complete implementation session — push the branch and finalize the PR.
+    """Complete a session — run the completion gates, push, and finalize the PR.
 
-    Detects the current branch, extracts the issue number, and delegates to
-    ``_done_via_pr`` (PR is the only merge strategy since #357 retired
-    ``direct``).
+    Detects the current branch, extracts the issue number, runs the completion
+    gates (parameterized by ``session_type``), and delegates to ``_done_via_pr``
+    (PR is the only merge strategy since #357 retired ``direct``).
+
+    Both ``implementation-session done`` and ``review-pr-comments-session done``
+    call this same service, so the gate set branches on ``session_type``:
+
+    - ``"implementation"`` — PR-SUMMARY, review-ran (vs pre-sync HEAD), then
+      auto-sync (may advance HEAD).
+    - ``"review-pr-comments"`` — unresolved review threads, then review-ran.
+
+    After all gates pass, ``_done_via_pr`` writes ``.wade/done@<post-sync HEAD>``
+    immediately before pushing, so ``done``'s own push satisfies the pre-push
+    backstop and the Stop hook sees the session as finalized.
 
     Args:
         target: Optional issue number, worktree name, or plan file.
@@ -68,6 +88,9 @@ def done(
         no_close: Don't close the issue on merge.
         draft: Create PR as draft.
         project_root: Repository root.
+        session_type: ``"implementation"`` or ``"review-pr-comments"`` — selects
+            the gate set.
+        skip_review: Escape hatch for the review-ran gate (``--skip-review``).
     """
     config = load_config(project_root)
     provider = get_provider(config)
@@ -207,6 +230,32 @@ def done(
             if stored_base and git_branch.branch_exists(repo_root, stored_base):
                 main_branch = stored_base
 
+    # Completion gates run AFTER the clean + tracked-managed gates and BEFORE
+    # finalize. The worktree root is where PR-SUMMARY.md and .wade/ markers live.
+    worktree_root = wt_path or cwd
+
+    # The review-ran gate checks the sha the agent actually reviewed — the
+    # PRE-SYNC HEAD. Capturing it before the (impl-only) auto-sync means a clean
+    # main-merge does not spuriously invalidate the review just performed.
+    try:
+        pre_sync_head = git_repo.rev_parse(cwd, "HEAD")
+    except GitError:
+        console.error("Cannot resolve HEAD to run the completion gates.")
+        return False
+
+    if not _run_completion_gates(
+        session_type=session_type,
+        config=config,
+        provider=provider,
+        repo_root=repo_root,
+        worktree_root=worktree_root,
+        branch=branch,
+        main_branch=main_branch,
+        pre_sync_head=pre_sync_head,
+        skip_review=skip_review,
+    ):
+        return False
+
     console.rule(f"done #{issue_number}")
 
     ok = _done_via_pr(
@@ -237,6 +286,231 @@ def done(
         console.hint("Remove the `# wade:worktree:start` block from .gitignore manually.")
         logger.warning("implementation.gitignore_strip_failed", error=str(e), exc_info=True)
 
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Completion gates (#349) — parameterized by session type
+# ---------------------------------------------------------------------------
+
+
+def _run_completion_gates(
+    *,
+    session_type: str,
+    config: ProjectConfig,
+    provider: AbstractTaskProvider,
+    repo_root: Path,
+    worktree_root: Path,
+    branch: str,
+    main_branch: str,
+    pre_sync_head: str,
+    skip_review: bool,
+) -> bool:
+    """Run the gate set for ``session_type`` in the fixed order. True ⇒ proceed.
+
+    Order matters: auto-sync (implementation only) can advance HEAD via a merge
+    commit, so the review-ran gate — which is keyed to the sha the agent actually
+    reviewed — runs against the **pre-sync HEAD**, before sync. A clean,
+    zero-conflict merge of main is therefore accepted without a fresh review (a
+    main-merge is not new authored work).
+    """
+    if session_type == "review-pr-comments":
+        if not _gate_resolved_threads(config, provider, repo_root, branch):
+            return False
+        return _gate_review_ran(config, worktree_root, pre_sync_head, skip_review)
+
+    # Default: implementation session.
+    if not _gate_pr_summary(config, worktree_root):
+        return False
+    if not _gate_review_ran(config, worktree_root, pre_sync_head, skip_review):
+        return False
+    return _gate_sync(config, repo_root, worktree_root, branch, main_branch, session_type)
+
+
+def _is_placeholder_pr_summary(text: str) -> bool:
+    """True when PR-SUMMARY.md is empty, headings-only, or still a template stub."""
+    stripped = text.strip()
+    if not stripped:
+        return True
+    lowered = stripped.lower()
+    if any(ph in lowered for ph in _PR_SUMMARY_PLACEHOLDERS):
+        return True
+    # Drop heading lines (``## …``), horizontal rules (``---``), and blanks — if
+    # nothing substantive remains, it is a headings-only stub, not a real summary.
+    substantive = [
+        line
+        for line in stripped.splitlines()
+        if line.strip() and not line.lstrip().startswith("#") and set(line.strip()) != {"-"}
+    ]
+    return not substantive
+
+
+def _gate_pr_summary(config: ProjectConfig, worktree_root: Path) -> bool:
+    """Refuse when PR-SUMMARY.md is missing, empty, or a template placeholder."""
+    if not config.done.require_pr_summary:
+        return True
+    path = worktree_root / "PR-SUMMARY.md"
+    if not path.is_file():
+        console.error("PR-SUMMARY.md is missing — the PR would have no description.")
+        console.hint("Write PR-SUMMARY.md in the worktree root, then re-run done.")
+        console.hint("Bypass: set `done.require_pr_summary: false` in .wade.yml.")
+        return False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        console.error(f"Could not read PR-SUMMARY.md: {exc}")
+        return False
+    if _is_placeholder_pr_summary(text):
+        console.error("PR-SUMMARY.md is empty or still contains template placeholders.")
+        console.hint("Replace the placeholder text with a real summary of your changes.")
+        console.hint("Bypass: set `done.require_pr_summary: false` in .wade.yml.")
+        return False
+    return True
+
+
+def _gate_review_ran(
+    config: ProjectConfig,
+    worktree_root: Path,
+    head_sha: str,
+    skip_review: bool,
+) -> bool:
+    """Refuse unless ``wade review implementation`` ran for ``head_sha``.
+
+    Auto-skipped when reviews are disabled (``review_implementation.enabled:
+    false``) — the marker is not written then either. Hatches: ``--skip-review``
+    and ``done.require_review: false``.
+    """
+    if config.ai.review_implementation.enabled is False:
+        return True  # reviews disabled project-wide → gate off (no marker written)
+    if skip_review or not config.done.require_review:
+        return True
+    if markers.marker_present(worktree_root, "reviewed", head_sha):
+        return True
+    console.error("Review has not run for the current commit.")
+    console.hint("Run `wade review implementation` (or pass --skip-review), then re-run done.")
+    console.detail(
+        "A clean merge of main is accepted without re-review, but new commits "
+        "require a fresh review — the marker is keyed to the commit sha."
+    )
+    console.hint("Bypass: set `done.require_review: false` in .wade.yml.")
+    return False
+
+
+def _behind_count(repo_root: Path, main_branch: str, branch: str) -> int | None:
+    """Commits on the base that ``branch`` lacks — how far *behind* it is.
+
+    ⚠ Argument order: ``commits_ahead(repo, base_in_branch_position, branch)`` —
+    the base ref (``origin/<main>`` or the local ``<main>``) goes in the *branch*
+    position, so it counts commits present on the base but not on the session
+    branch. This is the OPPOSITE role assignment from the Stop hook's ahead-count
+    (``_stop_git_facts``), which puts the session branch in the branch position.
+    Returns None when neither base ref resolves.
+    """
+    for base in (f"origin/{main_branch}", main_branch):
+        try:
+            return git_branch.commits_ahead(repo_root, base, branch)
+        except GitError:
+            continue
+    return None
+
+
+def _gate_sync(
+    config: ProjectConfig,
+    repo_root: Path,
+    worktree_root: Path,
+    branch: str,
+    main_branch: str,
+    session_type: str,
+) -> bool:
+    """Auto-sync a branch behind main; refuse only on conflict."""
+    if not config.done.require_sync:
+        return True
+
+    with contextlib.suppress(GitError):
+        git_sync.fetch_origin(repo_root)
+
+    behind = _behind_count(repo_root, main_branch, branch)
+    if behind is None:
+        console.warn(
+            f"Could not determine whether '{branch}' is behind '{main_branch}' "
+            "— skipping the sync gate."
+        )
+        return True
+    if behind == 0:
+        return True
+
+    console.step(f"Branch is {behind} commit(s) behind {main_branch} — auto-syncing...")
+    # Reuse the existing sync service rather than merging inline (planning
+    # decision: auto-sync, refuse only on conflict).
+    from wade.services.implementation_service.sync import sync as do_sync
+
+    result = do_sync(
+        main_branch=main_branch,
+        session_type=session_type,
+        project_root=worktree_root,
+    )
+    if result.success:
+        console.success(f"Synced with {main_branch}.")
+        return True
+
+    session_cmd = "review-pr-comments" if session_type == "review-pr-comments" else "implementation"
+    if result.conflicts:
+        console.error(f"Sync hit conflicts with {main_branch} — resolve them, then re-run done.")
+        console.hint(
+            f"Resolve via `wade {session_cmd}-session sync`, fix the conflicts, then re-run done."
+        )
+    else:
+        console.error(f"Could not sync with {main_branch}.")
+        console.hint(f"Run `wade {session_cmd}-session sync`, then re-run done.")
+    console.hint("Bypass: set `done.require_sync: false` in .wade.yml.")
+    return False
+
+
+def _gate_resolved_threads(
+    config: ProjectConfig,
+    provider: AbstractTaskProvider,
+    repo_root: Path,
+    branch: str,
+) -> bool:
+    """Refuse on unresolved PR review threads; a transient lookup is non-blocking.
+
+    Consistent with #357 B1/B2 typed-lookup handling: a provider/lookup error is
+    logged and warned, never blocking — a flaky ``gh`` call must not trap
+    completion. Only an actually-fetched, non-empty unresolved-thread list
+    refuses.
+    """
+    if not config.done.require_resolved_threads:
+        return True
+
+    from wade.models.review import filter_unresolved_threads
+
+    try:
+        lookup = git_pr.get_pr_for_branch(repo_root, branch)
+    except Exception:
+        console.warn("Could not look up the PR to check review threads — skipping the thread gate.")
+        logger.debug("done.thread_gate_pr_lookup_failed", exc_info=True)
+        return True
+    if lookup.lookup_failed or not lookup.is_open or lookup.pr is None:
+        # Transient failure or no open PR — non-blocking (nothing to gate on yet).
+        return True
+
+    pr_number = lookup.pr.number
+    try:
+        threads = provider.get_pr_review_threads(pr_number)
+    except Exception as exc:
+        console.warn(f"Could not fetch review threads (non-blocking): {exc}")
+        logger.debug("done.thread_gate_fetch_failed", exc_info=True)
+        return True
+
+    unresolved = filter_unresolved_threads(threads)
+    if unresolved:
+        console.error(f"{len(unresolved)} unresolved review thread(s) remain.")
+        console.hint(
+            "Resolve each via `wade review-pr-comments-session resolve <thread-id>`, "
+            "then re-run done."
+        )
+        console.hint("Bypass: set `done.require_resolved_threads: false` in .wade.yml.")
+        return False
     return True
 
 
@@ -357,6 +631,19 @@ def _done_via_pr(
     except Exception as e:
         console.error(f"Cannot read issue #{issue_number}: {e}")
         return False
+
+    # Write the sha-keyed done-marker keyed to the branch tip being pushed,
+    # immediately before pushing, so `done`'s own push satisfies the pre-push
+    # backstop (which tests `.wade/done@<pushed sha>`) and the Stop hook reads
+    # the session as finalized. Resolving `branch` (not HEAD) keeps this correct
+    # even when `done <target>` runs from the main checkout, where `repo_root`'s
+    # HEAD is not the branch tip. A new commit changes the sha and invalidates it.
+    marker_root = worktree_path or repo_root
+    try:
+        pushed_sha = git_repo.rev_parse(repo_root, branch)
+        markers.write_marker(marker_root, "done", pushed_sha)
+    except GitError:
+        logger.warning("done.marker_write_head_failed", exc_info=True)
 
     # Push branch (with non-fast-forward divergence recovery — never a silent
     # force-push).

--- a/src/wade/services/implementation_service/done.py
+++ b/src/wade/services/implementation_service/done.py
@@ -534,10 +534,26 @@ def _is_non_fast_forward(message: str) -> bool:
     return any(sig in lowered for sig in _NON_FAST_FORWARD_SIGNALS)
 
 
+def _write_done_marker(marker_root: Path, repo_root: Path, branch: str) -> None:
+    """Write ``.wade/done@<branch tip>`` best-effort (clears any prior ``done@*``).
+
+    Resolving ``branch`` (not HEAD) keeps the key correct even when ``done
+    <target>`` runs from the main checkout, where ``repo_root``'s HEAD is not the
+    branch tip.
+    """
+    try:
+        pushed_sha = git_repo.rev_parse(repo_root, branch)
+    except GitError:
+        logger.warning("done.marker_write_head_failed", exc_info=True)
+        return
+    markers.write_marker(marker_root, "done", pushed_sha)
+
+
 def _push_branch_with_recovery(
     repo_root: Path,
     branch: str,
     worktree_path: Path | None,
+    marker_root: Path,
 ) -> bool:
     """Push *branch*, recovering interactively from a non-fast-forward rejection.
 
@@ -545,7 +561,20 @@ def _push_branch_with_recovery(
     We fetch, report the divergence, and — only behind an explicit confirm —
     offer to merge the remote in and retry, or force-push with
     ``--force-with-lease``. wade never force-pushes silently (C4).
+
+    Owns the ``done`` marker lifecycle so the pre-push backstop and Stop hook
+    stay consistent with what is actually on the remote:
+
+    - The marker is written **immediately before each push attempt** (so the
+      worktree's own pre-push backstop passes), keyed to the branch tip being
+      pushed. A recovery merge advances that tip, so the marker is **re-written**
+      for the new sha before the retry — otherwise the backstop would reject
+      ``done``'s own recovery push.
+    - Every failure path **clears** the marker: if nothing reached the remote,
+      no stale ``done@<sha>`` may linger (which would tell the Stop hook the
+      session finished and let the next push skip the backstop).
     """
+    _write_done_marker(marker_root, repo_root, branch)
     try:
         git_repo.push_branch(repo_root, branch, set_upstream=True)
         console.success("Branch pushed.")
@@ -553,6 +582,7 @@ def _push_branch_with_recovery(
     except GitError as e:
         if not _is_non_fast_forward(str(e)):
             console.error(f"Push failed: {e}")
+            markers.clear_markers(marker_root, "done")
             return False
 
     console.warn(f"Push rejected — '{branch}' has diverged from its remote.")
@@ -570,6 +600,7 @@ def _push_branch_with_recovery(
             "Remote branch has diverged. Resolve it manually "
             f"(e.g. `git -C {merge_cwd} pull --no-rebase`), then re-run done."
         )
+        markers.clear_markers(marker_root, "done")
         return False
 
     choice = prompts.select(
@@ -585,22 +616,31 @@ def _push_branch_with_recovery(
             merge_result = git_sync.merge_branch(merge_cwd, f"origin/{branch}")
             if not merge_result.success:
                 console.error("Merge conflicts with the remote branch — resolve them, then re-run.")
+                markers.clear_markers(marker_root, "done")
                 return False
+            # The merge advanced the branch tip — re-key the marker to it so the
+            # retry push satisfies the backstop.
+            _write_done_marker(marker_root, repo_root, branch)
             git_repo.push_branch(repo_root, branch, set_upstream=True)
             console.success("Merged the remote and pushed.")
             return True
         except GitError as e:
             console.error(f"Could not merge and push: {e}")
+            markers.clear_markers(marker_root, "done")
             return False
     if choice == 1:
+        # Force-push sends the same local tip, so the marker from the initial
+        # write still matches — no re-write needed.
         try:
             git_repo.push_branch(repo_root, branch, set_upstream=True, force=True)
             console.success("Force-pushed with lease.")
             return True
         except GitError as e:
             console.error(f"Force push failed: {e}")
+            markers.clear_markers(marker_root, "done")
             return False
     console.info("Push cancelled — the branch was not updated on the remote.")
+    markers.clear_markers(marker_root, "done")
     return False
 
 
@@ -632,23 +672,15 @@ def _done_via_pr(
         console.error(f"Cannot read issue #{issue_number}: {e}")
         return False
 
-    # Write the sha-keyed done-marker keyed to the branch tip being pushed,
-    # immediately before pushing, so `done`'s own push satisfies the pre-push
-    # backstop (which tests `.wade/done@<pushed sha>`) and the Stop hook reads
-    # the session as finalized. Resolving `branch` (not HEAD) keeps this correct
-    # even when `done <target>` runs from the main checkout, where `repo_root`'s
-    # HEAD is not the branch tip. A new commit changes the sha and invalidates it.
-    marker_root = worktree_path or repo_root
-    try:
-        pushed_sha = git_repo.rev_parse(repo_root, branch)
-        markers.write_marker(marker_root, "done", pushed_sha)
-    except GitError:
-        logger.warning("done.marker_write_head_failed", exc_info=True)
-
     # Push branch (with non-fast-forward divergence recovery — never a silent
-    # force-push).
+    # force-push). `_push_branch_with_recovery` owns the `done` marker: it writes
+    # `.wade/done@<pushed sha>` right before each push (so `done`'s own push
+    # satisfies the pre-push backstop and the Stop hook reads the session as
+    # finalized) and clears it on any push failure. A new commit changes the sha
+    # and invalidates the marker.
+    marker_root = worktree_path or repo_root
     console.step("Pushing branch...")
-    if not _push_branch_with_recovery(repo_root, branch, worktree_path):
+    if not _push_branch_with_recovery(repo_root, branch, worktree_path, marker_root):
         return False
 
     # Check for existing PR (expected from plan or implement bootstrap).

--- a/src/wade/services/review_delegation_service.py
+++ b/src/wade/services/review_delegation_service.py
@@ -21,8 +21,27 @@ from wade.services.ai_resolution import (
 from wade.services.delegation_service import delegate, resolve_mode
 from wade.skills.installer import load_prompt_template
 from wade.ui.console import console
+from wade.utils.markers import write_marker
 
 logger = structlog.get_logger()
+
+
+def _mark_reviewed() -> None:
+    """Record that ``wade review implementation`` ran for the current commit.
+
+    Writes a sha-keyed ``.wade/reviewed@<HEAD>`` marker (best-effort) that the
+    ``done`` review-ran gate later checks. Because it is keyed to the HEAD sha,
+    any commit made while addressing findings invalidates it — forcing a
+    re-review. This records that the command *ran for this sha*, not that
+    findings were addressed (documented honestly; #355 relaxes the phrasing).
+    """
+    try:
+        repo_root = git_repo.get_repo_root(Path.cwd())
+        head = git_repo.rev_parse(repo_root, "HEAD")
+    except GitError:
+        logger.debug("review.reviewed_marker_skipped", exc_info=True)
+        return
+    write_marker(repo_root, "reviewed", head)
 
 
 def _load_review_config(
@@ -249,6 +268,10 @@ def review_implementation(
     if not diff_content:
         label = "staged changes" if staged else "changes"
         console.warn(f"No {label} to review.")
+        # "No diff to review" still counts as review having run for this sha —
+        # there is nothing to critique, so record the marker so `done` isn't
+        # falsely blocked on a review that had no work to do.
+        _mark_reviewed()
         return DelegationResult(
             success=True,
             feedback=f"No {label} to review.",
@@ -259,7 +282,7 @@ def review_implementation(
     template = load_prompt_template("review-code.md")
     prompt = template.replace("{diff_content}", diff_content)
 
-    return _run_review_delegation(
+    result = _run_review_delegation(
         prompt,
         "review_implementation",
         config=config,
@@ -272,3 +295,8 @@ def review_implementation(
         model_explicit=model_explicit,
         effort_explicit=effort_explicit,
     )
+    # Record the review-ran marker on any non-hard-failure result (success),
+    # keyed to the current HEAD sha. The `done` review-ran gate reads it.
+    if result.success:
+        _mark_reviewed()
+    return result

--- a/src/wade/skills/installer.py
+++ b/src/wade/skills/installer.py
@@ -76,6 +76,171 @@ def load_prompt_template(name: str) -> str:
     return template.read_text(encoding="utf-8").strip()
 
 
+def load_hook_template(name: str) -> str:
+    """Load a git-hook script template by name from templates/hooks/.
+
+    Unlike :func:`load_prompt_template`, the content is returned verbatim (no
+    ``.strip()``) — a shell script's leading shebang and trailing newline matter.
+
+    Raises:
+        FileNotFoundError: If the template does not exist.
+    """
+    template = get_templates_dir() / "hooks" / name
+    if not template.is_file():
+        raise FileNotFoundError(f"Hook template not found: {template}")
+    return template.read_text(encoding="utf-8")
+
+
+# --- Per-worktree git-hook install (#349 pre-push backstop, reusable by #352) ---
+
+# Relative to the worktree top. ``core.hooksPath`` is set to this dir per-worktree
+# so a relative path resolves against each working tree's top level and cannot
+# leak to the main checkout or sibling worktrees. ``.wade/`` is already gitignored
+# and flagged-if-tracked, so nothing here appears as untracked or gets committed.
+WADE_GITHOOKS_DIR = ".wade/githooks"
+# File recording the resolved chain target (a pre-existing hook) — written once
+# at first install so the wade hook can invoke it after its own check passes.
+WADE_HOOK_CHAIN_FILE = ".wade/githooks/.chain"
+
+
+def _wade_hooks_managed(worktree_path: Path) -> bool:
+    """True if this worktree's pre-push is already wade-managed.
+
+    Detection must not mistake wade's *own* prior install for a user hook on a
+    re-run: either the ``--worktree core.hooksPath`` already points at
+    ``.wade/githooks`` **or** a ``.chain`` file already exists. Either way the
+    chain target was captured on the first install and must NOT be re-captured
+    (which would now resolve to wade's own hook and self-chain or drop the real
+    original).
+    """
+    from wade.git import repo as git_repo
+
+    if (worktree_path / WADE_HOOK_CHAIN_FILE).exists():
+        return True
+    current = git_repo.get_config_value(worktree_path, "core.hooksPath", worktree=True)
+    return current == WADE_GITHOOKS_DIR
+
+
+def _detect_prior_hook(worktree_path: Path, hook_name: str) -> str | None:
+    """Return the absolute path of a pre-existing ``hook_name`` hook, or None.
+
+    ``core.hooksPath`` *replaces* ``.git/hooks``, so before we point it at
+    ``.wade/githooks`` we must find whatever git would run today and chain to it.
+    Precedence mirrors git's: a prior user-set ``core.hooksPath`` wins over the
+    common-dir ``hooks/`` directory. Called only on first install (before we set
+    our own worktree ``core.hooksPath``), so the merged ``core.hooksPath`` it
+    reads is genuinely the user's, not ours.
+    """
+    from wade.git import repo as git_repo
+
+    candidates: list[Path] = []
+
+    prior_hooks_path = git_repo.get_config_value(worktree_path, "core.hooksPath")
+    if prior_hooks_path and prior_hooks_path != WADE_GITHOOKS_DIR:
+        prior_dir = Path(prior_hooks_path)
+        if not prior_dir.is_absolute():
+            prior_dir = worktree_path / prior_dir
+        candidates.append(prior_dir / hook_name)
+
+    common_dir = git_repo.get_git_common_dir(worktree_path)
+    if common_dir:
+        common_path = Path(common_dir)
+        if not common_path.is_absolute():
+            common_path = worktree_path / common_path
+        candidates.append(common_path / "hooks" / hook_name)
+
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate.resolve())
+    return None
+
+
+def install_worktree_git_hook(worktree_path: Path, hook_name: str, script_body: str) -> bool:
+    """Install a per-worktree git hook via ``core.hooksPath``, chaining any prior hook.
+
+    Reusable core (designed for #352's ``pre-commit``/``commit-msg`` needs):
+
+    1. Write ``script_body`` to ``<worktree>/.wade/githooks/<hook_name>`` (``+x``).
+       Always refreshed so the hook body can never drift from the installed wade.
+    2. On the **first** install only, detect a pre-existing hook (prior
+       ``core.hooksPath`` or common-dir ``hooks/<hook_name>``) and persist its
+       resolved path to ``.wade/githooks/.chain`` so the wade hook can invoke it.
+    3. Enable ``extensions.worktreeConfig`` (repo-level, idempotent) and set
+       ``core.hooksPath .wade/githooks`` in the ``--worktree`` scope.
+
+    **Graceful degrade**: worktree-scoped config needs git ≥ 2.20. If enabling
+    the extension or setting the worktree ``core.hooksPath`` fails for any reason
+    (old git, restricted config), the function warns via the logger, leaves the
+    session's Python ``done`` gates as the sole enforcement, and returns
+    ``False`` — it never raises, so bootstrap can't crash over the optional
+    backstop.
+
+    Returns True when the worktree hooksPath is active, False when the backstop
+    had to be skipped.
+    """
+    from wade.git import repo as git_repo
+
+    hooks_dir = worktree_path / WADE_GITHOOKS_DIR
+    try:
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logger.warning("skills.githook_dir_failed", path=str(hooks_dir))
+        return False
+
+    already_managed = _wade_hooks_managed(worktree_path)
+
+    # Capture the chain target exactly once, BEFORE writing the hook script so a
+    # detection that scans common-dir/hooks can't pick up our own just-written
+    # file, and BEFORE setting our worktree core.hooksPath so the read reflects
+    # the user's prior config.
+    if not already_managed:
+        chain_target = _detect_prior_hook(worktree_path, hook_name)
+        if chain_target:
+            try:
+                (worktree_path / WADE_HOOK_CHAIN_FILE).write_text(
+                    chain_target + "\n", encoding="utf-8"
+                )
+            except OSError:
+                logger.warning("skills.githook_chain_write_failed", path=str(worktree_path))
+
+    hook_path = hooks_dir / hook_name
+    try:
+        hook_path.write_text(script_body, encoding="utf-8")
+        hook_path.chmod(0o755)
+    except OSError:
+        logger.warning("skills.githook_write_failed", path=str(hook_path))
+        return False
+
+    # Enable the worktree-config extension (repo-level), then set the worktree
+    # hooksPath. Order matters: --worktree writes require the extension first.
+    if not git_repo.set_config_value(worktree_path, "extensions.worktreeConfig", "true"):
+        logger.warning("skills.worktree_config_unsupported", path=str(worktree_path))
+        return False
+    if not git_repo.set_config_value(
+        worktree_path, "core.hooksPath", WADE_GITHOOKS_DIR, worktree=True
+    ):
+        logger.warning("skills.worktree_hookspath_failed", path=str(worktree_path))
+        return False
+
+    logger.debug("skills.githook_installed", hook=hook_name, path=str(worktree_path))
+    return True
+
+
+def install_pre_push_backstop(worktree_path: Path) -> bool:
+    """Install the ``done`` pre-push backstop hook into a worktree.
+
+    Loads the ``pre-push`` template and delegates to
+    :func:`install_worktree_git_hook`. Returns whatever that reports (False when
+    the backstop had to be skipped).
+    """
+    try:
+        script = load_hook_template("pre-push")
+    except FileNotFoundError:
+        logger.warning("skills.pre_push_template_missing")
+        return False
+    return install_worktree_git_hook(worktree_path, "pre-push", script)
+
+
 # --- Skill registry: name → list of files ---
 
 SKILL_FILES: dict[str, list[str]] = {

--- a/src/wade/skills/installer.py
+++ b/src/wade/skills/installer.py
@@ -213,6 +213,11 @@ def install_worktree_git_hook(worktree_path: Path, hook_name: str, script_body: 
 
     # Enable the worktree-config extension (repo-level), then set the worktree
     # hooksPath. Order matters: --worktree writes require the extension first.
+    # Capture the prior extension value first so a failed hooksPath write can roll
+    # the extension back: leaving it enabled is a persistent, repo-WIDE change
+    # (git then reads config.worktree for every worktree) caused by an optional
+    # backstop that did not install.
+    prior_worktree_config = git_repo.get_config_value(worktree_path, "extensions.worktreeConfig")
     if not git_repo.set_config_value(worktree_path, "extensions.worktreeConfig", "true"):
         logger.warning("skills.worktree_config_unsupported", path=str(worktree_path))
         return False
@@ -220,6 +225,14 @@ def install_worktree_git_hook(worktree_path: Path, hook_name: str, script_body: 
         worktree_path, "core.hooksPath", WADE_GITHOOKS_DIR, worktree=True
     ):
         logger.warning("skills.worktree_hookspath_failed", path=str(worktree_path))
+        # Undo the repo-wide extension we just enabled so a failed optional
+        # backstop leaves no persistent config change behind.
+        if prior_worktree_config is None:
+            git_repo.unset_config_value(worktree_path, "extensions.worktreeConfig")
+        else:
+            git_repo.set_config_value(
+                worktree_path, "extensions.worktreeConfig", prior_worktree_config
+            )
         return False
 
     logger.debug("skills.githook_installed", hook=hook_name, path=str(worktree_path))

--- a/src/wade/utils/markers.py
+++ b/src/wade/utils/markers.py
@@ -1,0 +1,241 @@
+"""SHA-keyed completion markers under a worktree's ``.wade/`` directory.
+
+A **marker** is a zero-byte file at ``.wade/<name>@<sha>`` whose presence means
+"the gates named ``<name>`` passed for commit ``<sha>``". Because it is keyed to
+a sha, a new commit changes the sha and every prior marker is automatically
+stale — **missing or stale ⇒ not done**. This is exactly the fact the ``done``
+completion gate, the pre-push backstop, and the Stop hook all want to verify.
+
+Pure-stdlib leaf module (only ``structlog``) so the lean ``wade-hook`` entry
+point can import it without paying the crossby/CLI cold-start cost. It also
+generalizes the single-shot ``.wade/stop-nudged`` mechanism (see
+``flag_marker_*``), so the two implementations can no longer drift.
+
+**Race-safety.** All reads/writes go through a ``.wade`` directory handle opened
+with ``O_DIRECTORY | O_NOFOLLOW`` and operate *relative to that handle* without
+following symlinks (a symlinked ``.wade`` fails outright). Using a handle rather
+than re-resolving the path closes the TOCTOU window where ``.wade`` is swapped
+for a symlink between the check and the read/write. On platforms without dir-fd
+support a marker is treated as absent (never followed unsafely) — the same
+policy the old ``stop_nudge_present`` used.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import stat as stat_module
+from pathlib import Path
+
+import structlog
+
+logger = structlog.get_logger()
+
+_WADE_DIRNAME = ".wade"
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _wade_dir(worktree_root: Path) -> Path:
+    return worktree_root / _WADE_DIRNAME
+
+
+def marker_path(worktree_root: Path, name: str, sha: str) -> Path:
+    """Absolute path of the sha-keyed ``.wade/<name>@<sha>`` marker."""
+    return _wade_dir(worktree_root) / f"{name}@{sha}"
+
+
+def flag_marker_path(worktree_root: Path, name: str) -> Path:
+    """Absolute path of a single-shot (non-sha) ``.wade/<name>`` flag marker."""
+    return _wade_dir(worktree_root) / name
+
+
+# ---------------------------------------------------------------------------
+# dir-fd capability probes
+# ---------------------------------------------------------------------------
+
+
+def _read_dir_fd_supported() -> bool:
+    return hasattr(os, "O_DIRECTORY") and os.stat in os.supports_dir_fd
+
+
+def _write_dir_fd_supported() -> bool:
+    return hasattr(os, "O_DIRECTORY") and os.open in os.supports_dir_fd
+
+
+# ---------------------------------------------------------------------------
+# Low-level, relname-scoped primitives (shared by sha-keyed + flag markers)
+# ---------------------------------------------------------------------------
+
+
+def _present(worktree_root: Path, relname: str) -> bool:
+    """True if ``.wade/<relname>`` is a *trusted* regular file (race-safe)."""
+    if not _read_dir_fd_supported():
+        return False
+    dir_fd = None
+    try:
+        dir_fd = os.open(_wade_dir(worktree_root), os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        st = os.stat(relname, dir_fd=dir_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    finally:
+        if dir_fd is not None:
+            os.close(dir_fd)
+    return stat_module.S_ISREG(st.st_mode)
+
+
+def _touch(worktree_root: Path, relname: str) -> bool:
+    """Create an empty ``.wade/<relname>`` marker (0o600). Best-effort."""
+    if not _write_dir_fd_supported():
+        return False
+    wade_dir = _wade_dir(worktree_root)
+    try:
+        wade_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+    dir_fd = None
+    try:
+        dir_fd = os.open(wade_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        fd = os.open(
+            relname,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=dir_fd,
+        )
+        os.close(fd)
+        return True
+    except OSError:
+        return False
+    finally:
+        if dir_fd is not None:
+            os.close(dir_fd)
+
+
+def _atomic_write(worktree_root: Path, relname: str) -> bool:
+    """Create the (zero-byte) ``.wade/<relname>`` marker safely; return success.
+
+    All I/O is relative to an ``O_DIRECTORY | O_NOFOLLOW`` handle on ``.wade`` so
+    a symlinked ``.wade`` can never redirect the write outside the worktree. When
+    the platform supports ``renameat`` (``os.replace`` with dir-fds) the marker
+    is written to ``*.tmp`` then atomically renamed onto the final name; when it
+    does not, the zero-byte marker is created directly with a single ``O_CREAT``
+    (atomic enough for a presence flag). There is deliberately **no** path-based
+    fallback — following the symlink is worse than not writing the marker, so an
+    unsupported platform returns ``False`` (fail toward absent, matching the read
+    side).
+    """
+    wade_dir = _wade_dir(worktree_root)
+    try:
+        wade_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+
+    if not _write_dir_fd_supported():
+        return False  # no safe no-follow write path available
+
+    tmp_name = f"{relname}.tmp"
+    dir_fd = None
+    try:
+        dir_fd = os.open(wade_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        if os.replace in os.supports_dir_fd:
+            fd = os.open(
+                tmp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=dir_fd,
+            )
+            os.close(fd)
+            os.replace(tmp_name, relname, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        else:
+            fd = os.open(
+                relname,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=dir_fd,
+            )
+            os.close(fd)
+        return True
+    except OSError:
+        if dir_fd is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name, dir_fd=dir_fd)
+        return False
+    finally:
+        if dir_fd is not None:
+            os.close(dir_fd)
+
+
+def _clear_prefix(worktree_root: Path, prefix: str) -> None:
+    """Remove every ``.wade/<prefix>*`` entry. Best-effort; ignores errors."""
+    wade_dir = _wade_dir(worktree_root)
+    if _write_dir_fd_supported() and os.listdir in os.supports_fd:
+        dir_fd = None
+        try:
+            dir_fd = os.open(wade_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+            for entry in os.listdir(dir_fd):
+                if entry.startswith(prefix):
+                    with contextlib.suppress(OSError):
+                        os.unlink(entry, dir_fd=dir_fd)
+        except OSError:
+            return
+        finally:
+            if dir_fd is not None:
+                os.close(dir_fd)
+        return
+    # Fallback: plain path iteration.
+    try:
+        for path_entry in wade_dir.iterdir():
+            if path_entry.name.startswith(prefix):
+                with contextlib.suppress(OSError):
+                    path_entry.unlink()
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Public sha-keyed API
+# ---------------------------------------------------------------------------
+
+
+def marker_present(worktree_root: Path, name: str, sha: str) -> bool:
+    """True if a trusted ``.wade/<name>@<sha>`` marker exists (race-safe)."""
+    return _present(worktree_root, f"{name}@{sha}")
+
+
+def write_marker(worktree_root: Path, name: str, sha: str) -> bool:
+    """Atomically write ``.wade/<name>@<sha>``; return whether it succeeded.
+
+    Clears any prior ``<name>@*`` marker first so only the current sha's marker
+    exists — this bounds ``.wade/`` growth over a long session and makes
+    "is there *any* ``<name>`` marker" unambiguous. Best-effort: a failed write
+    returns ``False`` and callers treat that as "marker absent" (fail toward
+    reminding / re-gating).
+    """
+    clear_markers(worktree_root, name)
+    ok = _atomic_write(worktree_root, f"{name}@{sha}")
+    if not ok:
+        logger.debug("markers.write_failed", name=name, sha=sha)
+    return ok
+
+
+def clear_markers(worktree_root: Path, name: str) -> None:
+    """Remove every ``.wade/<name>@*`` marker for ``name``. Best-effort."""
+    _clear_prefix(worktree_root, f"{name}@")
+
+
+# ---------------------------------------------------------------------------
+# Public single-shot flag API (generalizes ``.wade/stop-nudged``)
+# ---------------------------------------------------------------------------
+
+
+def flag_marker_present(worktree_root: Path, name: str) -> bool:
+    """True if a trusted single-shot ``.wade/<name>`` flag marker exists."""
+    return _present(worktree_root, name)
+
+
+def write_flag_marker(worktree_root: Path, name: str) -> bool:
+    """Create the single-shot ``.wade/<name>`` flag marker. Best-effort."""
+    return _touch(worktree_root, name)

--- a/templates/hooks/pre-push
+++ b/templates/hooks/pre-push
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# wade pre-push backstop — refuses to push the session branch unless `done`
+# wrote a completion marker for the pushed commit (.wade/done@<sha>).
+#
+# Installed per-worktree by wade at <worktree>/.wade/githooks/pre-push and wired
+# via `git config --worktree core.hooksPath .wade/githooks`. git runs the hook
+# with cwd at the worktree top, so the marker check is a plain file test — no
+# python callback needed.
+#
+# Honesty: `git push --no-verify` bypasses this in one flag. This is a
+# quality/backstop layer that makes the `done` gate hard to skip, NOT an
+# airtight boundary.
+#
+# git invokes pre-push as:  pre-push <remote-name> <remote-location>
+# and streams the ref updates on stdin, one per line:
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+
+set -euo pipefail
+
+zero_sha="0000000000000000000000000000000000000000"
+
+# Buffer ALL of stdin ONCE. A `git push --all` sends many ref-update lines, and
+# stdin is a single-pass stream: we must consume it for the marker check AND
+# re-emit it verbatim to a chained hook. Reading it twice is impossible.
+#
+# The `; echo X` + `%X` sentinel preserves the exact bytes: plain `$(cat)` would
+# strip the trailing newline(s) git sends, so a chained hook would receive a
+# truncated final line. Appending X, then stripping it, keeps the stream intact.
+stdin_data="$(cat; echo X)"
+stdin_data="${stdin_data%X}"
+
+# Only the session branch is gated. In a wade worktree that is the checked-out
+# branch; other refs (tags, notes) and deletions pass straight through.
+session_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+
+marker_ok=1
+missing_sha=""
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  [[ -z "${local_ref:-}" ]] && continue
+  # Deletion (local sha all-zero): nothing is being pushed, so nothing to gate.
+  if [[ "$local_sha" == "$zero_sha" ]]; then
+    continue
+  fi
+  # Skip anything that is not the session branch head.
+  if [[ -z "$session_branch" || "$local_ref" != "refs/heads/${session_branch}" ]]; then
+    continue
+  fi
+  if [[ ! -f ".wade/done@${local_sha}" ]]; then
+    marker_ok=0
+    missing_sha="$local_sha"
+  fi
+done <<<"$stdin_data"
+
+if [[ "$marker_ok" -eq 0 ]]; then
+  echo "[wade] Refusing to push ${missing_sha}: no completion marker (.wade/done@${missing_sha})." >&2
+  echo "[wade] Run \`wade implementation-session done\` (or \`wade review-pr-comments-session done\`) first." >&2
+  echo "[wade] To bypass this backstop for one push: git push --no-verify" >&2
+  exit 1
+fi
+
+# Chain to a pre-existing hook captured at install time (core.hooksPath REPLACES
+# .git/hooks, so a prior hook would otherwise be silently disabled). Re-emit the
+# exact buffered stdin so the chained hook sees the same ref list, forward the
+# same argv, and honor its exit code. Never silently shadow.
+chain_file=".wade/githooks/.chain"
+if [[ -f "$chain_file" ]]; then
+  chained="$(cat "$chain_file")"
+  if [[ -n "$chained" && -x "$chained" ]]; then
+    set +e
+    printf '%s' "$stdin_data" | "$chained" "$@"
+    rc=$?
+    set -e
+    exit "$rc"
+  fi
+fi
+
+exit 0

--- a/templates/hooks/pre-push
+++ b/templates/hooks/pre-push
@@ -34,7 +34,9 @@ stdin_data="${stdin_data%X}"
 session_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
 
 marker_ok=1
-missing_sha=""
+# Collect EVERY session-branch sha that lacks a marker (newline-separated), not
+# just the last one, so a multi-ref push reports all of them.
+missing_shas=""
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   [[ -z "${local_ref:-}" ]] && continue
   # Deletion (local sha all-zero): nothing is being pushed, so nothing to gate.
@@ -47,12 +49,15 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   fi
   if [[ ! -f ".wade/done@${local_sha}" ]]; then
     marker_ok=0
-    missing_sha="$local_sha"
+    missing_shas+="${local_sha}"$'\n'
   fi
 done <<<"$stdin_data"
 
 if [[ "$marker_ok" -eq 0 ]]; then
-  echo "[wade] Refusing to push ${missing_sha}: no completion marker (.wade/done@${missing_sha})." >&2
+  while IFS= read -r missing_sha; do
+    [[ -z "$missing_sha" ]] && continue
+    echo "[wade] Refusing to push ${missing_sha}: no completion marker (.wade/done@${missing_sha})." >&2
+  done <<<"$missing_shas"
   echo "[wade] Run \`wade implementation-session done\` (or \`wade review-pr-comments-session done\`) first." >&2
   echo "[wade] To bypass this backstop for one push: git push --no-verify" >&2
   exit 1
@@ -66,8 +71,17 @@ chain_file=".wade/githooks/.chain"
 if [[ -f "$chain_file" ]]; then
   chained="$(cat "$chain_file")"
   if [[ -n "$chained" && -x "$chained" ]]; then
+    # Re-emit the exact buffered stdin via a temp file, NOT a pipe. A chained
+    # pre-push hook that never reads stdin (many only inspect refs through git)
+    # would close the read end early; with `pipefail` on, the writer's SIGPIPE
+    # (exit 141) would then mask the chained hook's real status via $? — turning
+    # a hook that PASSED into a refused push. A file redirect keeps rc as the
+    # chained hook's own exit status, nothing else.
+    tmp_stdin="$(mktemp)"
+    trap 'rm -f "$tmp_stdin"' EXIT
+    printf '%s' "$stdin_data" >"$tmp_stdin"
     set +e
-    printf '%s' "$stdin_data" | "$chained" "$@"
+    "$chained" "$@" <"$tmp_stdin"
     rc=$?
     set -e
     exit "$rc"

--- a/templates/skills/implementation-session/SKILL.md
+++ b/templates/skills/implementation-session/SKILL.md
@@ -108,9 +108,9 @@ git operations yourself.
 wade implementation-session done
 ```
 
-`done` is the **authoritative completion gate**: it refuses to finalize unless
-PR-SUMMARY is present, the branch is synced with `main`, and review ran for this
-commit (bypass: `--skip-review`, or a `done.*` toggle in `.wade.yml`). A pre-push
+`done` is the **authoritative completion gate**: it requires PR-SUMMARY and a
+review for this commit; it auto-syncs a branch behind `main`, refusing only on
+conflict (bypass: `--skip-review`, or a `done.*` toggle in `.wade.yml`). A pre-push
 hook blocks pushes with no `.wade/done@<sha>` marker (`--no-verify` bypasses it).
 The worktree is **not** deleted (cleaned up after merge). **Mandatory**; if it
 fails, fix the cause, do NOT bypass.

--- a/templates/skills/implementation-session/SKILL.md
+++ b/templates/skills/implementation-session/SKILL.md
@@ -108,9 +108,12 @@ git operations yourself.
 wade implementation-session done
 ```
 
-`done` pushes the branch and updates the existing draft PR (appends a summary,
-marks it ready). The worktree is **not** deleted — `implement` cleans it up after
-merge. This is a **mandatory** step; if it fails, debug and fix it — do NOT bypass.
+`done` is the **authoritative completion gate**: it refuses to finalize unless
+PR-SUMMARY is present, the branch is synced with `main`, and review ran for this
+commit (bypass: `--skip-review`, or a `done.*` toggle in `.wade.yml`). A pre-push
+hook blocks pushes with no `.wade/done@<sha>` marker (`--no-verify` bypasses it).
+The worktree is **not** deleted (cleaned up after merge). **Mandatory**; if it
+fails, fix the cause, do NOT bypass.
 
 **Step 6 — Present results:** give a brief **workflow recap** (only the steps you
 performed) and **current state** (PR number/URL, that the issue closes on merge,

--- a/templates/skills/review-pr-comments-session/SKILL.md
+++ b/templates/skills/review-pr-comments-session/SKILL.md
@@ -152,6 +152,18 @@ wade review-pr-comments-session done
 `done` pushes changes to the existing PR branch. This is a **mandatory** step; if
 it fails, debug and fix it — do NOT bypass.
 
+`done` is a completion gate here too. It refuses when:
+
+- **unresolved review threads remain** → resolve each one (see *Resolving
+  threads* above), then re-run `done`. A transient `gh` lookup failure does not
+  block. Hatch: `done.require_resolved_threads: false` in `.wade.yml`.
+- `wade review implementation` has not run for the current commit → run it, or
+  pass `--skip-review`. Hatch: `done.require_review: false`.
+
+A **pre-push git hook** refuses a push of the session branch without a current
+`.wade/done@<sha>` marker (`done` writes it). `git push --no-verify` bypasses it
+in one flag — it is a quality layer, not a boundary; do not route around it.
+
 **Step 5 — Present results:** give a brief **workflow recap** (only the steps you
 performed) and **current state** (PR number/URL, threads resolved and remaining),
 then note what's next (wade keeps monitoring the PR; reviewers are notified of

--- a/tests/e2e/test_implement_work_done_contract.py
+++ b/tests/e2e/test_implement_work_done_contract.py
@@ -232,7 +232,9 @@ class TestWorkDoneCommand:
         _git(["commit", "-m", f"feat: complete #{issue_number}"], cwd=worktree_path)
         assert _git(["status", "--porcelain"], cwd=worktree_path).stdout.strip() == ""
 
-        result = _run(["implementation-session", "done"], cwd=worktree_path)
+        # --skip-review bypasses the review-ran completion gate — this contract
+        # exercises the done→PR mechanics, not the review gate (covered by unit tests).
+        result = _run(["implementation-session", "done", "--skip-review"], cwd=worktree_path)
         assert result.returncode == 0
         assert _remote_has_branch(origin_repo, branch_name)
         pr_number = _find_mock_pr_number_by_head(mock_gh_cli["state_file"], branch_name)
@@ -303,7 +305,7 @@ class TestWorkDoneCommand:
         _git(["add", "-A"], cwd=worktree_path)
         _git(["commit", "-m", f"feat: complete #{issue_number}"], cwd=worktree_path)
 
-        result = _run(["implementation-session", "done"], cwd=worktree_path)
+        result = _run(["implementation-session", "done", "--skip-review"], cwd=worktree_path)
         assert result.returncode == 0
 
         pr_number = _find_mock_pr_number_by_head(mock_gh_cli["state_file"], branch_name)

--- a/tests/e2e/test_review_contract.py
+++ b/tests/e2e/test_review_contract.py
@@ -883,7 +883,9 @@ class TestReviewPrCommentsSessionCommands:
         _git(["add", "-A"], cwd=worktree_path)
         _git(["commit", "-m", "fix: address review comments"], cwd=worktree_path)
 
-        result = _run(["review-pr-comments-session", "done"], cwd=worktree_path)
+        # --skip-review bypasses the review-ran gate; this contract exercises the
+        # done→PR mechanics (thread gate + push + PR update), not the review gate.
+        result = _run(["review-pr-comments-session", "done", "--skip-review"], cwd=worktree_path)
 
         assert result.returncode == 0
         origin_repo = e2e_repo.parent / "origin.git"

--- a/tests/unit/test_cli/test_done_review_hint.py
+++ b/tests/unit/test_cli/test_done_review_hint.py
@@ -124,66 +124,26 @@ class TestPlanSessionDoneReviewHint:
 # ---------------------------------------------------------------------------
 
 
-class TestImplementationSessionDoneReviewHint:
-    """Review hint in ``wade implementation-session done`` output."""
+class TestImplementationSessionDoneNoReviewAdvisory:
+    """The post-done review advisory was removed (#349).
 
-    @patch("wade.config.loader.load_config")
+    The review-ran completion gate inside ``done()`` now enforces that
+    ``wade review implementation`` ran before ``done`` can succeed, so the old
+    "review not confirmed — run wade review implementation" advisory is redundant
+    (and would contradict the gate). On success ``done`` only emits the doc-pass
+    advisory + the SESSION COMPLETE message.
+    """
+
     @patch("wade.services.implementation_service.done", return_value=True)
-    def test_hint_shown_when_review_enabled(
-        self,
-        _mock_done: MagicMock,
-        mock_load_config: MagicMock,
-    ) -> None:
-        mock_load_config.return_value = _config(review_impl_enabled=True)
+    def test_no_review_advisory_on_success(self, _mock_done: MagicMock) -> None:
         result = runner.invoke(app, ["implementation-session", "done"])
         assert result.exit_code == 0
-        assert "wade review implementation" in result.output
-
-    @patch("wade.config.loader.load_config")
-    @patch("wade.services.implementation_service.done", return_value=True)
-    def test_hint_shown_when_review_not_explicitly_set(
-        self,
-        _mock_done: MagicMock,
-        mock_load_config: MagicMock,
-    ) -> None:
-        mock_load_config.return_value = _config(review_impl_enabled=None)
-        result = runner.invoke(app, ["implementation-session", "done"])
-        assert result.exit_code == 0
-        assert "wade review implementation" in result.output
-
-    @patch("wade.config.loader.load_config")
-    @patch("wade.services.implementation_service.done", return_value=True)
-    def test_hint_hidden_when_review_disabled(
-        self,
-        _mock_done: MagicMock,
-        mock_load_config: MagicMock,
-    ) -> None:
-        mock_load_config.return_value = _config(review_impl_enabled=False)
-        result = runner.invoke(app, ["implementation-session", "done"])
-        assert result.exit_code == 0
-        assert "wade review implementation" not in result.output
+        assert "review not confirmed" not in result.output.lower()
+        assert "SESSION COMPLETE" in result.output
 
     @patch("wade.services.implementation_service.done", return_value=False)
-    def test_no_hint_when_done_fails(
-        self,
-        _mock_done: MagicMock,
-    ) -> None:
-        """When done() returns False, no hint should appear."""
+    def test_no_output_when_done_fails(self, _mock_done: MagicMock) -> None:
+        """When done() returns False, none of the closing advisories appear."""
         result = runner.invoke(app, ["implementation-session", "done"])
         assert result.exit_code == 1
-        assert "wade review implementation" not in result.output
-
-    @patch(
-        "wade.config.loader.load_config",
-        side_effect=Exception("config load failed"),
-    )
-    @patch("wade.services.implementation_service.done", return_value=True)
-    def test_hint_skipped_on_config_load_failure(
-        self,
-        _mock_done: MagicMock,
-        _mock_load_config: MagicMock,
-    ) -> None:
-        """Config load failure must not break a successful done."""
-        result = runner.invoke(app, ["implementation-session", "done"])
-        assert result.exit_code == 0
-        assert "wade review implementation" not in result.output
+        assert "SESSION COMPLETE" not in result.output

--- a/tests/unit/test_config/test_loader.py
+++ b/tests/unit/test_config/test_loader.py
@@ -132,6 +132,37 @@ class TestParseConfigFile:
         assert config.project.issue_label == "feature-plan"
         assert config.ai.default_tool is None
 
+    def test_done_gates_default_on(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\n")
+
+        config = parse_config_file(config_path)
+        # Every completion gate defaults on — enforcement is the point (#349).
+        assert config.done.require_pr_summary is True
+        assert config.done.require_sync is True
+        assert config.done.require_review is True
+        assert config.done.require_resolved_threads is True
+        assert config.done.pre_push_backstop is True
+
+    def test_done_gates_round_trip(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text(
+            "version: 2\n"
+            "done:\n"
+            "  require_pr_summary: false\n"
+            "  require_sync: false\n"
+            "  require_review: false\n"
+            "  require_resolved_threads: false\n"
+            "  pre_push_backstop: false\n"
+        )
+
+        config = parse_config_file(config_path)
+        assert config.done.require_pr_summary is False
+        assert config.done.require_sync is False
+        assert config.done.require_review is False
+        assert config.done.require_resolved_threads is False
+        assert config.done.pre_push_backstop is False
+
     def test_empty_file(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
         config_path.write_text("")

--- a/tests/unit/test_config/test_loader.py
+++ b/tests/unit/test_config/test_loader.py
@@ -163,6 +163,16 @@ class TestParseConfigFile:
         assert config.done.require_resolved_threads is False
         assert config.done.pre_push_backstop is False
 
+    def test_done_flag_null_normalized_to_default(self, tmp_path: Path) -> None:
+        # `require_sync:` with no value parses to None. DoneConfig's fields are
+        # non-optional bools, so the loader must normalize None to the default
+        # (True) rather than crash with a cryptic Pydantic error.
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\ndone:\n  require_sync:\n")
+
+        config = parse_config_file(config_path)
+        assert config.done.require_sync is True
+
     def test_empty_file(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
         config_path.write_text("")

--- a/tests/unit/test_hooks/test_hook_cli.py
+++ b/tests/unit/test_hooks/test_hook_cli.py
@@ -30,6 +30,31 @@ def _run_lean(event: str, guard: str, tool: str, stdin: str, root: str | None = 
     return subprocess.run(cmd, input=stdin, capture_output=True, text=True)
 
 
+def _make_ahead_repo(root: Path) -> None:
+    """Init a git repo at *root* on a branch one commit ahead of main.
+
+    The Stop guard now nudges only when the branch has authored work (commits
+    ahead of base) and no current ``.wade/done@<HEAD>`` marker — so a real repo
+    is required to exercise the block path (a plain temp dir has no git facts and
+    fails open).
+    """
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
+
+    root.mkdir(parents=True, exist_ok=True)
+    git("init", "-b", "main")
+    git("config", "user.email", "t@e.st")
+    git("config", "user.name", "T")
+    (root / "base.txt").write_text("base\n")
+    git("add", "-A")
+    git("commit", "-m", "base")
+    git("checkout", "-b", "feat/1-x")
+    (root / "work.txt").write_text("work\n")
+    git("add", "-A")
+    git("commit", "-m", "work")
+
+
 class TestWorktreeGuardCLI:
     def test_inside_allows_exit_zero_clean_stdout(self) -> None:
         r = _run(
@@ -187,14 +212,16 @@ class TestStopGuardCLI:
     def _run_stop(self, tool: str, stdin: str, root: str):
         return _run("stop", "session-complete", tool, stdin, root=root)
 
-    def test_blocks_when_pr_summary_missing(self, tmp_path: Path) -> None:
+    def test_blocks_when_work_and_no_done_marker(self, tmp_path: Path) -> None:
+        _make_ahead_repo(tmp_path)
         r = self._run_stop("claude", json.dumps({"stop_hook_active": False}), str(tmp_path))
         assert r.returncode == 0  # Stop blocks via the JSON decision, not exit code
         payload = json.loads(r.stdout)
         assert payload["decision"] == "block"
-        assert "PR-SUMMARY.md" in payload["reason"]
+        assert "done" in payload["reason"]
 
     def test_cursor_uses_followup_message(self, tmp_path: Path) -> None:
+        _make_ahead_repo(tmp_path)
         r = self._run_stop("cursor", json.dumps({"stop_hook_active": False}), str(tmp_path))
         assert r.returncode == 0
         assert "followup_message" in json.loads(r.stdout)
@@ -214,7 +241,8 @@ class TestStopGuardCLI:
         assert json.loads(r.stdout) == {"continue": True}
 
     def test_marker_makes_nudge_single_shot_across_tools(self, tmp_path: Path) -> None:
-        # First Stop (no summary, no marker) blocks and writes the .wade marker...
+        _make_ahead_repo(tmp_path)
+        # First Stop (work ahead, no done marker) blocks and writes the .wade marker...
         r1 = self._run_stop("claude", json.dumps({}), str(tmp_path))
         assert json.loads(r1.stdout)["decision"] == "block"
         assert (tmp_path / ".wade" / "stop-nudged").is_file()
@@ -228,7 +256,7 @@ class TestStopGuardCLI:
         # If .wade is a symlink out of the worktree, the marker write must refuse
         # rather than truncate a file outside the worktree.
         wt = tmp_path / "wt"
-        wt.mkdir()
+        _make_ahead_repo(wt)
         outside = tmp_path / "outside"
         outside.mkdir()
         (wt / ".wade").symlink_to(outside)
@@ -236,16 +264,28 @@ class TestStopGuardCLI:
         assert json.loads(r.stdout)["decision"] == "block"  # still nudges
         assert not (outside / "stop-nudged").exists()  # but never wrote outside
 
-    def test_allows_when_pr_summary_present(self, tmp_path: Path) -> None:
-        (tmp_path / "PR-SUMMARY.md").write_text("done")
+    def test_allows_when_no_commits_ahead(self, tmp_path: Path) -> None:
+        # A repo sitting on main with no authored work ahead of base: nothing to
+        # finalize, so the Stop guard allows (adopts #318's higher-signal check).
+        def git(*args: str) -> None:
+            subprocess.run(
+                ["git", "-C", str(tmp_path), *args], check=True, capture_output=True, text=True
+            )
+
+        git("init", "-b", "main")
+        git("config", "user.email", "t@e.st")
+        git("config", "user.name", "T")
+        (tmp_path / "base.txt").write_text("base\n")
+        git("add", "-A")
+        git("commit", "-m", "base")
         r = self._run_stop("claude", json.dumps({"stop_hook_active": False}), str(tmp_path))
         assert r.returncode == 0
         assert json.loads(r.stdout) == {"continue": True}
 
     def test_codex_noop_emits_valid_json_not_empty(self, tmp_path: Path) -> None:
         # Codex rejects an empty-stdout Stop hook ("invalid stop hook JSON
-        # output"), so a clean stop on Codex must emit {"continue": true}.
-        (tmp_path / "PR-SUMMARY.md").write_text("done")
+        # output"), so a clean stop on Codex must emit {"continue": true}. A plain
+        # temp dir has no git facts, so the guard fails open (allow) here.
         r = self._run_stop("codex", json.dumps({}), str(tmp_path))
         assert r.returncode == 0
         assert r.stdout != ""
@@ -294,6 +334,7 @@ class TestLeanEntryParity:
         assert json.loads(lean.stdout)["permission"] == "deny"
 
     def test_stop_block_via_lean_entry(self, tmp_path: Path) -> None:
+        _make_ahead_repo(tmp_path)
         r = _run_lean(
             "stop",
             "session-complete",
@@ -421,6 +462,7 @@ class TestPerToolDialectsMatchCrossby:
 
     def test_copilot_stop_hook_blocks(self, tmp_path: Path) -> None:
         """Copilot gained supports_stop_hook in 0.13 — its Stop must actually block."""
+        _make_ahead_repo(tmp_path)
         r = _run_lean("stop", "session-complete", "copilot", "{}", str(tmp_path))
         assert r.returncode == 0
         assert json.loads(r.stdout)["decision"] == "block"

--- a/tests/unit/test_hooks/test_policies.py
+++ b/tests/unit/test_hooks/test_policies.py
@@ -415,14 +415,26 @@ class TestPlanArtifactOnly:
 
 
 class TestSessionComplete:
-    def test_blocks_when_pr_summary_missing(self, tmp_path: Path) -> None:
-        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path)
+    def test_blocks_when_work_and_no_done_marker(self, tmp_path: Path) -> None:
+        # Commits ahead of base + no done marker + no nudge -> nudge to run `done`.
+        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path, commits_ahead=1)
         assert d.action == "deny"  # deny == block the stop
-        assert "PR-SUMMARY.md" in d.reason
+        assert "done" in d.reason
+        assert "PR-SUMMARY" not in d.reason  # split-brain gone
 
-    def test_allows_when_pr_summary_present(self, tmp_path: Path) -> None:
-        (tmp_path / "PR-SUMMARY.md").write_text("done")
-        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path)
+    def test_allows_when_no_commits_ahead(self, tmp_path: Path) -> None:
+        # No authored work to finalize (#318 higher-signal condition).
+        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path, commits_ahead=0)
+        assert d.action == "allow"
+
+    def test_allows_when_done_marker_present(self, tmp_path: Path) -> None:
+        # The session was already finalized via `done` — same completion fact.
+        d = session_complete(
+            HookEvent(event="stop"),
+            worktree_root=tmp_path,
+            commits_ahead=1,
+            done_marker_present=True,
+        )
         assert d.action == "allow"
 
     def test_allows_when_nudge_marker_present(self, tmp_path: Path) -> None:
@@ -433,7 +445,7 @@ class TestSessionComplete:
         marker = stop_nudge_marker_path(tmp_path)
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.write_text("")
-        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path)
+        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path, commits_ahead=1)
         assert d.action == "allow"
 
     def test_symlinked_marker_not_trusted(self, tmp_path: Path) -> None:
@@ -445,7 +457,7 @@ class TestSessionComplete:
         marker = stop_nudge_marker_path(tmp_path)
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.symlink_to(real)
-        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path)
+        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path, commits_ahead=1)
         assert d.action == "deny"
 
     def test_symlinked_wade_dir_not_trusted(self, tmp_path: Path) -> None:
@@ -454,10 +466,14 @@ class TestSessionComplete:
         outside.mkdir()
         (outside / "stop-nudged").write_text("")
         (tmp_path / ".wade").symlink_to(outside)
-        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path)
+        d = session_complete(HookEvent(event="stop"), worktree_root=tmp_path, commits_ahead=1)
         assert d.action == "deny"
 
     def test_single_shot_allows_when_already_fired(self, tmp_path: Path) -> None:
-        # PR-SUMMARY.md still missing, but a Stop hook already fired -> never loop.
-        d = session_complete(HookEvent(event="stop", stop_hook_active=True), worktree_root=tmp_path)
+        # Work still unfinished, but a Stop hook already fired -> never loop.
+        d = session_complete(
+            HookEvent(event="stop", stop_hook_active=True),
+            worktree_root=tmp_path,
+            commits_ahead=1,
+        )
         assert d.action == "allow"

--- a/tests/unit/test_services/test_bootstrap_pre_push.py
+++ b/tests/unit/test_services/test_bootstrap_pre_push.py
@@ -25,7 +25,9 @@ def _run(tmp_path: Path, *, plan_mode: bool, backstop: bool):
 class TestBootstrapPrePushBackstop:
     def test_installed_for_implementation_session(self, tmp_path: Path) -> None:
         mock_install = _run(tmp_path, plan_mode=False, backstop=True)
-        mock_install.assert_called_once()
+        # Assert the target too: a refactor must not pass the repo root instead
+        # of the worktree path.
+        mock_install.assert_called_once_with(tmp_path / "wt")
 
     def test_not_installed_in_plan_mode(self, tmp_path: Path) -> None:
         mock_install = _run(tmp_path, plan_mode=True, backstop=True)
@@ -40,10 +42,13 @@ class TestBootstrapPrePushBackstop:
         wt.mkdir()
         repo = tmp_path / "repo"
         repo.mkdir()
-        config = ProjectConfig(project=ProjectSettings())
+        # Enable the backstop explicitly so this exercises the failure path
+        # regardless of the DoneConfig default.
+        config = ProjectConfig(project=ProjectSettings(), done=DoneConfig(pre_push_backstop=True))
         with patch(
             "wade.skills.installer.install_pre_push_backstop",
             side_effect=RuntimeError("boom"),
-        ):
+        ) as mock_install:
             # A backstop install error must never crash bootstrap.
             bootstrap_worktree(wt, config, repo, plan_mode=False)
+        mock_install.assert_called_once_with(wt)

--- a/tests/unit/test_services/test_bootstrap_pre_push.py
+++ b/tests/unit/test_services/test_bootstrap_pre_push.py
@@ -1,0 +1,49 @@
+"""Tests that bootstrap installs the pre-push backstop for the right sessions (#349)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from wade.models.config import DoneConfig, ProjectConfig, ProjectSettings
+from wade.services.implementation_service import bootstrap_worktree
+
+
+def _run(tmp_path: Path, *, plan_mode: bool, backstop: bool):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = ProjectConfig(project=ProjectSettings(), done=DoneConfig(pre_push_backstop=backstop))
+    with patch(
+        "wade.skills.installer.install_pre_push_backstop", return_value=True
+    ) as mock_install:
+        bootstrap_worktree(wt, config, repo, plan_mode=plan_mode)
+    return mock_install
+
+
+class TestBootstrapPrePushBackstop:
+    def test_installed_for_implementation_session(self, tmp_path: Path) -> None:
+        mock_install = _run(tmp_path, plan_mode=False, backstop=True)
+        mock_install.assert_called_once()
+
+    def test_not_installed_in_plan_mode(self, tmp_path: Path) -> None:
+        mock_install = _run(tmp_path, plan_mode=True, backstop=True)
+        mock_install.assert_not_called()
+
+    def test_not_installed_when_config_disabled(self, tmp_path: Path) -> None:
+        mock_install = _run(tmp_path, plan_mode=False, backstop=False)
+        mock_install.assert_not_called()
+
+    def test_install_failure_does_not_crash_bootstrap(self, tmp_path: Path) -> None:
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        config = ProjectConfig(project=ProjectSettings())
+        with patch(
+            "wade.skills.installer.install_pre_push_backstop",
+            side_effect=RuntimeError("boom"),
+        ):
+            # A backstop install error must never crash bootstrap.
+            bootstrap_worktree(wt, config, repo, plan_mode=False)

--- a/tests/unit/test_services/test_check.py
+++ b/tests/unit/test_services/test_check.py
@@ -217,6 +217,15 @@ class TestValidateConfig:
         assert result.exit_code == ConfigExitCode.INVALID
         assert any("done.require_sync" in e and "true or false" in e for e in result.errors)
 
+    def test_null_done_value_rejected(self, tmp_path: Path) -> None:
+        # An explicit null (`require_sync:` with no value) is a user mistake, not
+        # an unset default — `wade check` must flag it as a non-bool.
+        config = tmp_path / ".wade.yml"
+        config.write_text("version: 2\ndone:\n  require_sync:\n")
+        result = validate_config(tmp_path)
+        assert result.exit_code == ConfigExitCode.INVALID
+        assert any("done.require_sync" in e and "true or false" in e for e in result.errors)
+
     def test_valid_full_config(self, tmp_path: Path) -> None:
         config = tmp_path / ".wade.yml"
         config.write_text(

--- a/tests/unit/test_services/test_check.py
+++ b/tests/unit/test_services/test_check.py
@@ -189,6 +189,34 @@ class TestValidateConfig:
         result = validate_config(tmp_path)
         assert result.is_valid, f"Errors: {result.errors}"
 
+    def test_valid_done_section(self, tmp_path: Path) -> None:
+        config = tmp_path / ".wade.yml"
+        config.write_text(
+            "version: 2\n"
+            "done:\n"
+            "  require_pr_summary: true\n"
+            "  require_sync: false\n"
+            "  require_review: true\n"
+            "  require_resolved_threads: false\n"
+            "  pre_push_backstop: true\n"
+        )
+        result = validate_config(tmp_path)
+        assert result.is_valid, f"Errors: {result.errors}"
+
+    def test_unknown_done_key_rejected(self, tmp_path: Path) -> None:
+        config = tmp_path / ".wade.yml"
+        config.write_text("version: 2\ndone:\n  require_everything: true\n")
+        result = validate_config(tmp_path)
+        assert result.exit_code == ConfigExitCode.INVALID
+        assert any("done.require_everything" in e for e in result.errors)
+
+    def test_non_bool_done_value_rejected(self, tmp_path: Path) -> None:
+        config = tmp_path / ".wade.yml"
+        config.write_text("version: 2\ndone:\n  require_sync: sometimes\n")
+        result = validate_config(tmp_path)
+        assert result.exit_code == ConfigExitCode.INVALID
+        assert any("done.require_sync" in e and "true or false" in e for e in result.errors)
+
     def test_valid_full_config(self, tmp_path: Path) -> None:
         config = tmp_path / ".wade.yml"
         config.write_text(

--- a/tests/unit/test_services/test_done_gates.py
+++ b/tests/unit/test_services/test_done_gates.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from wade.git import branch as git_branch
 from wade.models.config import AICommandConfig, AIConfig, DoneConfig, ProjectConfig, ProjectSettings
@@ -18,6 +18,7 @@ from wade.services.implementation_service.done import (
     _gate_review_ran,
     _gate_sync,
     _is_placeholder_pr_summary,
+    _run_completion_gates,
 )
 from wade.utils import markers
 
@@ -264,3 +265,54 @@ class TestSyncGate:
     def test_hatch_disables_gate(self, tmp_path: Path) -> None:
         config = self._config(require=False)
         assert _gate_sync(config, tmp_path, tmp_path, "feat", "main", "implementation") is True
+
+
+# ---------------------------------------------------------------------------
+# _run_completion_gates dispatch order (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+class TestRunCompletionGatesOrder:
+    """Pin the fixed gate order per session type.
+
+    The order is load-bearing: review-ran must run against the pre-sync HEAD
+    *before* the sync gate can advance it, and review sessions must run the
+    unresolved-threads gate first. Testing each gate in isolation would not catch
+    a reordering of the calls inside ``_run_completion_gates``.
+    """
+
+    def _order(self, session_type: str) -> list[str]:
+        calls: list[str] = []
+
+        def _record(name: str):
+            return lambda *a, **k: (calls.append(name), True)[1]
+
+        with (
+            patch.object(done_mod, "_gate_pr_summary", side_effect=_record("pr_summary")),
+            patch.object(
+                done_mod, "_gate_resolved_threads", side_effect=_record("resolved_threads")
+            ),
+            patch.object(done_mod, "_gate_review_ran", side_effect=_record("review_ran")),
+            patch.object(done_mod, "_gate_sync", side_effect=_record("sync")),
+        ):
+            assert (
+                _run_completion_gates(
+                    session_type=session_type,
+                    config=ProjectConfig(),
+                    provider=MagicMock(),
+                    repo_root=Path("/repo"),
+                    worktree_root=Path("/wt"),
+                    branch="feat/x",
+                    main_branch="main",
+                    pre_sync_head="abc123",
+                    skip_review=False,
+                )
+                is True
+            )
+        return calls
+
+    def test_implementation_runs_pr_summary_review_then_sync(self) -> None:
+        assert self._order("implementation") == ["pr_summary", "review_ran", "sync"]
+
+    def test_review_runs_threads_then_review_and_never_syncs(self) -> None:
+        assert self._order("review-pr-comments") == ["resolved_threads", "review_ran"]

--- a/tests/unit/test_services/test_done_gates.py
+++ b/tests/unit/test_services/test_done_gates.py
@@ -1,0 +1,266 @@
+"""Unit tests for the ``done`` completion gates and their escape hatches (#349)."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from wade.git import branch as git_branch
+from wade.models.config import AICommandConfig, AIConfig, DoneConfig, ProjectConfig, ProjectSettings
+from wade.models.review import ReviewComment, ReviewThread
+from wade.models.session import SyncResult
+from wade.services.implementation_service.done import (
+    _behind_count,
+    _gate_pr_summary,
+    _gate_resolved_threads,
+    _gate_review_ran,
+    _gate_sync,
+    _is_placeholder_pr_summary,
+)
+from wade.utils import markers
+
+# The package re-exports the ``done``/``sync`` *functions*, shadowing the
+# submodule attributes, so import the module objects explicitly for patching.
+done_mod = importlib.import_module("wade.services.implementation_service.done")
+sync_mod = importlib.import_module("wade.services.implementation_service.sync")
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
+
+
+# ---------------------------------------------------------------------------
+# PR-SUMMARY gate
+# ---------------------------------------------------------------------------
+
+
+class TestPrSummaryGate:
+    def _config(self, *, require: bool = True) -> ProjectConfig:
+        return ProjectConfig(done=DoneConfig(require_pr_summary=require))
+
+    def test_refuses_when_missing(self, tmp_path: Path) -> None:
+        assert _gate_pr_summary(self._config(), tmp_path) is False
+
+    def test_passes_with_real_summary(self, tmp_path: Path) -> None:
+        (tmp_path / "PR-SUMMARY.md").write_text("## Summary\n\nReal work was done here.\n")
+        assert _gate_pr_summary(self._config(), tmp_path) is True
+
+    def test_refuses_on_placeholder(self, tmp_path: Path) -> None:
+        (tmp_path / "PR-SUMMARY.md").write_text(
+            "## What was done\n[High-level summary in 2-3 sentences]\n"
+        )
+        assert _gate_pr_summary(self._config(), tmp_path) is False
+
+    def test_hatch_disables_gate(self, tmp_path: Path) -> None:
+        # No PR-SUMMARY.md at all, but the hatch is off → gate passes.
+        assert _gate_pr_summary(self._config(require=False), tmp_path) is True
+
+
+class TestPlaceholderDetection:
+    def test_empty_is_placeholder(self) -> None:
+        assert _is_placeholder_pr_summary("   \n  ") is True
+
+    def test_headings_only_is_placeholder(self) -> None:
+        assert _is_placeholder_pr_summary("## Summary\n\n## Changes\n\n---\n") is True
+
+    def test_bracket_placeholder_detected(self) -> None:
+        assert _is_placeholder_pr_summary("## Notes\n[Optional: anything]\n") is True
+
+    def test_real_prose_not_placeholder(self) -> None:
+        assert _is_placeholder_pr_summary("## Summary\n\nAdded the gate and tests.\n") is False
+
+    def test_bullet_list_not_placeholder(self) -> None:
+        assert _is_placeholder_pr_summary("## Changes\n\n- Added X\n- Fixed Y\n") is False
+
+
+# ---------------------------------------------------------------------------
+# review-ran gate
+# ---------------------------------------------------------------------------
+
+
+class TestReviewRanGate:
+    def test_refuses_without_marker(self, tmp_path: Path) -> None:
+        assert _gate_review_ran(ProjectConfig(), tmp_path, "abc123", skip_review=False) is False
+
+    def test_passes_with_marker(self, tmp_path: Path) -> None:
+        markers.write_marker(tmp_path, "reviewed", "abc123")
+        assert _gate_review_ran(ProjectConfig(), tmp_path, "abc123", skip_review=False) is True
+
+    def test_marker_for_other_sha_refuses(self, tmp_path: Path) -> None:
+        markers.write_marker(tmp_path, "reviewed", "old")
+        assert _gate_review_ran(ProjectConfig(), tmp_path, "new", skip_review=False) is False
+
+    def test_skip_review_hatch(self, tmp_path: Path) -> None:
+        assert _gate_review_ran(ProjectConfig(), tmp_path, "abc", skip_review=True) is True
+
+    def test_require_review_hatch(self, tmp_path: Path) -> None:
+        config = ProjectConfig(done=DoneConfig(require_review=False))
+        assert _gate_review_ran(config, tmp_path, "abc", skip_review=False) is True
+
+    def test_auto_skipped_when_reviews_disabled(self, tmp_path: Path) -> None:
+        config = ProjectConfig(
+            ai=AIConfig(review_implementation=AICommandConfig(enabled=False)),
+        )
+        assert _gate_review_ran(config, tmp_path, "abc", skip_review=False) is True
+
+
+# ---------------------------------------------------------------------------
+# review-thread gate (review-pr-comments sessions)
+# ---------------------------------------------------------------------------
+
+
+def _thread(resolved: bool) -> ReviewThread:
+    return ReviewThread(id="t1", is_resolved=resolved, comments=[ReviewComment(body="please fix")])
+
+
+class TestResolvedThreadsGate:
+    def _provider(self, threads: list[ReviewThread] | Exception) -> MagicMock:
+        provider = MagicMock()
+        if isinstance(threads, Exception):
+            provider.get_pr_review_threads.side_effect = threads
+        else:
+            provider.get_pr_review_threads.return_value = threads
+        return provider
+
+    def _lookup(self, *, open_: bool = True) -> MagicMock:
+        lookup = MagicMock()
+        lookup.lookup_failed = False
+        lookup.is_open = open_
+        lookup.pr = MagicMock(number=7) if open_ else None
+        return lookup
+
+    def test_refuses_on_unresolved(self, monkeypatch, tmp_path: Path) -> None:
+        provider = self._provider([_thread(resolved=False)])
+        monkeypatch.setattr(done_mod.git_pr, "get_pr_for_branch", lambda *a, **k: self._lookup())
+        assert _gate_resolved_threads(ProjectConfig(), provider, tmp_path, "feat/x") is False
+
+    def test_passes_when_all_resolved(self, monkeypatch, tmp_path: Path) -> None:
+        provider = self._provider([_thread(resolved=True)])
+        monkeypatch.setattr(done_mod.git_pr, "get_pr_for_branch", lambda *a, **k: self._lookup())
+        assert _gate_resolved_threads(ProjectConfig(), provider, tmp_path, "feat/x") is True
+
+    def test_transient_fetch_failure_non_blocking(self, monkeypatch, tmp_path: Path) -> None:
+        provider = self._provider(RuntimeError("gh boom"))
+        monkeypatch.setattr(done_mod.git_pr, "get_pr_for_branch", lambda *a, **k: self._lookup())
+        # A flaky provider must not trap completion.
+        assert _gate_resolved_threads(ProjectConfig(), provider, tmp_path, "feat/x") is True
+
+    def test_lookup_failure_non_blocking(self, monkeypatch, tmp_path: Path) -> None:
+        lookup = MagicMock(lookup_failed=True, is_open=False, pr=None)
+        monkeypatch.setattr(done_mod.git_pr, "get_pr_for_branch", lambda *a, **k: lookup)
+        assert _gate_resolved_threads(ProjectConfig(), MagicMock(), tmp_path, "feat/x") is True
+
+    def test_hatch_disables_gate(self, tmp_path: Path) -> None:
+        config = ProjectConfig(done=DoneConfig(require_resolved_threads=False))
+        # No provider call should be needed when the gate is off.
+        assert _gate_resolved_threads(config, MagicMock(), tmp_path, "feat/x") is True
+
+
+# ---------------------------------------------------------------------------
+# sync gate + commits_ahead argument-order (both call sites)
+# ---------------------------------------------------------------------------
+
+
+def _repo_ahead_and_behind(root: Path) -> None:
+    """Repo where ``feat`` is 2 commits ahead of ``main`` and 1 behind it."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@e.st")
+    _git(root, "config", "user.name", "T")
+    (root / "m1.txt").write_text("m1\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "m1")
+    _git(root, "checkout", "-b", "feat")
+    for name in ("f1", "f2"):
+        (root / f"{name}.txt").write_text(f"{name}\n")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-m", name)
+    _git(root, "checkout", "main")
+    (root / "m2.txt").write_text("m2\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "m2")
+    _git(root, "checkout", "feat")
+
+
+class TestCommitsAheadArgumentOrder:
+    """Pin the OPPOSITE role assignments used by the sync gate vs the Stop hook."""
+
+    def test_commits_ahead_semantics(self, tmp_path: Path) -> None:
+        repo = tmp_path / "r"
+        _repo_ahead_and_behind(repo)
+        # branch-in-branch-position → how far AHEAD feat is of main.
+        assert git_branch.commits_ahead(repo, "feat", "main") == 2
+        # base-in-branch-position → how far BEHIND feat is of main.
+        assert git_branch.commits_ahead(repo, "main", "feat") == 1
+
+    def test_behind_count_uses_base_in_branch_position(self, tmp_path: Path) -> None:
+        # The sync gate measures "behind" — origin/<main> (falls back to <main>)
+        # in the branch position.
+        repo = tmp_path / "r"
+        _repo_ahead_and_behind(repo)
+        assert _behind_count(repo, "main", "feat") == 1
+
+    def test_stop_hook_ahead_count_opposite_order(self, tmp_path: Path) -> None:
+        # The Stop hook measures "ahead" — the session branch in the branch
+        # position (the opposite ref order from the sync gate).
+        from wade.hooks.cli import _stop_git_facts
+
+        repo = tmp_path / "r"
+        _repo_ahead_and_behind(repo)
+        ahead, done_present = _stop_git_facts(repo)
+        assert ahead == 2
+        assert done_present is False
+
+
+class TestSyncGate:
+    def _config(self, *, require: bool = True) -> ProjectConfig:
+        return ProjectConfig(
+            project=ProjectSettings(main_branch="main"), done=DoneConfig(require_sync=require)
+        )
+
+    def test_passes_when_up_to_date(self, tmp_path: Path, monkeypatch) -> None:
+        # main == branch tip → behind 0 → gate passes without syncing.
+        repo = tmp_path / "r"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "t@e.st")
+        _git(repo, "config", "user.name", "T")
+        (repo / "a.txt").write_text("a\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "a")
+        _git(repo, "checkout", "-b", "feat")
+        monkeypatch.setattr(done_mod.git_sync, "fetch_origin", lambda *a, **k: None)
+        assert _gate_sync(self._config(), repo, repo, "feat", "main", "implementation") is True
+
+    def test_auto_syncs_when_behind(self, tmp_path: Path, monkeypatch) -> None:
+        repo = tmp_path / "r"
+        _repo_ahead_and_behind(repo)  # feat is 1 behind main
+        monkeypatch.setattr(done_mod.git_sync, "fetch_origin", lambda *a, **k: None)
+        called = {}
+
+        def _fake_sync(**kwargs: object) -> SyncResult:
+            called.update(kwargs)
+            return SyncResult(success=True, current_branch="feat", main_branch="main")
+
+        monkeypatch.setattr(sync_mod, "sync", _fake_sync)
+        assert _gate_sync(self._config(), repo, repo, "feat", "main", "implementation") is True
+        assert called["main_branch"] == "main"
+
+    def test_refuses_on_conflict(self, tmp_path: Path, monkeypatch) -> None:
+        repo = tmp_path / "r"
+        _repo_ahead_and_behind(repo)
+        monkeypatch.setattr(done_mod.git_sync, "fetch_origin", lambda *a, **k: None)
+
+        def _conflict_sync(**kwargs: object) -> SyncResult:
+            return SyncResult(
+                success=False, current_branch="feat", main_branch="main", conflicts=["a.txt"]
+            )
+
+        monkeypatch.setattr(sync_mod, "sync", _conflict_sync)
+        assert _gate_sync(self._config(), repo, repo, "feat", "main", "implementation") is False
+
+    def test_hatch_disables_gate(self, tmp_path: Path) -> None:
+        config = self._config(require=False)
+        assert _gate_sync(config, tmp_path, tmp_path, "feat", "main", "implementation") is True

--- a/tests/unit/test_services/test_done_idempotent.py
+++ b/tests/unit/test_services/test_done_idempotent.py
@@ -37,6 +37,10 @@ def _run_done(tmp_path: Path, *, pr_result: bool) -> MagicMock:
         stack.enter_context(patch(f"{_DONE}.git_repo.is_clean", return_value=True))
         stack.enter_context(patch(f"{_DONE}._check_tracked_managed_files", return_value=[]))
         stack.enter_context(patch(f"{_DONE}.git_repo.unskip_worktree_file"))
+        # This test isolates strip-deferral behavior; the completion gates have
+        # their own tests, so stub them out (and the HEAD read they precede).
+        stack.enter_context(patch(f"{_DONE}.git_repo.rev_parse", return_value="deadbeef"))
+        stack.enter_context(patch(f"{_DONE}._run_completion_gates", return_value=True))
         strip = stack.enter_context(patch(f"{_DONE}.strip_worktree_gitignore"))
         stack.enter_context(patch(f"{_DONE}._done_via_pr", return_value=pr_result))
         stack.enter_context(patch(f"{_DONE}.console"))
@@ -80,6 +84,8 @@ class TestDoneDefersStrip:
             stack.enter_context(patch(f"{_DONE}.git_repo.is_clean", return_value=True))
             stack.enter_context(patch(f"{_DONE}._check_tracked_managed_files", return_value=[]))
             stack.enter_context(patch(f"{_DONE}.git_repo.unskip_worktree_file"))
+            stack.enter_context(patch(f"{_DONE}.git_repo.rev_parse", return_value="deadbeef"))
+            stack.enter_context(patch(f"{_DONE}._run_completion_gates", return_value=True))
             stack.enter_context(
                 patch(f"{_DONE}.strip_worktree_gitignore", side_effect=OSError("read-only fs"))
             )

--- a/tests/unit/test_services/test_done_plan_flag.py
+++ b/tests/unit/test_services/test_done_plan_flag.py
@@ -106,6 +106,10 @@ def test_done_with_plan_flag_resolves_and_delegates() -> None:
         ),
         patch("wade.services.implementation_service.done.git_repo.is_clean", return_value=True),
         patch(
+            "wade.services.implementation_service.done.git_repo.rev_parse", return_value="deadbeef"
+        ),
+        patch("wade.services.implementation_service.done._run_completion_gates", return_value=True),
+        patch(
             "wade.services.implementation_service.done._done_via_pr", return_value=True
         ) as mock_done,
     ):
@@ -150,6 +154,8 @@ def test_cli_plan_flag_passes_to_service() -> None:
         plan_file=Path("/tmp/PLAN.md"),
         no_close=False,
         draft=False,
+        session_type="implementation",
+        skip_review=False,
     )
 
 

--- a/tests/unit/test_services/test_implementation_done_sync.py
+++ b/tests/unit/test_services/test_implementation_done_sync.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 from crossby.models.ai import TokenUsage
 
 from wade.git.repo import GitError
-from wade.models.config import ProjectConfig, ProjectSettings
+from wade.models.config import DoneConfig, ProjectConfig, ProjectSettings
 from wade.models.session import WorktreeState
 from wade.models.task import Task, TaskState
 from wade.services.implementation_service import (
@@ -1303,6 +1303,13 @@ class TestDone:
                 "wade.services.implementation_service.done.load_config",
                 return_value=ProjectConfig(
                     project=ProjectSettings(main_branch="main"),
+                    # Disable the completion gates — this test asserts base-branch
+                    # resolution, not gate behavior (gates are tested separately).
+                    done=DoneConfig(
+                        require_pr_summary=False,
+                        require_sync=False,
+                        require_review=False,
+                    ),
                 ),
             ),
             patch(

--- a/tests/unit/test_services/test_pre_push_backstop.py
+++ b/tests/unit/test_services/test_pre_push_backstop.py
@@ -101,6 +101,22 @@ class TestHookMarkerGate:
         r = _run_hook(wt, stdin)
         assert r.returncode == 0
 
+    def test_refuses_when_marker_is_for_an_older_sha(self, tmp_path: Path) -> None:
+        # The core invariant is sha-keying: a marker written for an earlier
+        # commit must not authorize a push of a newer commit.
+        _main, wt, branch = _main_and_worktree(tmp_path)
+        install_pre_push_backstop(wt)
+        old_head = _head(wt)
+        markers.write_marker(wt, "done", old_head)
+        (wt / "b.txt").write_text("b\n")
+        _git(wt, "add", "-A")
+        _git(wt, "commit", "-m", "b")
+        new_head = _head(wt)
+        stdin = f"refs/heads/{branch} {new_head} refs/heads/{branch} {_ZERO}\n"
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 1
+        assert new_head in r.stderr
+
     def test_other_ref_not_gated(self, tmp_path: Path) -> None:
         _main, wt, _branch = _main_and_worktree(tmp_path)
         install_pre_push_backstop(wt)
@@ -119,6 +135,38 @@ class TestChaining:
         prior.write_text(f"#!/usr/bin/env bash\ncat > '{record}'\nexit 0\n")
         prior.chmod(0o755)
         return prior
+
+    def _install_prior_hook_body(self, main: Path, body: str) -> Path:
+        hooks = main / ".git" / "hooks"
+        hooks.mkdir(parents=True, exist_ok=True)
+        prior = hooks / "pre-push"
+        prior.write_text(body)
+        prior.chmod(0o755)
+        return prior
+
+    def test_chained_hook_that_ignores_stdin_still_allows(self, tmp_path: Path) -> None:
+        # A prior hook that never reads stdin closes the pipe early. Under
+        # `pipefail` the writer's SIGPIPE must NOT mask the hook's 0 exit.
+        main, wt, branch = _main_and_worktree(tmp_path)
+        self._install_prior_hook_body(main, "#!/usr/bin/env bash\nexit 0\n")
+        install_pre_push_backstop(wt)
+        head = _head(wt)
+        markers.write_marker(wt, "done", head)
+        stdin = f"refs/heads/{branch} {head} refs/heads/{branch} {_ZERO}\n"
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 0, r.stderr
+
+    def test_chained_hook_failure_is_propagated(self, tmp_path: Path) -> None:
+        # The mirror case: a non-stdin-reading hook that fails must propagate its
+        # own status, not the writer's.
+        main, wt, branch = _main_and_worktree(tmp_path)
+        self._install_prior_hook_body(main, "#!/usr/bin/env bash\nexit 3\n")
+        install_pre_push_backstop(wt)
+        head = _head(wt)
+        markers.write_marker(wt, "done", head)
+        stdin = f"refs/heads/{branch} {head} refs/heads/{branch} {_ZERO}\n"
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 3
 
     def test_captures_and_chains_to_preexisting_hook(self, tmp_path: Path) -> None:
         main, wt, branch = _main_and_worktree(tmp_path)
@@ -177,3 +225,24 @@ class TestGracefulDegrade:
         monkeypatch.setattr(git_repo, "set_config_value", lambda *a, **k: False)
         # Must warn-and-skip (return False), never raise.
         assert install_pre_push_backstop(wt) is False
+
+    def test_rolls_back_extension_when_hookspath_write_fails(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Enabling extensions.worktreeConfig is a repo-WIDE change; if the
+        # follow-up worktree hooksPath write fails, it must be rolled back so a
+        # failed optional backstop leaves no persistent config behind.
+        _main, wt, _branch = _main_and_worktree(tmp_path)
+        assert git_repo.get_config_value(wt, "extensions.worktreeConfig") is None
+
+        real_set = git_repo.set_config_value
+
+        def fake_set(path: Path, key: str, value: str, *, worktree: bool = False) -> bool:
+            if key == "core.hooksPath":
+                return False  # simulate the worktree hooksPath write failing
+            return real_set(path, key, value, worktree=worktree)
+
+        monkeypatch.setattr(git_repo, "set_config_value", fake_set)
+        assert install_pre_push_backstop(wt) is False
+        # The extension was unset (prior value was None), not left enabled.
+        assert git_repo.get_config_value(wt, "extensions.worktreeConfig") is None

--- a/tests/unit/test_services/test_pre_push_backstop.py
+++ b/tests/unit/test_services/test_pre_push_backstop.py
@@ -1,0 +1,179 @@
+"""Tests for the per-worktree pre-push backstop install + hook behavior (#349)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from wade.git import repo as git_repo
+from wade.skills.installer import install_pre_push_backstop
+from wade.utils import markers
+
+_ZERO = "0" * 40
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _main_and_worktree(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Build a main checkout + a linked worktree on ``feat/1-x``."""
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "-b", "main")
+    _git(main, "config", "user.email", "t@e.st")
+    _git(main, "config", "user.name", "T")
+    (main / "a.txt").write_text("a\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-m", "a")
+    wt = tmp_path / "wt"
+    _git(main, "worktree", "add", "-b", "feat/1-x", str(wt))
+    return main, wt, "feat/1-x"
+
+
+def _head(root: Path) -> str:
+    return _git(root, "rev-parse", "HEAD")
+
+
+def _run_hook(wt: Path, stdin: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(wt / ".wade" / "githooks" / "pre-push"), "origin", "https://example/repo.git"],
+        cwd=str(wt),
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestInstallScoping:
+    def test_installs_worktree_scoped_hook(self, tmp_path: Path) -> None:
+        _main, wt, _branch = _main_and_worktree(tmp_path)
+        assert install_pre_push_backstop(wt) is True
+
+        hook = wt / ".wade" / "githooks" / "pre-push"
+        assert hook.is_file()
+        assert os.access(hook, os.X_OK)
+        assert git_repo.get_config_value(wt, "core.hooksPath", worktree=True) == ".wade/githooks"
+
+    def test_not_leaked_to_main_checkout(self, tmp_path: Path) -> None:
+        main, wt, _branch = _main_and_worktree(tmp_path)
+        install_pre_push_backstop(wt)
+        # The main checkout must not pick up the worktree-scoped hooksPath.
+        assert git_repo.get_config_value(main, "core.hooksPath") is None
+        assert git_repo.get_config_value(main, "core.hooksPath", worktree=True) is None
+
+    def test_not_leaked_to_sibling_worktree(self, tmp_path: Path) -> None:
+        main, wt, _branch = _main_and_worktree(tmp_path)
+        sib = tmp_path / "sib"
+        _git(main, "worktree", "add", "-b", "feat/2-y", str(sib))
+        install_pre_push_backstop(wt)
+        assert git_repo.get_config_value(sib, "core.hooksPath", worktree=True) is None
+        assert git_repo.get_config_value(sib, "core.hooksPath") is None
+
+
+class TestHookMarkerGate:
+    def test_refuses_without_marker(self, tmp_path: Path) -> None:
+        _main, wt, branch = _main_and_worktree(tmp_path)
+        install_pre_push_backstop(wt)
+        head = _head(wt)
+        stdin = f"refs/heads/{branch} {head} refs/heads/{branch} {_ZERO}\n"
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 1
+        assert "done@" in r.stderr
+
+    def test_allows_with_marker(self, tmp_path: Path) -> None:
+        _main, wt, branch = _main_and_worktree(tmp_path)
+        install_pre_push_backstop(wt)
+        head = _head(wt)
+        markers.write_marker(wt, "done", head)
+        stdin = f"refs/heads/{branch} {head} refs/heads/{branch} {_ZERO}\n"
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 0
+
+    def test_deletion_is_skipped(self, tmp_path: Path) -> None:
+        _main, wt, branch = _main_and_worktree(tmp_path)
+        install_pre_push_backstop(wt)
+        # local sha all-zero = branch deletion → nothing pushed, no marker needed.
+        stdin = f"refs/heads/{branch} {_ZERO} refs/heads/{branch} {_head(wt)}\n"
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 0
+
+    def test_other_ref_not_gated(self, tmp_path: Path) -> None:
+        _main, wt, _branch = _main_and_worktree(tmp_path)
+        install_pre_push_backstop(wt)
+        head = _head(wt)
+        # A ref that isn't the session branch (e.g. a tag push) passes ungated.
+        stdin = f"refs/tags/v1 {head} refs/tags/v1 {_ZERO}\n"
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 0
+
+
+class TestChaining:
+    def _install_prior_common_hook(self, main: Path, record: Path) -> Path:
+        hooks = main / ".git" / "hooks"
+        hooks.mkdir(parents=True, exist_ok=True)
+        prior = hooks / "pre-push"
+        prior.write_text(f"#!/usr/bin/env bash\ncat > '{record}'\nexit 0\n")
+        prior.chmod(0o755)
+        return prior
+
+    def test_captures_and_chains_to_preexisting_hook(self, tmp_path: Path) -> None:
+        main, wt, branch = _main_and_worktree(tmp_path)
+        record = tmp_path / "chained_stdin.txt"
+        prior = self._install_prior_common_hook(main, record)
+
+        install_pre_push_backstop(wt)
+        chain = (wt / ".wade" / "githooks" / ".chain").read_text().strip()
+        assert chain == str(prior.resolve())
+
+        head = _head(wt)
+        markers.write_marker(wt, "done", head)
+        stdin = f"refs/heads/{branch} {head} refs/heads/{branch} {_ZERO}\n"
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 0
+        # The chained hook ran and saw the buffered stdin.
+        assert record.read_text() == stdin
+
+    def test_multi_ref_push_forwards_all_buffered_stdin(self, tmp_path: Path) -> None:
+        main, wt, branch = _main_and_worktree(tmp_path)
+        record = tmp_path / "chained_stdin.txt"
+        self._install_prior_common_hook(main, record)
+        install_pre_push_backstop(wt)
+
+        head = _head(wt)
+        markers.write_marker(wt, "done", head)
+        # A `git push --all`-style multi-line stdin: the session branch + another
+        # ref. Only the session branch is gated; the full buffer must be forwarded.
+        stdin = (
+            f"refs/heads/{branch} {head} refs/heads/{branch} {_ZERO}\n"
+            f"refs/heads/other {head} refs/heads/other {_ZERO}\n"
+        )
+        r = _run_hook(wt, stdin)
+        assert r.returncode == 0
+        assert record.read_text() == stdin
+
+    def test_reinstall_does_not_self_chain(self, tmp_path: Path) -> None:
+        main, wt, _branch = _main_and_worktree(tmp_path)
+        record = tmp_path / "chained_stdin.txt"
+        prior = self._install_prior_common_hook(main, record)
+
+        install_pre_push_backstop(wt)
+        first = (wt / ".wade" / "githooks" / ".chain").read_text().strip()
+        # Re-run bootstrap install against the already-managed worktree.
+        install_pre_push_backstop(wt)
+        second = (wt / ".wade" / "githooks" / ".chain").read_text().strip()
+        # The chain target is captured once and never re-points at wade's own hook.
+        assert first == second == str(prior.resolve())
+        assert "githooks/pre-push" not in second
+
+
+class TestGracefulDegrade:
+    def test_skips_when_worktree_config_unsupported(self, tmp_path: Path, monkeypatch) -> None:
+        _main, wt, _branch = _main_and_worktree(tmp_path)
+        # Simulate old/locked-down git: worktree-scoped config writes fail.
+        monkeypatch.setattr(git_repo, "set_config_value", lambda *a, **k: False)
+        # Must warn-and-skip (return False), never raise.
+        assert install_pre_push_backstop(wt) is False

--- a/tests/unit/test_services/test_pre_push_backstop.py
+++ b/tests/unit/test_services/test_pre_push_backstop.py
@@ -246,3 +246,24 @@ class TestGracefulDegrade:
         assert install_pre_push_backstop(wt) is False
         # The extension was unset (prior value was None), not left enabled.
         assert git_repo.get_config_value(wt, "extensions.worktreeConfig") is None
+
+    def test_restores_prior_extension_when_hookspath_write_fails(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Mirror of the unset case: when extensions.worktreeConfig was ALREADY
+        # set (here "false"), the failed hooksPath write must restore that prior
+        # value rather than unset the key.
+        _main, wt, _branch = _main_and_worktree(tmp_path)
+        assert git_repo.set_config_value(wt, "extensions.worktreeConfig", "false")
+
+        real_set = git_repo.set_config_value
+
+        def fake_set(path: Path, key: str, value: str, *, worktree: bool = False) -> bool:
+            if key == "core.hooksPath":
+                return False  # simulate the worktree hooksPath write failing
+            return real_set(path, key, value, worktree=worktree)
+
+        monkeypatch.setattr(git_repo, "set_config_value", fake_set)
+        assert install_pre_push_backstop(wt) is False
+        # The extension was restored to its prior value, not unset.
+        assert git_repo.get_config_value(wt, "extensions.worktreeConfig") == "false"

--- a/tests/unit/test_services/test_push_recovery.py
+++ b/tests/unit/test_services/test_push_recovery.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from wade.git.repo import GitError
+from wade.models.session import SyncResult
 from wade.services.implementation_service.done import (
     _is_non_fast_forward,
     _push_branch_with_recovery,
@@ -86,14 +87,19 @@ class TestPushRecoveryMarkerLifecycle:
 
     def _patches(self, stack: ExitStack, *, is_tty: bool, select: int = 0) -> dict[str, MagicMock]:
         stack.enter_context(patch(f"{_DONE}.console"))
-        stack.enter_context(patch(f"{_DONE}.git_sync"))
+        mock_git_sync = stack.enter_context(patch(f"{_DONE}.git_sync"))
         stack.enter_context(patch(f"{_DONE}.git_branch.commits_ahead", return_value=1))
         mock_push = stack.enter_context(patch(f"{_DONE}.git_repo.push_branch"))
         stack.enter_context(patch(f"{_DONE}.prompts.is_tty", return_value=is_tty))
         stack.enter_context(patch(f"{_DONE}.prompts.select", return_value=select))
         mock_write = stack.enter_context(patch(f"{_DONE}._write_done_marker"))
         mock_markers = stack.enter_context(patch(f"{_DONE}.markers"))
-        return {"push": mock_push, "write": mock_write, "markers": mock_markers}
+        return {
+            "push": mock_push,
+            "write": mock_write,
+            "markers": mock_markers,
+            "git_sync": mock_git_sync,
+        }
 
     def test_recovery_merge_rewrites_marker_for_new_tip(self) -> None:
         # A recovery merge advances the branch tip, so the marker must be
@@ -120,6 +126,34 @@ class TestPushRecoveryMarkerLifecycle:
         with ExitStack() as stack:
             mocks = self._patches(stack, is_tty=True)
             mocks["push"].side_effect = GitError("fatal: authentication failed")
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/wt"))
+        assert result is False
+        mocks["markers"].clear_markers.assert_called_once_with(Path("/wt"), "done")
+
+    def test_recovery_merge_conflict_clears_marker(self) -> None:
+        # Merge-and-retry chosen, but the merge hits conflicts → nothing reached
+        # the remote, so the marker must be cleared.
+        with ExitStack() as stack:
+            mocks = self._patches(stack, is_tty=True, select=0)  # merge-and-retry
+            mocks["push"].side_effect = GitError("(non-fast-forward)")
+            mocks["git_sync"].merge_branch.return_value = SyncResult(
+                success=False,
+                current_branch="feat/1-x",
+                main_branch="origin/feat/1-x",
+                conflicts=["a.txt"],
+            )
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/wt"))
+        assert result is False
+        mocks["markers"].clear_markers.assert_called_once_with(Path("/wt"), "done")
+
+    def test_force_push_failure_clears_marker(self) -> None:
+        # Force-with-lease chosen, but the force push itself fails → clear marker.
+        with ExitStack() as stack:
+            mocks = self._patches(stack, is_tty=True, select=1)  # force-with-lease
+            mocks["push"].side_effect = [
+                GitError("(non-fast-forward)"),
+                GitError("remote rejected the force push"),
+            ]
             result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/wt"))
         assert result is False
         mocks["markers"].clear_markers.assert_called_once_with(Path("/wt"), "done")

--- a/tests/unit/test_services/test_push_recovery.py
+++ b/tests/unit/test_services/test_push_recovery.py
@@ -45,7 +45,7 @@ class TestPushRecovery:
     def test_clean_push_succeeds(self) -> None:
         with ExitStack() as stack:
             mocks = self._patches(stack, is_tty=True)
-            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None)
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/repo"))
         assert result is True
         mocks["push"].assert_called_once()
 
@@ -54,7 +54,7 @@ class TestPushRecovery:
             mocks = self._patches(stack, is_tty=False)
             # First push raises non-FF; no further push attempts in non-TTY.
             mocks["push"].side_effect = GitError("Updates were rejected (non-fast-forward)")
-            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None)
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/repo"))
         assert result is False
         assert mocks["push"].call_count == 1  # never force-pushed
 
@@ -66,7 +66,7 @@ class TestPushRecovery:
                 GitError("! [rejected] (non-fast-forward)"),
                 None,
             ]
-            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None)
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/repo"))
         assert result is True
         assert mocks["push"].call_count == 2
         _, kwargs = mocks["push"].call_args
@@ -76,6 +76,50 @@ class TestPushRecovery:
         with ExitStack() as stack:
             mocks = self._patches(stack, is_tty=True, select=2)  # choice 2 = cancel
             mocks["push"].side_effect = GitError("(non-fast-forward)")
-            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None)
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/repo"))
         assert result is False
         assert mocks["push"].call_count == 1  # only the initial attempt
+
+
+class TestPushRecoveryMarkerLifecycle:
+    """#349: the done-marker must track what actually reached the remote."""
+
+    def _patches(self, stack: ExitStack, *, is_tty: bool, select: int = 0) -> dict[str, MagicMock]:
+        stack.enter_context(patch(f"{_DONE}.console"))
+        stack.enter_context(patch(f"{_DONE}.git_sync"))
+        stack.enter_context(patch(f"{_DONE}.git_branch.commits_ahead", return_value=1))
+        mock_push = stack.enter_context(patch(f"{_DONE}.git_repo.push_branch"))
+        stack.enter_context(patch(f"{_DONE}.prompts.is_tty", return_value=is_tty))
+        stack.enter_context(patch(f"{_DONE}.prompts.select", return_value=select))
+        mock_write = stack.enter_context(patch(f"{_DONE}._write_done_marker"))
+        mock_markers = stack.enter_context(patch(f"{_DONE}.markers"))
+        return {"push": mock_push, "write": mock_write, "markers": mock_markers}
+
+    def test_recovery_merge_rewrites_marker_for_new_tip(self) -> None:
+        # A recovery merge advances the branch tip, so the marker must be
+        # re-written before the retry push — else the backstop rejects it.
+        with ExitStack() as stack:
+            mocks = self._patches(stack, is_tty=True, select=0)  # merge-and-retry
+            mocks["push"].side_effect = [GitError("(non-fast-forward)"), None]
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/wt"))
+        assert result is True
+        # Written twice: before the initial push, and again after the merge.
+        assert mocks["write"].call_count == 2
+        mocks["markers"].clear_markers.assert_not_called()
+
+    def test_push_failure_clears_marker(self) -> None:
+        # If nothing reached the remote, no stale done@<sha> may linger.
+        with ExitStack() as stack:
+            mocks = self._patches(stack, is_tty=False)  # non-FF then non-TTY bail-out
+            mocks["push"].side_effect = GitError("(non-fast-forward)")
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/wt"))
+        assert result is False
+        mocks["markers"].clear_markers.assert_called_once_with(Path("/wt"), "done")
+
+    def test_non_recoverable_push_failure_clears_marker(self) -> None:
+        with ExitStack() as stack:
+            mocks = self._patches(stack, is_tty=True)
+            mocks["push"].side_effect = GitError("fatal: authentication failed")
+            result = _push_branch_with_recovery(Path("/repo"), "feat/1-x", None, Path("/wt"))
+        assert result is False
+        mocks["markers"].clear_markers.assert_called_once_with(Path("/wt"), "done")

--- a/tests/unit/test_services/test_reviewed_marker.py
+++ b/tests/unit/test_services/test_reviewed_marker.py
@@ -1,0 +1,96 @@
+"""Tests that ``wade review implementation`` records the ``reviewed@<sha>`` marker."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from wade.models.delegation import DelegationMode, DelegationResult
+from wade.utils import markers
+
+rds = importlib.import_module("wade.services.review_delegation_service")
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
+
+
+def _repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@e.st")
+    _git(root, "config", "user.name", "T")
+    (root / "a.txt").write_text("a\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "a")
+
+
+def _head(root: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"], capture_output=True, text=True
+    ).stdout.strip()
+
+
+class TestMarkReviewed:
+    def test_writes_marker_for_head(self, tmp_path: Path, monkeypatch) -> None:
+        repo = tmp_path / "r"
+        _repo(repo)
+        monkeypatch.chdir(repo)
+        rds._mark_reviewed()
+        assert markers.marker_present(repo, "reviewed", _head(repo))
+
+    def test_invalidated_by_new_commit(self, tmp_path: Path, monkeypatch) -> None:
+        repo = tmp_path / "r"
+        _repo(repo)
+        monkeypatch.chdir(repo)
+        rds._mark_reviewed()
+        old = _head(repo)
+
+        (repo / "b.txt").write_text("b\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "b")
+        new = _head(repo)
+
+        # A subsequent commit invalidates the marker: it is present for the sha
+        # it was written against, but not for the new HEAD — forcing a re-review.
+        assert markers.marker_present(repo, "reviewed", old) is True
+        assert markers.marker_present(repo, "reviewed", new) is False
+
+
+class TestReviewImplementationWritesMarker:
+    def test_no_diff_path_marks_reviewed(self, tmp_path: Path) -> None:
+        with (
+            patch.object(rds.git_repo, "get_repo_root", return_value=tmp_path),
+            patch.object(rds.git_repo, "diff_worktree", return_value=""),
+            patch.object(rds, "_committed_diff_fallback", return_value=""),
+            patch.object(rds, "_mark_reviewed") as mock_mark,
+        ):
+            result = rds.review_implementation()
+        assert result.skipped is True
+        mock_mark.assert_called_once()
+
+    def test_success_path_marks_reviewed(self, tmp_path: Path) -> None:
+        success = DelegationResult(success=True, feedback="ok", mode=DelegationMode.PROMPT)
+        with (
+            patch.object(rds.git_repo, "get_repo_root", return_value=tmp_path),
+            patch.object(rds.git_repo, "diff_worktree", return_value="diff --git a b"),
+            patch.object(rds, "_run_review_delegation", return_value=success),
+            patch.object(rds, "_mark_reviewed") as mock_mark,
+        ):
+            rds.review_implementation()
+        mock_mark.assert_called_once()
+
+    def test_failure_path_does_not_mark(self, tmp_path: Path) -> None:
+        failure = DelegationResult(
+            success=False, feedback="boom", mode=DelegationMode.HEADLESS, exit_code=1
+        )
+        with (
+            patch.object(rds.git_repo, "get_repo_root", return_value=tmp_path),
+            patch.object(rds.git_repo, "diff_worktree", return_value="diff --git a b"),
+            patch.object(rds, "_run_review_delegation", return_value=failure),
+            patch.object(rds, "_mark_reviewed") as mock_mark,
+        ):
+            rds.review_implementation()
+        mock_mark.assert_not_called()

--- a/tests/unit/test_utils/test_markers.py
+++ b/tests/unit/test_utils/test_markers.py
@@ -1,0 +1,107 @@
+"""Unit tests for the sha-keyed completion-marker primitive (#349)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wade.utils import markers
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+
+
+class TestShaKeyedMarkers:
+    def test_write_then_present(self, tmp_path: Path) -> None:
+        assert markers.write_marker(tmp_path, "done", _SHA_A) is True
+        assert markers.marker_present(tmp_path, "done", _SHA_A) is True
+        assert (tmp_path / ".wade" / f"done@{_SHA_A}").is_file()
+
+    def test_absent_for_different_sha(self, tmp_path: Path) -> None:
+        markers.write_marker(tmp_path, "done", _SHA_A)
+        # A marker for sha A is not present for sha B — a new commit invalidates it.
+        assert markers.marker_present(tmp_path, "done", _SHA_B) is False
+
+    def test_missing_marker_absent(self, tmp_path: Path) -> None:
+        assert markers.marker_present(tmp_path, "done", _SHA_A) is False
+
+    def test_write_clears_prior_marker_for_same_name(self, tmp_path: Path) -> None:
+        markers.write_marker(tmp_path, "done", _SHA_A)
+        markers.write_marker(tmp_path, "done", _SHA_B)
+        # Only the current sha's marker survives (bounds .wade/ growth).
+        assert markers.marker_present(tmp_path, "done", _SHA_B) is True
+        assert markers.marker_present(tmp_path, "done", _SHA_A) is False
+        entries = sorted(p.name for p in (tmp_path / ".wade").iterdir())
+        assert entries == [f"done@{_SHA_B}"]
+
+    def test_write_does_not_clear_other_names(self, tmp_path: Path) -> None:
+        markers.write_marker(tmp_path, "reviewed", _SHA_A)
+        markers.write_marker(tmp_path, "done", _SHA_A)
+        # Different names are independent.
+        assert markers.marker_present(tmp_path, "reviewed", _SHA_A) is True
+        assert markers.marker_present(tmp_path, "done", _SHA_A) is True
+
+    def test_clear_markers(self, tmp_path: Path) -> None:
+        markers.write_marker(tmp_path, "done", _SHA_A)
+        markers.clear_markers(tmp_path, "done")
+        assert markers.marker_present(tmp_path, "done", _SHA_A) is False
+
+    def test_no_temp_file_left_behind(self, tmp_path: Path) -> None:
+        markers.write_marker(tmp_path, "done", _SHA_A)
+        leftovers = [p.name for p in (tmp_path / ".wade").iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []
+
+    def test_marker_path(self, tmp_path: Path) -> None:
+        assert markers.marker_path(tmp_path, "done", _SHA_A) == (
+            tmp_path / ".wade" / f"done@{_SHA_A}"
+        )
+
+
+class TestSymlinkSafety:
+    def test_symlinked_marker_not_trusted(self, tmp_path: Path) -> None:
+        # A planted symlink at the marker path must not read as present.
+        wade = tmp_path / ".wade"
+        wade.mkdir()
+        real = tmp_path / "elsewhere"
+        real.write_text("")
+        (wade / f"done@{_SHA_A}").symlink_to(real)
+        assert markers.marker_present(tmp_path, "done", _SHA_A) is False
+
+    def test_symlinked_wade_dir_not_trusted_on_read(self, tmp_path: Path) -> None:
+        # A symlinked .wade dir must not let an outside file count as a marker.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / f"done@{_SHA_A}").write_text("")
+        (tmp_path / ".wade").symlink_to(outside)
+        assert markers.marker_present(tmp_path, "done", _SHA_A) is False
+
+    def test_symlinked_wade_dir_not_written_through(self, tmp_path: Path) -> None:
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (wt / ".wade").symlink_to(outside)
+        # The write must refuse rather than land a file outside the worktree.
+        assert markers.write_marker(wt, "done", _SHA_A) is False
+        assert not (outside / f"done@{_SHA_A}").exists()
+
+
+class TestFlagMarkers:
+    def test_write_and_present(self, tmp_path: Path) -> None:
+        assert markers.write_flag_marker(tmp_path, "stop-nudged") is True
+        assert markers.flag_marker_present(tmp_path, "stop-nudged") is True
+
+    def test_absent_when_missing(self, tmp_path: Path) -> None:
+        assert markers.flag_marker_present(tmp_path, "stop-nudged") is False
+
+    def test_flag_marker_path(self, tmp_path: Path) -> None:
+        assert markers.flag_marker_path(tmp_path, "stop-nudged") == (
+            tmp_path / ".wade" / "stop-nudged"
+        )
+
+    def test_symlinked_flag_not_trusted(self, tmp_path: Path) -> None:
+        wade = tmp_path / ".wade"
+        wade.mkdir()
+        real = tmp_path / "elsewhere"
+        real.write_text("")
+        (wade / "stop-nudged").symlink_to(real)
+        assert markers.flag_marker_present(tmp_path, "stop-nudged") is False


### PR DESCRIPTION
Closes #349

<!-- wade:plan:start -->

## Complexity
very_complex

## Context / Problem

`done` rigorously enforces *git hygiene* (clean tree, no tracked wade-managed
files, push with non-FF recovery) but **not workflow completeness** — and nothing
makes it *reachable*. Verified in source:

- **PR-SUMMARY split-brain** — the Stop hook *blocks* when `PR-SUMMARY.md` is
  missing (`hooks/policies.py:747`, `session_complete`), but `done` only
  `console.warn`s (`done.py:391`) and opens the PR with an empty body. Same
  requirement, two layers, different strictness.
- **Sync is never enforced** — `done` pushes and finalizes with no
  behind-main check. A branch behind `main` ships silently.
  (`git_branch.commits_ahead` already exists at `git/branch.py:200`.)
- **`review` is never checked** — `cli/implementation_session.py:134` prints an
  advisory `console.warn` *after* success. Nothing verifies it ran, and nothing
  is recorded when `wade review implementation` runs
  (`review_delegation_service.py:211` just delegates a diff prompt).
- **Review threads are never gated** in the review flow — `review-pr-comments-session done`
  calls `get_review_status()` only *after* a successful push, purely to print an
  advisory (`cli/review_pr_comments_session.py:83`).
- **Nothing records that `done` ran**, so the Stop hook can't tell "summary
  written" from "actually finished."
- **Nothing makes `done` unavoidable** — the only mechanism routing the agent
  there is the Stop hook, which is fail-open, single-shot, and "deliberately
  ignorable" by its own docstring (`policies.py:739`). An agent that commits,
  pushes, and stops never meets a gate.

This issue is **Wave 2** of epic #348. Its prerequisite #357 A3 ("a failed
`done` is retryable") is **CLOSED** — confirmed in source: `done()` now defers
the gitignore-strip to the success path (`done.py:172-238`) and
`_push_branch_with_recovery` handles non-FF divergence (`done.py:263-330`). It
introduces the **marker primitive** that #350 reuses and shares the per-worktree
git-hook install plumbing with #352 (**built once, here**).

### Grounding facts confirmed in source

- Both `implementation-session done` and `review-pr-comments-session done`
  delegate to the **same** `implementation_service.done()` service
  (`cli/implementation_session.py:118`, `cli/review_pr_comments_session.py:69`).
  Gates must therefore be parameterized by session type.
- `wade review implementation` reviews the working-tree/committed diff and
  records **nothing** durable to disk (`review_delegation_service.py:211-274`).
- Provider `get_pr_review_threads(pr_number) -> list[ReviewThread]` exists on all
  three providers (GitHub native + Markdown/ClickUp via `GitHubPRDelegateMixin`,
  `providers/_pr_delegate.py:56`); `filter_unresolved_threads`
  (`models/review.py:163`) and `PRReviewStatus.is_all_clear`
  (`models/review.py:405`) already exist.
- `.wade/` is gitignored per-session in the worktree block and `.wade/base_branch`
  / `.wade/stop-nudged` are the existing marker precedents (the latter uses a
  race-safe `O_DIRECTORY | O_NOFOLLOW` dir-fd pattern in `hooks/cli.py:154` /
  `hooks/policies.py:65`).
- No existing `core.hooksPath` usage anywhere — the pre-push plumbing is
  greenfield.

## Proposed Solution

Five interlocking workstreams built around one new primitive — a sha-keyed
**done-marker**. `done` writes `.wade/done@<HEAD>` after all gates pass and
immediately before it pushes (so `done`'s own push satisfies the backstop). The
marker's meaning is precisely **"the done gates passed for this sha"** — exactly
what the pre-push backstop and the Stop hook want to verify. A new commit
invalidates every marker (sha-keyed), forcing re-completion.

Confirmed design decisions (from planning):
- **Single issue** (this file) — matches the epic's framing; all five parts
  interlock around the done-marker.
- **Sync gate: auto-sync, refuse only on conflict** — reuses the existing
  `do_sync` service rather than merging inline.

### 1. Marker primitive — `src/wade/utils/markers.py` (NEW)

Pure-stdlib leaf module (no wade imports beyond `structlog`) so the lean
`wade-hook` entry point can import it without paying the crossby/CLI cold-start
cost. Generalizes the `stop-nudged` mechanism.

```python
def marker_path(worktree_root: Path, name: str, sha: str) -> Path      # .wade/<name>@<sha>
def write_marker(worktree_root: Path, name: str, sha: str) -> bool     # atomic *.tmp -> os.replace, 0o600
def marker_present(worktree_root: Path, name: str, sha: str) -> bool   # race-safe, regular-file only
def clear_markers(worktree_root: Path, name: str) -> None              # remove all .wade/<name>@*
```

- **Atomic write**: write to `.wade/<name>@<sha>.tmp` then `os.replace` onto the
  final path, mode `0o600`. Best-effort — a failed write returns `False` and
  callers treat that as "marker absent" (fail toward reminding). `write_marker`
  first calls `clear_markers(name)` to remove any prior `<name>@*` marker, so
  only the current sha's marker exists — this bounds `.wade/` growth over a long
  session and makes "is there *any* done marker" checks unambiguous. (This is the
  concrete call site for `clear_markers`; it is not dead scaffolding.)
- **Race-safe read**: open `.wade` with `O_DIRECTORY | O_NOFOLLOW`, `os.stat` the
  marker relative to that dir-fd without following symlinks, require `S_ISREG`.
  On platforms without dir-fd support, treat as absent (never follow unsafely) —
  same policy as `stop_nudge_present`.
- **sha-keyed** so a marker for sha A is not present for sha B; **missing/stale ⇒
  not done**.
- Refactor `hooks/cli.py:_mark_stop_nudged` and
  `hooks/policies.py:stop_nudge_present`/`stop_nudge_marker_path` to sit on top of
  this module (keep the `.wade/stop-nudged` path — it is a plain single-shot, not
  sha-keyed — but share the dir-fd primitives so the two implementations can't
  drift).

### 2. `implementation-session done` hard gates

Add a `session_type: str` parameter to `done()` (`"implementation"` |
`"review-pr-comments"`, default `"implementation"`); the two CLI wrappers pass it.
Gates run **after** the existing clean + tracked-managed gates and **before**
`_done_via_pr`. Each aborts with an actionable message + an escape hatch.

**Gate execution order matters** (auto-sync can advance HEAD via a merge commit,
which would invalidate any sha-keyed marker checked *before* it). Fixed order:

1. **PR-SUMMARY** check (no HEAD change).
2. **review-ran** check against the **pre-sync HEAD** — this is the sha the agent
   actually reviewed. Doing it before sync means a clean main-merge does not
   spuriously invalidate the review the agent just performed.
3. **sync** — may advance HEAD via a merge commit.
4. Write `done@<HEAD>` (via `write_marker`) keyed to the **post-sync HEAD**,
   immediately before the push in `_done_via_pr`. The pre-push backstop checks
   the pushed (post-sync) sha, so they match.

Deliberate consequence: a clean, zero-conflict merge of `main` is accepted
without a fresh review (a main-merge is not new authored work). This is
preferred over forcing a spurious re-review of the identical diff every time the
branch is a commit behind. Document this in the review-ran gate message.

- **PR-SUMMARY present and non-placeholder** — upgrade the `done.py:391` warn to a
  gate. Refuse when `PR-SUMMARY.md` is missing, empty after `.strip()`, or matches
  the template stub (headings-only with the `[High-level summary …]` /
  `[Optional: …]` placeholders from `pr-summary-format.md` and no real prose).
  Hatch: `done.require_pr_summary: false`.
- **Synced with main** — `git_sync.fetch_origin`, then compute the behind-count.
  ⚠️ The signature is `commits_ahead(repo_root, branch, base)` = "commits on
  *branch* not in *base*". To measure how far *behind* the session branch is, pass
  `origin/<main>` in the **branch** position:
  `behind = commits_ahead(repo_root, f"origin/{main_branch}", branch)` — i.e.
  commits present on `origin/<main>` that the session branch lacks. (Do **not**
  invert the arguments; the Stop hook in §5 uses the opposite role assignment, so
  both call sites get an explicit unit test pinning argument order.) Resolve
  `main_branch` the same way `done()` already does, honoring `.wade/base_branch`
  for stacked chains (`done.py:203`). When `behind > 0`, **auto-sync via the
  existing `do_sync` service**; if `do_sync` reports a conflict, **refuse** with
  the `wade <session>-session sync` next-step. Hatch: `done.require_sync: false`.
- **`review` ran** — require `marker_present(worktree, "reviewed", HEAD)` against
  the **pre-sync HEAD** (see gate order above). Refuse otherwise. Hatches:
  `--skip-review` flag, `done.require_review: false`, and the existing
  `review_implementation.enabled: false` (confirmed in source:
  `AICommandConfig.enabled`, read at `cli/implementation_session.py:134` and
  `review_delegation_service.py:40` — gate auto-skipped when reviews are
  disabled). Message: run `wade review implementation` (or pass `--skip-review`),
  then re-run done.

The `reviewed@<sha>` marker is written by `wade review implementation`: in
`review_delegation_service.review_implementation`, after a successful
(non-hard-failure) result — including the "no diff to review" skip — call
`write_marker(worktree, "reviewed", HEAD)` best-effort. It is **not** written when
the command is disabled (the gate is then also off). Because it is sha-keyed, any
commit made while addressing findings invalidates it, forcing a re-review. This
gate verifies the command *ran for this sha*, not that findings were addressed —
documented honestly (#355 will later relax the enforcement-theater phrasing).

### 3. `review-pr-comments-session done` gates

Under `session_type == "review-pr-comments"`, run:

- **Unresolved review threads** — look up the PR for the branch
  (`git_pr.get_pr_for_branch`, already imported), fetch
  `provider.get_pr_review_threads(pr_number)`, and refuse when
  `filter_unresolved_threads(...)` is non-empty. Message names the count and the
  `wade review-pr-comments-session resolve <thread-id>` path. Hatch:
  `done.require_resolved_threads: false`. Treat a provider/lookup error as
  non-blocking (log + warn) so a transient `gh` failure can't trap completion —
  consistent with #357 B1/B2 typed-lookup handling.
- **`review` ran** — same `reviewed@<HEAD>` check as §2. Hatch: `--skip-review`.

(Per the issue, PR-SUMMARY and sync gates stay scoped to the implementation
session to avoid over-blocking review-comment sessions.)

### 4. Pre-push git hook — the backstop that makes the gate unavoidable

**Template**: new `templates/hooks/pre-push`, modeled on `scripts/hooks/pre-push`
(reuse its stdin protocol `<local_ref> <local_sha> <remote_ref> <remote_sha>`,
zero-SHA deletion skip, and new-branch range fallback). The marker check is pure
shell — git runs the hook with cwd at the worktree top, so it tests
`[[ -f ".wade/done@${local_sha}" ]]` directly; **no python callback needed**. If
the pushed sha has no current done-marker, print an actionable message ("run
`wade implementation-session done` first, or bypass with `git push --no-verify`")
and `exit 1`. Only enforce for the session branch (skip deletions and pushes of
other refs).

⚠️ **stdin is a single-pass stream.** Pre-push receives *all* ref updates on
stdin (a `git push --all` sends many lines). The script must **buffer stdin once**
(`stdin_data=$(cat)`) before consuming it for the marker check, then iterate the
buffered lines — and, when chaining (below), re-emit that exact buffered content
to the chained hook on *its* stdin. A naive read-once-forward-nothing
implementation silently breaks a downstream chained hook. Covered by a multi-ref
test case.

**Per-worktree install** (NEW installer plumbing, shared with #352):

- Write the script to `<worktree>/.wade/githooks/pre-push` (chmod `+x`).
  `.wade/` is already gitignored, so it never appears as untracked.
- Set `extensions.worktreeConfig true` (repo-level, idempotent) **and**
  `git config --worktree core.hooksPath .wade/githooks` (per-worktree). A relative
  `core.hooksPath` resolves against each working tree's top level, and `--worktree`
  scoping guarantees it does **not** leak to the main checkout or sibling
  worktrees.
- **⚠️ Chain-or-refuse** — `core.hooksPath` *replaces* `.git/hooks`, silently
  disabling any pre-existing hook (wade's own repo ships
  `scripts/hooks/pre-push`). Before setting `core.hooksPath`, detect (a) an
  existing `pre-push` in `$(git rev-parse --git-common-dir)/hooks` and (b) any
  prior user-set `core.hooksPath`. If either exists, the wade-managed `pre-push`
  **chains** to it: after its own marker check passes, invoke the prior hook with
  the same argv + the buffered stdin re-emitted, and honor its exit code.
  Persist the resolved chain target to `.wade/githooks/.chain` **once at first
  install**; the script reads it. Never silently shadow.
- **⚠️ Idempotent re-install** — `bootstrap_worktree` runs on *every*
  `wade implement`/`wade review` invocation against a possibly-reused worktree.
  The detection must not mistake wade's *own* prior install for a user hook:
  if the worktree's `--worktree core.hooksPath` already equals `.wade/githooks`
  (or a `.wade/githooks/.chain` file already exists), treat it as
  already-wade-managed — **do not** re-capture the chain target (which would now
  resolve to wade's own hook and cause self-chaining or drop the real original);
  only refresh the `pre-push` script body. Capture the chain target exactly once,
  on the first install. Covered by a "re-run install against an already-managed
  worktree" test.
- **⚠️ Graceful degrade** — worktree-scoped config needs
  `extensions.worktreeConfig` + `git config --worktree` (git ≥ 2.20). If enabling
  the extension or setting the worktree `core.hooksPath` fails for any reason
  (old git, restricted config), **warn and skip the backstop** — the session's
  Python `done` gates still hold; bootstrap must never crash over the optional
  backstop. Confirm CI's git version supports it.
- Install for **implement + review** sessions (`not plan_mode`) in
  `bootstrap_worktree`, alongside the existing guard/stop hooks. Gate on
  `done.pre_push_backstop: true` (default on).
- Extract the reusable core (resolve common-dir, detect existing hooks, write
  worktree hooksPath + chain wrapper, idempotent re-install, graceful degrade)
  into a helper #352 can call for its `pre-commit`/`commit-msg` hooks.

**Honesty**: document in README + skill reference that `--no-verify` bypasses the
backstop in one flag — this is a *backstop/quality* layer, not an airtight
boundary.

### 5. Realign the Stop policy (`session_complete`)

Rewrite `hooks/policies.py:session_complete` from "is PR-SUMMARY present?" →
"completed via `done`?", keeping it a pure, unit-testable predicate:

```python
def session_complete(event, *, worktree_root, commits_ahead=0, done_marker_present=False):
    if event.stop_hook_active:      return allow()
    if commits_ahead == 0:          return allow()   # no work to finalize (#318 signal)
    if done_marker_present:         return allow()   # completed via done
    if stop_nudge_present(root):    return allow()   # single-shot
    return deny("Before finishing: run `wade implementation-session done` (or "
                "`wade review-pr-comments-session done`) to sync, push, and "
                "finalize the PR. If you are pausing to ask a question or are "
                "still mid-task, disregard this and continue.")
```

- **Git facts are computed in `hooks/cli.py`'s Stop branch** (lazy `subprocess`
  git calls — HEAD sha, the branch's ahead-count, and
  `marker_present(root, "done", HEAD)`) and passed into the predicate. This keeps
  the predicate free of side effects and off the hot per-edit import path.
  ⚠️ The Stop hook needs "how many commits is my branch **ahead** of base", which
  is the **opposite** role assignment from the sync gate:
  `commits_ahead(repo_root, branch, f"origin/{main_branch}")` (session branch in
  the *branch* position). The same argument-order unit test pins both call sites.
  **Any error → fail-open** (`emit_stop_decision(False, "")`) — a Stop guard must
  never trap the agent. The base branch is resolved cheaply
  (upstream/`origin/<main>` with a detect fallback); if it can't be resolved,
  fail open.
- Adopts #318's higher-signal condition: nudge only when the branch has commits
  ahead of base, so an early "stopping to ask a question" turn doesn't trigger it.
- The split-brain is gone — both `done` and Stop now key on the same completion
  fact.

### 6. Config — `DoneConfig` (NEW)

Add a `DoneConfig` Pydantic model and a `done: DoneConfig` field on
`ProjectConfig` (`models/config.py`). Gates default **on** (enforcement is the
point):

```yaml
done:
  require_pr_summary: true
  require_sync: true
  require_review: true
  require_resolved_threads: true
  pre_push_backstop: true
```

Per knowledge `ca245d6a`, config-key validity lives in **three** places — update
all: the Pydantic model, `config/loader.py`, and the `check_service.py`
`valid_keys` allowlists.

### Files

- **NEW** `src/wade/utils/markers.py` — marker primitive.
- **NEW** `templates/hooks/pre-push` — backstop script.
- `src/wade/services/implementation_service/done.py` — `session_type` param,
  gate set, write `done@<HEAD>` before push.
- `src/wade/services/implementation_service/bootstrap.py` — install pre-push
  per-worktree (chain-or-refuse), gated on config.
- `src/wade/skills/installer.py` — githooks path constants, gitignore/tracked
  coverage, pre-push template loader + install helper (reusable by #352).
- `src/wade/hooks/policies.py` — rewrite `session_complete`; base marker helpers
  on `utils/markers`.
- `src/wade/hooks/cli.py` — Stop branch computes git facts, passes to predicate;
  reuse `utils/markers` for the nudge marker.
- `src/wade/services/review_delegation_service.py` — write `reviewed@<HEAD>`.
- `src/wade/services/review_service.py` / `src/wade/models/review.py` — thread-gate
  helper (reuse `filter_unresolved_threads` / `PRReviewStatus`).
- `src/wade/cli/implementation_session.py`, `src/wade/cli/review_pr_comments_session.py`
  — pass `session_type`, add `--skip-review`.
- `src/wade/models/config.py`, `src/wade/config/loader.py`,
  `src/wade/services/check_service.py` — `DoneConfig` + validation.
- Docs: `README.md`, `docs/dev/architecture.md`, and the implementation/review
  skill references (note the `--no-verify` honesty + the new gates).

### Out of scope / non-goals

- The cooldown re-nudge (`pendingSince` + ~2h) — **dropped** per the epic; item 4
  covers the real case.
- No change to providers' `get_pr_review_threads` (already implemented) — this
  issue only *consumes* it.
- #355's phrasing cleanup for review-ran/PR-SUMMARY is a follow-up, not here.

## Tasks

- [ ] Add `src/wade/utils/markers.py` (`marker_path`/`write_marker`/`marker_present`/`clear_markers`), atomic write (clears prior `<name>@*` first) + race-safe read; unit-test symlink/stale/atomicity/clear-prior cases.
- [ ] Refactor `hooks/cli.py` + `hooks/policies.py` stop-nudge helpers onto `utils/markers` (keep the `.wade/stop-nudged` path).
- [ ] Add `DoneConfig` to `models/config.py` (+ `done` field on `ProjectConfig`), wire into `config/loader.py` and `check_service.py` allowlists; test round-trip + `check-config` rejecting unknown `done.*` keys.
- [ ] Add `session_type` param to `done()`; branch the gate set on it; enforce the fixed gate order (PR-SUMMARY → review-ran vs pre-sync HEAD → sync → write `done@<post-sync HEAD>` → push).
- [ ] Implement the PR-SUMMARY gate (present + non-placeholder detection) with `done.require_pr_summary` hatch.
- [ ] Implement the review-ran gate reading `reviewed@<pre-sync HEAD>`; add `--skip-review` to both `done` CLI commands; `done.require_review` hatch; auto-skip when `review_implementation.enabled is False`.
- [ ] Write `reviewed@<HEAD>` in `review_delegation_service.review_implementation` after a successful result (best-effort) — immediately follows the review-ran gate for reviewable-in-isolation.
- [ ] Implement the sync gate: fetch, `behind = commits_ahead(repo, origin/<main>, branch)` (origin/main in the branch position), auto-sync via `do_sync`, refuse on conflict; `done.require_sync` hatch; honor `.wade/base_branch`.
- [ ] Write `done@<post-sync HEAD>` in `done()` after all gates pass, immediately before the push in `_done_via_pr`.
- [ ] Add a unit test pinning `commits_ahead` argument order for **both** call sites (sync-gate behind-count and Stop-hook ahead-count) — they use opposite role assignments.
- [ ] Implement the review-pr-comments thread gate via `get_pr_review_threads` + `filter_unresolved_threads`; refuse with count + resolve command; `done.require_resolved_threads` hatch; transient-lookup failure is non-blocking.
- [ ] Add `templates/hooks/pre-push` (buffer stdin once, marker check per pushed ref, deletion/new-branch handling, chain-to-prior-hook re-emitting buffered stdin, `--no-verify` note).
- [ ] Add the reusable per-worktree hook-install helper in `skills/installer.py` (write `.wade/githooks/pre-push`, set `extensions.worktreeConfig` + `--worktree core.hooksPath`, detect existing common-dir/user hook, chain-or-refuse persisting `.chain` once, idempotent re-install, graceful degrade on old git). Design it for #352 reuse.
- [ ] Call the installer from `bootstrap_worktree` for non-plan sessions, gated on `done.pre_push_backstop`; ensure `.wade/githooks` is covered by gitignore/tracked-file checks.
- [ ] Rewrite `session_complete` (predicate) to key on commits-ahead + done-marker; update the message to "run `done`".
- [ ] Update `hooks/cli.py` Stop branch to compute HEAD sha / `commits_ahead(repo, branch, origin/<main>)` / done-marker (lazy subprocess, fail-open) and pass them to `session_complete`.
- [ ] Trim/adjust the now-redundant post-`done` review advisory in `cli/implementation_session.py` (keep behavior consistent with the enforced gate).
- [ ] Update `README.md`, `docs/dev/architecture.md`, and the impl/review skill references (new gates, escape hatches, `--no-verify` honesty).
- [ ] Tests: unit for markers, each gate + every escape hatch, `session_complete`, `wade-hook` Stop CLI path; pre-push install/scoping/chaining (main checkout + sibling worktree unaffected; pre-existing hook still runs; multi-ref `--all` push forwards buffered stdin; re-run install against an already-managed worktree does not self-chain; graceful degrade on unsupported git). Run `./scripts/check-all.sh`.

## Acceptance Criteria

- [ ] `done` refuses (with an actionable message + escape hatch) when PR-SUMMARY is missing/empty/placeholder, when the branch is behind main (auto-syncing first, refusing only on conflict), or when review did not run for the current sha.
- [ ] `review-pr-comments-session done` refuses on unresolved review threads and on review-not-run; a transient provider/lookup failure does not block completion.
- [ ] A push of the session branch without a current `.wade/done@<sha>` is refused by the pre-push hook; `done`'s own push passes because it writes the marker first.
- [ ] The pre-push hook is scoped to the worktree and does **not** appear in the main checkout or a sibling worktree; a pre-existing user/common-dir hook still runs after wade installs its own, including for a multi-ref (`git push --all`) push (asserted by tests).
- [ ] Re-running bootstrap against an already-wade-managed worktree does not self-chain or lose the original chain target; if the git version cannot support worktree-scoped `core.hooksPath`, bootstrap warns and skips the backstop instead of crashing.
- [ ] Stop nudges "run `done`" (not "write PR-SUMMARY"), only when the branch is ahead of base and no current done-marker exists; the split-brain requirement is gone; Stop stays fail-open on any error/missing-root.
- [ ] Every escape hatch works: `--skip-review`, each `done.*` `.wade.yml` toggle, `git push --no-verify`, and Stop's fail-open path — each covered by a test.
- [ ] `reviewed@<sha>` is written by `wade review implementation` and invalidated by a subsequent commit.
- [ ] `wade check-config` accepts the new `done` section and rejects unknown `done.*` keys.
- [ ] Full unit + `wade-hook` CLI coverage; `./scripts/check-all.sh` passes.

<!-- wade:plan:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added completion checks for summaries, synchronization, reviews, and resolved threads.
  * Added `--skip-review` options to completion commands.
  * Added commit-specific completion markers and pre-push validation.
  * Added configurable completion requirements, enabled by default.
  * Added automatic branch synchronization when required.

* **Bug Fixes**
  * Completion markers are cleared after failed or cancelled pushes and refreshed after recovery.
  * Clean sessions with no unfinished commits are no longer blocked.

* **Documentation**
  * Documented completion gates, configuration options, marker behavior, review requirements, and push safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:summary:start -->

## Summary

## What was done

Made `done` the **authoritative completion gate** for wade sessions (issue #349,
Wave 2 of epic #348). `done` previously enforced git hygiene but not workflow
completeness, and nothing made it reachable. This change adds a sha-keyed
completion-marker primitive and wires it through five interlocking parts so that
finishing a session actually means the work is ready — PR summary written, synced
with main, reviewed, and (for review sessions) all threads resolved.

## Changes

- **Marker primitive** — new `src/wade/utils/markers.py`: pure-stdlib leaf with
  sha-keyed `.wade/<name>@<sha>` markers (`marker_path`/`write_marker`/
  `marker_present`/`clear_markers`) plus single-shot flag markers. Race-safe via
  an `O_DIRECTORY | O_NOFOLLOW` `.wade` handle (no path-based fallback that could
  follow a symlink). The old `.wade/stop-nudged` mechanism now rides these
  primitives so the two can't drift.
- **`done` gates** (`implementation_service/done.py`) — a `session_type` param
  selects the gate set, run in a fixed order (PR-SUMMARY → review-ran vs pre-sync
  HEAD → sync → write `done@<post-sync HEAD>` → push). PR-SUMMARY presence/
  non-placeholder, auto-sync (refuse only on conflict), review-ran, and (review
  sessions) unresolved-threads gates — each with a `.wade.yml` escape hatch and
  `--skip-review`. The marker lifecycle lives in `_push_branch_with_recovery`: it
  re-keys the marker after a recovery merge and clears it on any push failure.
- **`reviewed@<HEAD>` marker** written by `wade review implementation` on a
  successful (or no-diff) result; invalidated by any new commit.
- **Pre-push backstop** — new `templates/hooks/pre-push` + reusable installer in
  `skills/installer.py`. Installed per-worktree via worktree-scoped
  `core.hooksPath`, chains to any pre-existing hook (re-emitting buffered stdin
  byte-exact), detects self on re-install, and degrades gracefully on git < 2.20.
- **Stop hook realigned** (`hooks/policies.py` + `hooks/cli.py`) — nudges "run
  `done`" keyed on commits-ahead + done-marker instead of "PR-SUMMARY missing";
  git facts computed via raw subprocess (the lean entry leaves structlog
  unconfigured, so a `wade.git` call would corrupt the stdout contract);
  fail-open on any error.
- **`DoneConfig`** added to `models/config.py`, wired into `config/loader.py` and
  the `check_service.py` validator (keys derived from the model per knowledge
  `ca245d6a`).
- Docs: README (session guards + completion gates + `--no-verify` honesty),
  `docs/dev/architecture.md` (new "Completion Gates & the `done`-marker"
  section), and the implementation/review skill templates.

## Testing

- New unit suites: markers (symlink/stale/atomicity/clear-prior), each gate +
  every escape hatch, `session_complete` predicate, `commits_ahead` argument
  order (both opposite call sites), reviewed-marker write + invalidation,
  push-recovery marker lifecycle, `DoneConfig` round-trip + `check-config`
  rejection of unknown `done.*` keys.
- Pre-push install/scoping/chaining (main + sibling worktrees unaffected,
  pre-existing hook still runs, multi-ref `--all` forwards buffered stdin, re-run
  doesn't self-chain, graceful degrade), driven against real git worktrees.
- `wade-hook` Stop CLI path exercised end-to-end through the lean entry point.
- `./scripts/check-all.sh` passes: 2650 unit + e2e tests, ruff, and `mypy
  --strict` all green.

## Notes for reviewers

- Deliberate: a clean, zero-conflict merge of `main` during the sync gate is
  accepted without a fresh review (the review-ran gate checks the pre-sync HEAD).
- Honesty documented throughout: `git push --no-verify` bypasses the backstop in
  one flag — it is a quality layer that makes skipping `done` hard, not an
  airtight boundary.
- The `wade review implementation` step for this PR completed and flagged two
  correctness bugs (backstop vs. recovery-merge, and marker rollback on push
  failure); both are fixed in the second commit with dedicated tests.

## Review feedback addressed

Resolved all 16 CodeRabbit threads across 11 files (4 follow-up commits):

- **Correctness / robustness**
  - `done.py`: resolve the pre-sync sha from the branch ref (not `cwd` HEAD) so
    it agrees with `_write_done_marker` when `done` runs from the main checkout.
  - `loader.py` / `check_service.py`: a null `done.*` flag (e.g. `require_sync:`)
    is normalized to its default in the loader (no cryptic Pydantic crash) and
    rejected as a non-bool by `wade check`. Regression tests added for both.
  - `installer.py`: roll back the repo-wide `extensions.worktreeConfig` when the
    follow-up worktree `core.hooksPath` write fails — a failed optional backstop
    no longer leaves a persistent repo config change. Added `unset_config_value`.
  - `templates/hooks/pre-push`: report every missing marker on a multi-ref push,
    and re-emit buffered stdin via a temp file rather than a pipe so a chained
    hook that never reads stdin can't have its status masked by the writer's
    `SIGPIPE` under `pipefail`.
- **Docs**
  - `architecture.md`: gate list now shows unresolved-threads as
    review-sessions-first and sync as implementation-only (matching
    `_run_completion_gates`); adjacent blockquotes joined to clear MD028.
  - `bootstrap.py`: `_install_stop_hook` docstring now describes the
    commits-ahead + done-marker guard (not the old PR-SUMMARY condition).
  - implementation-session skill: `done` auto-syncs a branch behind `main` and
    refuses only on conflict (kept within the session-start char budget).
- **Tests**
  - Pin `_run_completion_gates` dispatch order per session type; stale-marker
    refusal; chained hooks that ignore stdin (pass-through + failure propagation);
    extension-rollback (both the unset branch and — added last — the
    restore-prior-value branch when `extensions.worktreeConfig` was already set);
    merge-conflict and force-push-failure marker-clear paths; tightened backstop
    install-target assertions.

No threads were left unresolved. Full suite (2660 passed, 1 xfailed), E2E (67),
ruff, and `mypy --strict` all green.

<!-- wade:summary:end -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **556,000** |
| Input tokens | **554,600** |
| Output tokens | **1,400** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **192,800** |
| Input tokens | **191,500** |
| Output tokens | **1,300** |
| Cached tokens | **0** |

### Session 2

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **57,712** |
| Input tokens | **56,800** |
| Output tokens | **912** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `6003cc56-3b7d-4267-9abc-22a06f6aa5a4` |
| Review | `claude` | `0d8a76c4-d3a6-4e6d-b074-162612a31c4d` |
| Review | `claude` | `5c673b98-7826-4b79-9393-5e2aa4c4dfc4` |

<!-- wade:sessions:end -->
