### PR TITLE
E2: Plan-phase enforcement (auto-validate + plan Stop guard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,22 @@ enough to pick up improvements, with no re-init or migration.
 |-------|----------------|
 | Worktree containment | Writes that land outside your worktree |
 | Plan-artifact | During `wade plan`, writes to anything but plan artifacts |
-| Session completion | Finishing a session with unfinished work not yet run through `done` (nudges once) |
+| Session completion | Finishing an implement/review session with unfinished work not yet run through `done` (nudges once) |
+| Plan completion | Finishing a `wade plan` session that produced no valid `PLAN*.md` yet (nudges once) |
 
 The session-completion guard keys on the same fact `done` records — a sha-keyed
 `.wade/done@<HEAD>` marker written when `done`'s gates pass — so it nudges only
 when the branch has commits ahead of its base **and** `done` has not finalized
 the current commit. An early "stopping to ask a question" turn (no commits ahead)
-never triggers it.
+never triggers it. The plan-completion guard is the planning counterpart: it
+nudges once if a plan session is about to end with no valid plan file (a title
+with a conventional-commit prefix plus a `## Complexity`). Both fail **open** — a
+session is never trapped.
+
+Independently of that nudge, `wade plan` now **strictly validates** plan files
+before creating issues: a `PLAN*.md` missing a valid `## Complexity` or a
+conventional-commit title is dropped with a loud error instead of silently
+becoming an issue with no complexity label.
 
 Both write guards cover **shell commands** as well as file edits, so a redirect
 like `printf x > ../other-repo/app.py` is blocked, not just an `Edit` call. Shell

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ before creating issues: a `PLAN*.md` missing a valid `## Complexity` or a
 conventional-commit title is dropped with a loud error instead of silently
 becoming an issue with no complexity label.
 
+If some files pass and others fail, an interactive run asks whether to continue
+with the valid ones; `--yolo` and non-interactive runs continue without asking.
+If you decline, or if every plan file fails validation, no issues are created —
+the generated `PLAN*.md` are preserved to a temp directory so you can fix the
+reported errors and re-run instead of regenerating from scratch.
+
 Both write guards cover **shell commands** as well as file edits, so a redirect
 like `printf x > ../other-repo/app.py` is blocked, not just an `Edit` call. Shell
 coverage is best-effort defense-in-depth: it catches ordinary commands, not

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -117,6 +117,7 @@ src/wade/
     ├── terminal.py      # Tab title, TTY detection, launch_in_new_terminal
     ├── slug.py          # Title -> URL-safe slug
     ├── markdown.py      # Plan file parsing
+    ├── plan_validation.py # Lean plan-file validator (discover/validate/has_valid_plan) — Stop-path safe
     ├── process.py       # Subprocess helpers
     ├── http.py          # HTTPClient for REST API providers
     ├── markers.py       # sha-keyed .wade/<name>@<sha> completion markers (done, reviewed, stop-nudged)
@@ -171,15 +172,23 @@ trusting the agent to follow the skill. The split across the two repos:
 |-------|-------|--------------|--------|
 | `worktree` | PreToolUse | **closed** (deny) | Writes resolving outside the worktree |
 | `plan` | PreToolUse | **closed** (deny) | Writes to anything but plan artifacts |
-| `session-complete` | Stop | **open** (allow) | Ending a turn with commits ahead of base and no current `done` marker (once) |
+| `session-complete` | Stop | **open** (allow) | Ending an impl/review turn with commits ahead of base and no current `done` marker (once) |
+| `plan-complete` | Stop | **open** (allow) | Ending a plan turn with no valid `PLAN*.md` in `.wade/plans` (once) |
 
 The asymmetry is deliberate and must not regress: a write guard that allows on
 error is worse than useless, while a Stop guard that blocks on error traps the
-agent in a session it cannot exit. `session-complete` (`hooks/policies.py`) is a
-pure predicate over `commits_ahead` + `done_marker_present`; the git facts are
-computed in `hooks/cli.py`'s Stop branch via **raw `subprocess`** (never the
-`wade.git` layer, whose `structlog` output would corrupt the lean entry's
-decision-JSON contract) and any failure fails open.
+agent in a session it cannot exit. Both Stop guards live in `hooks/policies.py`
+as pure predicates fed a fact the `hooks/cli.py` Stop branch computes:
+`session-complete` over `commits_ahead` + `done_marker_present` (git facts read
+via **raw `subprocess`** — never the `wade.git` layer, whose `structlog` output
+would corrupt the lean entry's decision-JSON contract), and `plan-complete` over
+`has_valid_plan(.wade/plans)` (via a **lazy** import of
+`wade.utils.plan_validation`, kept off the hot PreToolUse write path). Any
+failure — unresolvable dir, missing `--root`, exception — fails open. The two
+Stop guards share the single-shot `.wade/stop-nudged` marker because a worktree
+is either a plan worktree or an impl worktree, never both. Installation:
+`bootstrap_worktree` installs `session-complete` for impl/review sessions (plus
+the pre-push `done` backstop) and `plan-complete` for plan sessions.
 
 ### Two write channels
 

--- a/src/wade/cli/hook.py
+++ b/src/wade/cli/hook.py
@@ -25,7 +25,7 @@ def hook_command(
     guard: str = typer.Option(
         ...,
         "--guard",
-        help="Guard policy to apply: worktree | plan | session-complete.",
+        help="Guard policy to apply: worktree | plan | session-complete | plan-complete.",
     ),
     tool: str = typer.Option(
         ...,

--- a/src/wade/hooks/cli.py
+++ b/src/wade/hooks/cli.py
@@ -40,6 +40,7 @@ from crossby.models.ai import HookOutputDialect, HookStopDialect
 
 from wade.hooks.policies import (
     GUARD_NAMES,
+    StopGuard,
     plan_artifact_only,
     plan_complete,
     session_complete,
@@ -48,10 +49,11 @@ from wade.hooks.policies import (
 )
 from wade.utils import markers
 
-# Stop guards fail OPEN — an unknown one must never trap the agent. Two exist:
-# ``session-complete`` (impl/review) nudges to run ``done``; ``plan-complete``
-# (plan sessions) nudges to write a valid plan file.
-_STOP_GUARDS = frozenset({"session-complete", "plan-complete"})
+# Stop guards fail OPEN — an unknown one must never trap the agent. Derived from
+# :class:`StopGuard` (the shared source of truth) so this set cannot drift from
+# what bootstrap installs. ``session-complete`` (impl/review) nudges to run
+# ``done``; ``plan-complete`` (plan sessions) nudges to write a valid plan file.
+_STOP_GUARDS = frozenset(g.value for g in StopGuard)
 
 # Static ``tool id -> output dialect`` map, mirroring each crossby adapter's
 # ``capabilities().hook_output_dialect``. Inlined so the hot per-edit path never
@@ -309,7 +311,7 @@ def _run(event: str, guard: str, tool: str, root: str) -> HookEmission:
             # trap the agent, which a Stop guard must never do.
             return emit_stop_decision(False, "", stop_dialect)
         try:
-            if guard == "plan-complete":
+            if guard == StopGuard.PLAN_COMPLETE:
                 # Plan-session Stop: nudge unless the plan dir holds a valid plan.
                 # ``has_valid_plan`` pulls in pydantic + models, so it is imported
                 # lazily HERE — never on the hot PreToolUse write path, only on

--- a/src/wade/hooks/cli.py
+++ b/src/wade/hooks/cli.py
@@ -40,13 +40,13 @@ from crossby.models.ai import HookOutputDialect, HookStopDialect
 
 from wade.hooks.policies import (
     GUARD_NAMES,
-    StopGuard,
     plan_artifact_only,
     plan_complete,
     session_complete,
     shell_containment,
     worktree_containment,
 )
+from wade.models.hooks import StopGuard
 from wade.utils import markers
 
 # Stop guards fail OPEN — an unknown one must never trap the agent. Derived from

--- a/src/wade/hooks/cli.py
+++ b/src/wade/hooks/cli.py
@@ -41,11 +41,17 @@ from crossby.models.ai import HookOutputDialect, HookStopDialect
 from wade.hooks.policies import (
     GUARD_NAMES,
     plan_artifact_only,
+    plan_complete,
     session_complete,
     shell_containment,
     worktree_containment,
 )
 from wade.utils import markers
+
+# Stop guards fail OPEN — an unknown one must never trap the agent. Two exist:
+# ``session-complete`` (impl/review) nudges to run ``done``; ``plan-complete``
+# (plan sessions) nudges to write a valid plan file.
+_STOP_GUARDS = frozenset({"session-complete", "plan-complete"})
 
 # Static ``tool id -> output dialect`` map, mirroring each crossby adapter's
 # ``capabilities().hook_output_dialect``. Inlined so the hot per-edit path never
@@ -258,10 +264,11 @@ def _run(event: str, guard: str, tool: str, root: str) -> HookEmission:
       exception, an unknown guard name, a missing ``--root``, or an *unparseable*
       payload denies the write. A guard that silently allows on error is worse
       than useless.
-    - The Stop guard (``session-complete``) fails **open**: a bug, an internal
-      error, a missing ``--root``, *or an unrecognized guard name* must never trap
-      the agent in a session it cannot exit — it emits a non-blocking decision
-      rather than inspecting the CWD (which could spuriously block completion).
+    - The Stop guards (``session-complete`` / ``plan-complete``) fail **open**: a
+      bug, an internal error, a missing ``--root``, *or an unrecognized guard
+      name* must never trap the agent in a session it cannot exit — they emit a
+      non-blocking decision rather than inspecting the CWD (which could spuriously
+      block completion).
 
     Payload handling is asymmetric on purpose. An *empty* payload describes no
     write target, so there is nothing that could escape the worktree — allowing
@@ -286,12 +293,12 @@ def _run(event: str, guard: str, tool: str, root: str) -> HookEmission:
 
     ev = parse_event(raw, event=event)
 
-    # The Stop channel is claimed by either the guard name or the event, so an
+    # The Stop channel is claimed by either a known Stop guard or the event, so an
     # unknown ``--guard`` on a Stop event cannot fall through to the write-guard
     # path below and block session completion (it fails open here instead).
-    if guard == "session-complete" or _is_stop_event(event, ev):
+    if guard in _STOP_GUARDS or _is_stop_event(event, ev):
         stop_dialect = _stop_dialect_for(tool)
-        if guard != "session-complete":
+        if guard not in _STOP_GUARDS:
             # Unrecognized guard on a Stop event — emit a non-blocking decision
             # without evaluating any policy. A Stop guard must never trap the agent.
             return emit_stop_decision(False, "", stop_dialect)
@@ -302,17 +309,33 @@ def _run(event: str, guard: str, tool: str, root: str) -> HookEmission:
             # trap the agent, which a Stop guard must never do.
             return emit_stop_decision(False, "", stop_dialect)
         try:
-            # Git facts feed the predicate: nudge only when the branch has
-            # authored work (commits ahead of base) and no current done marker.
-            # Computed here (lazy subprocess) to keep the predicate pure; any
-            # failure raises and falls through to the fail-open handler below.
-            commits_ahead, done_present = _stop_git_facts(Path(root))
-            decision = session_complete(
-                ev,
-                worktree_root=Path(root),
-                commits_ahead=commits_ahead,
-                done_marker_present=done_present,
-            )
+            if guard == "plan-complete":
+                # Plan-session Stop: nudge unless the plan dir holds a valid plan.
+                # ``has_valid_plan`` pulls in pydantic + models, so it is imported
+                # lazily HERE — never on the hot PreToolUse write path, only on
+                # this Stop branch. Any exception falls through to fail-open below.
+                # The plan dir is ``<worktree>/.wade/plans`` because ``plan()`` sets
+                # ``plan_output_dir = planning_worktree / ".wade" / "plans"`` and the
+                # hook is installed with ``--root <planning_worktree>``.
+                from wade.utils.plan_validation import has_valid_plan
+
+                decision = plan_complete(
+                    ev,
+                    worktree_root=Path(root),
+                    has_valid_plan=has_valid_plan(Path(root) / ".wade" / "plans"),
+                )
+            else:
+                # Git facts feed the predicate: nudge only when the branch has
+                # authored work (commits ahead of base) and no current done marker.
+                # Computed here (lazy subprocess) to keep the predicate pure; any
+                # failure raises and falls through to the fail-open handler below.
+                commits_ahead, done_present = _stop_git_facts(Path(root))
+                decision = session_complete(
+                    ev,
+                    worktree_root=Path(root),
+                    commits_ahead=commits_ahead,
+                    done_marker_present=done_present,
+                )
             should_block = decision.action == "deny"
             reason = decision.reason
             if should_block:
@@ -391,7 +414,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Canonical hook event: pre_tool_use, stop, or session_start.",
     )
     parser.add_argument(
-        "--guard", required=True, help="Guard policy: worktree | plan | session-complete."
+        "--guard",
+        required=True,
+        help="Guard policy: worktree | plan | session-complete | plan-complete.",
     )
     parser.add_argument("--tool", required=True, help="AI tool id (selects the output dialect).")
     parser.add_argument("--root", default="", help="Worktree root — required by write guards.")

--- a/src/wade/hooks/policies.py
+++ b/src/wade/hooks/policies.py
@@ -26,16 +26,15 @@ import os
 import posixpath
 import re
 import shlex
-from enum import StrEnum
 from pathlib import Path
 
 from crossby.hooks.runtime import HookDecision, HookEvent
 
+from wade.models.hooks import StopGuard
 from wade.utils import markers
 
 __all__ = [
     "GUARD_NAMES",
-    "StopGuard",
     "plan_artifact_only",
     "plan_complete",
     "session_complete",
@@ -43,21 +42,6 @@ __all__ = [
     "stop_nudge_marker_path",
     "worktree_containment",
 ]
-
-
-class StopGuard(StrEnum):
-    """The Stop-hook guards ``wade-hook stop --guard`` accepts.
-
-    A single source of truth shared by the installer
-    (:func:`wade.services.implementation_service.bootstrap._install_stop_hook`)
-    and the CLI (``wade.hooks.cli._STOP_GUARDS``), so bootstrap cannot install a
-    guard the CLI does not recognize and a typo is a type error rather than a
-    silently fail-open unknown guard. A worktree is only ever one kind of session,
-    so the two guards never share one.
-    """
-
-    SESSION_COMPLETE = "session-complete"  # impl/review sessions — nudge to run ``done``
-    PLAN_COMPLETE = "plan-complete"  # plan sessions — nudge to write a valid plan file
 
 
 # Guard names understood by the ``wade hook`` entry point. ``worktree`` / ``plan``

--- a/src/wade/hooks/policies.py
+++ b/src/wade/hooks/policies.py
@@ -26,6 +26,7 @@ import os
 import posixpath
 import re
 import shlex
+from enum import StrEnum
 from pathlib import Path
 
 from crossby.hooks.runtime import HookDecision, HookEvent
@@ -34,6 +35,7 @@ from wade.utils import markers
 
 __all__ = [
     "GUARD_NAMES",
+    "StopGuard",
     "plan_artifact_only",
     "plan_complete",
     "session_complete",
@@ -42,11 +44,25 @@ __all__ = [
     "worktree_containment",
 ]
 
+
+class StopGuard(StrEnum):
+    """The Stop-hook guards ``wade-hook stop --guard`` accepts.
+
+    A single source of truth shared by the installer
+    (:func:`wade.services.implementation_service.bootstrap._install_stop_hook`)
+    and the CLI (``wade.hooks.cli._STOP_GUARDS``), so bootstrap cannot install a
+    guard the CLI does not recognize and a typo is a type error rather than a
+    silently fail-open unknown guard. A worktree is only ever one kind of session,
+    so the two guards never share one.
+    """
+
+    SESSION_COMPLETE = "session-complete"  # impl/review sessions — nudge to run ``done``
+    PLAN_COMPLETE = "plan-complete"  # plan sessions — nudge to write a valid plan file
+
+
 # Guard names understood by the ``wade hook`` entry point. ``worktree`` / ``plan``
-# are PreToolUse write guards; ``session-complete`` / ``plan-complete`` are Stop
-# guards (an impl/review session vs a plan session — a worktree is only ever one
-# of the two, so the two Stop guards never share a session).
-GUARD_NAMES = ("worktree", "plan", "session-complete", "plan-complete")
+# are PreToolUse write guards; the Stop guards come from :class:`StopGuard`.
+GUARD_NAMES = ("worktree", "plan", *(g.value for g in StopGuard))
 
 # Name of the single-shot flag marker (under ``.wade/``, gitignored per-session)
 # that records the Stop guard already nudged this worktree. Unlike the sha-keyed

--- a/src/wade/hooks/policies.py
+++ b/src/wade/hooks/policies.py
@@ -35,6 +35,7 @@ from wade.utils import markers
 __all__ = [
     "GUARD_NAMES",
     "plan_artifact_only",
+    "plan_complete",
     "session_complete",
     "shell_containment",
     "stop_nudge_marker_path",
@@ -42,8 +43,10 @@ __all__ = [
 ]
 
 # Guard names understood by the ``wade hook`` entry point. ``worktree`` / ``plan``
-# are PreToolUse write guards; ``session-complete`` is a Stop guard.
-GUARD_NAMES = ("worktree", "plan", "session-complete")
+# are PreToolUse write guards; ``session-complete`` / ``plan-complete`` are Stop
+# guards (an impl/review session vs a plan session — a worktree is only ever one
+# of the two, so the two Stop guards never share a session).
+GUARD_NAMES = ("worktree", "plan", "session-complete", "plan-complete")
 
 # Name of the single-shot flag marker (under ``.wade/``, gitignored per-session)
 # that records the Stop guard already nudged this worktree. Unlike the sha-keyed
@@ -762,4 +765,52 @@ def session_complete(
         "`wade review-pr-comments-session done`) to sync, push, and finalize the "
         "PR. If you are pausing to ask a question or are still mid-task, disregard "
         "this and continue."
+    )
+
+
+def plan_complete(
+    event: HookEvent,
+    *,
+    worktree_root: Path,
+    has_valid_plan: bool = False,
+) -> HookDecision:
+    """Stop-hook guard: nudge (once) when a plan session produced no valid plan.
+
+    Mirrors :func:`session_complete` — a pure predicate fed a fact the
+    ``wade-hook`` CLI computes (here ``has_valid_plan``: does the plan dir hold at
+    least one ``PLAN*.md`` with no error-level diagnostics). Returns a ``deny``
+    (which the Stop path renders as *block the stop and feed the reason back*) when
+    the session is about to end with nothing wade can turn into an issue, so the
+    plan-phase requirement is enforced rather than left to the agent's goodwill.
+
+    Allow conditions, in order (same shape as ``session_complete``):
+
+    - ``event.stop_hook_active`` — Claude sets this once its Stop hook has fired
+      and blocked; other tools do not send it. Prevents looping.
+    - ``has_valid_plan`` — the session already wrote a usable plan; nothing to nudge.
+    - the ``.wade/stop-nudged`` single-shot marker — the CLI writes it after this
+      guard blocks, so the second Stop is allowed on *any* tool, not just Claude.
+      This predicate only *reads* the marker; the CLI owns the write. The marker
+      is shared with ``session_complete`` because a worktree is a plan worktree or
+      an impl worktree, never both, so the two guards never collide on it.
+
+    The message is deliberately ignorable so a legitimate pause (e.g. stopping to
+    ask the user a question mid-plan) costs at most one gentle nudge. The hook is
+    only installed in plan-session worktrees on Stop-capable tools, so no
+    session-detection is needed here.
+    """
+    if event.stop_hook_active:
+        return HookDecision.allow()
+
+    if has_valid_plan:
+        return HookDecision.allow()  # a usable plan already exists
+
+    if stop_nudge_present(worktree_root):
+        return HookDecision.allow()  # already nudged once this worktree
+
+    return HookDecision.deny(
+        "Before finishing: write at least one valid `PLAN*.md` (a title with a "
+        "conventional-commit prefix, e.g. `feat: ...`, plus a `## Complexity` "
+        "section) to the plan directory so wade can create the issue. If you are "
+        "pausing to ask a question or are still mid-plan, disregard this and continue."
     )

--- a/src/wade/models/__init__.py
+++ b/src/wade/models/__init__.py
@@ -23,6 +23,7 @@ from wade.models.config import (
 from wade.models.delegation import DelegationMode, DelegationRequest, DelegationResult
 from wade.models.deps import DependencyEdge, DependencyGraph
 from wade.models.events import EventType, WorkflowEvent
+from wade.models.hooks import StopGuard
 from wade.models.session import (
     ImplementationSession,
     MergeStrategy,
@@ -59,6 +60,7 @@ __all__ = [
     "ProjectSettings",
     "ProviderConfig",
     "ProviderID",
+    "StopGuard",
     "SyncEvent",
     "SyncResult",
     "Task",

--- a/src/wade/models/hooks.py
+++ b/src/wade/models/hooks.py
@@ -1,0 +1,29 @@
+"""Hook-related domain models — pure data shared by the hooks and service layers.
+
+Lives in the leaf ``models`` layer so both the ``wade-hook`` CLI
+(:mod:`wade.hooks`) and the bootstrap installer
+(:mod:`wade.services.implementation_service.bootstrap`) can name the same guard
+identifiers without the service layer importing the hooks layer (which the
+layering rules forbid).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["StopGuard"]
+
+
+class StopGuard(StrEnum):
+    """The Stop-hook guards ``wade-hook stop --guard`` accepts.
+
+    A single source of truth shared by the installer
+    (:func:`wade.services.implementation_service.bootstrap._install_stop_hook`)
+    and the CLI (``wade.hooks.cli._STOP_GUARDS``), so bootstrap cannot install a
+    guard the CLI does not recognize and a typo is a type error rather than a
+    silently fail-open unknown guard. A worktree is only ever one kind of session,
+    so the two guards never share one.
+    """
+
+    SESSION_COMPLETE = "session-complete"  # impl/review sessions — nudge to run ``done``
+    PLAN_COMPLETE = "plan-complete"  # plan sessions — nudge to write a valid plan file

--- a/src/wade/services/implementation_service/bootstrap.py
+++ b/src/wade/services/implementation_service/bootstrap.py
@@ -310,15 +310,21 @@ def _install_guard_hooks(
     logger.info(f"implementation.{guard_type}_guard_hooks_installed", path=str(worktree_path))
 
 
-def _install_stop_hook(worktree_path: Path) -> None:
-    """Install a Stop-hook workflow-completion reminder into each capable tool.
+def _install_stop_hook(worktree_path: Path, *, guard: str = "session-complete") -> None:
+    """Install a Stop-hook completion reminder into each capable tool.
 
-    On session Stop, ``wade hook stop --guard session-complete`` nudges (once)
-    when the session branch has commits ahead of its base and no current
-    ``.wade/done@<HEAD>`` marker — enforcing the closing steps rather than relying
-    on the skill checklist. Installed only for tools that fire a blocking Stop
-    hook (``supports_stop_hook``), which as of crossby 0.13 is every tool wade
-    drives: Copilot joined once its ``agentStop`` event and blocking
+    On session Stop, ``wade hook stop --guard {guard}`` nudges (once) when the
+    session's closing artifact is missing — enforcing the closing step rather than
+    relying on the skill checklist. Two guards share this installer:
+
+    - ``session-complete`` (impl/review sessions) nudges when the branch has
+      commits ahead of its base and no current ``.wade/done@<HEAD>`` marker.
+    - ``plan-complete`` (plan sessions) nudges when the plan dir holds no valid
+      ``PLAN*.md`` yet.
+
+    Installed only for tools that fire a blocking Stop hook
+    (``supports_stop_hook``), which as of crossby 0.13 is every tool wade drives:
+    Copilot joined once its ``agentStop`` event and blocking
     ``{"decision": "block", "reason": …}`` contract were confirmed. Merged
     alongside the PreToolUse write guard by crossby's hook writers.
 
@@ -336,11 +342,11 @@ def _install_stop_hook(worktree_path: Path) -> None:
     for tool_id, writer in _hook_writers():
         if not AbstractAITool.get(tool_id).capabilities().supports_stop_hook:
             continue
-        command = f"wade-hook stop --guard session-complete --tool {tool_id.value} --root {root}"
+        command = f"wade-hook stop --guard {guard} --tool {tool_id.value} --root {root}"
         hook = HookEntry(event="stop", tools=[], command=command)
         _log_sync_result(writer.sync(SyncData(hooks=[hook]), worktree_path), tool_id)
 
-    logger.info("implementation.stop_hook_installed", path=str(worktree_path))
+    logger.info("implementation.stop_hook_installed", path=str(worktree_path), guard=guard)
 
 
 def _effective_copy_files(config: ProjectConfig) -> list[str]:
@@ -660,9 +666,12 @@ def bootstrap_worktree(
     # overwrite the guarded config files.
     _install_guard_hooks(worktree_path, guard_type="plan" if plan_mode else "worktree")
 
-    # Implement/review sessions (not plan) also get a Stop-hook completion
-    # reminder that nudges the agent to run `done` before exit.
-    if not plan_mode:
+    # Every session gets a Stop-hook completion reminder, but the guard differs:
+    # plan sessions nudge to write a valid plan; impl/review sessions nudge to run
+    # `done` (and also get the pre-push backstop that hard-enforces it).
+    if plan_mode:
+        _install_stop_hook(worktree_path, guard="plan-complete")
+    else:
         _install_stop_hook(worktree_path)
 
         # ...and the pre-push backstop that makes the `done` gate hard to skip:

--- a/src/wade/services/implementation_service/bootstrap.py
+++ b/src/wade/services/implementation_service/bootstrap.py
@@ -14,13 +14,13 @@ if TYPE_CHECKING:
     from crossby.sync.base import AbstractSyncWriter
 
 from wade.git import repo as git_repo
-from wade.hooks.policies import StopGuard
 from wade.models.config import (
     AI_COMMAND_NAMES,
     WADE_BASE_ALLOWLIST_PATTERN,
     ProjectConfig,
     with_wade_base_pattern,
 )
+from wade.models.hooks import StopGuard
 from wade.models.task import Task
 from wade.utils.markdown import has_marker_block, remove_marker_block
 

--- a/src/wade/services/implementation_service/bootstrap.py
+++ b/src/wade/services/implementation_service/bootstrap.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from crossby.sync.base import AbstractSyncWriter
 
 from wade.git import repo as git_repo
+from wade.hooks.policies import StopGuard
 from wade.models.config import (
     AI_COMMAND_NAMES,
     WADE_BASE_ALLOWLIST_PATTERN,
@@ -310,7 +311,9 @@ def _install_guard_hooks(
     logger.info(f"implementation.{guard_type}_guard_hooks_installed", path=str(worktree_path))
 
 
-def _install_stop_hook(worktree_path: Path, *, guard: str = "session-complete") -> None:
+def _install_stop_hook(
+    worktree_path: Path, *, guard: StopGuard = StopGuard.SESSION_COMPLETE
+) -> None:
     """Install a Stop-hook completion reminder into each capable tool.
 
     On session Stop, ``wade hook stop --guard {guard}`` nudges (once) when the
@@ -342,11 +345,11 @@ def _install_stop_hook(worktree_path: Path, *, guard: str = "session-complete") 
     for tool_id, writer in _hook_writers():
         if not AbstractAITool.get(tool_id).capabilities().supports_stop_hook:
             continue
-        command = f"wade-hook stop --guard {guard} --tool {tool_id.value} --root {root}"
+        command = f"wade-hook stop --guard {guard.value} --tool {tool_id.value} --root {root}"
         hook = HookEntry(event="stop", tools=[], command=command)
         _log_sync_result(writer.sync(SyncData(hooks=[hook]), worktree_path), tool_id)
 
-    logger.info("implementation.stop_hook_installed", path=str(worktree_path), guard=guard)
+    logger.info("implementation.stop_hook_installed", path=str(worktree_path), guard=guard.value)
 
 
 def _effective_copy_files(config: ProjectConfig) -> list[str]:
@@ -670,7 +673,7 @@ def bootstrap_worktree(
     # plan sessions nudge to write a valid plan; impl/review sessions nudge to run
     # `done` (and also get the pre-push backstop that hard-enforces it).
     if plan_mode:
-        _install_stop_hook(worktree_path, guard="plan-complete")
+        _install_stop_hook(worktree_path, guard=StopGuard.PLAN_COMPLETE)
     else:
         _install_stop_hook(worktree_path)
 

--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -1061,16 +1061,34 @@ def _preserve_generated_plans(
     which keeps the worktree/temp dir from lingering.
     """
     generated = discover_plan_files(Path(plan_dir))
-    if generated:
-        try:
-            preserved = Path(tempfile.mkdtemp(prefix="wade-plans-"))
-            for plan_file in generated:
-                shutil.copy2(plan_file, preserved / plan_file.name)
-            console.info(
-                f"Preserved {len(generated)} generated plan file(s) — fix the reported "
-                "errors and re-run `wade plan` instead of regenerating from scratch."
-            )
-            console.hint(f"Plan files: {preserved}")
-        except OSError:
-            logger.warning("plan.preserve_generated_failed", exc_info=True)
+    if not generated:
+        # Nothing to salvage — the usual cleanup can run unconditionally.
+        _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
+        return
+
+    try:
+        preserved = Path(tempfile.mkdtemp(prefix="wade-plans-"))
+        for plan_file in generated:
+            shutil.copy2(plan_file, preserved / plan_file.name)
+    except OSError:
+        # A copy failed after mkdtemp, so the temp dir may hold only part of the
+        # batch. Retain the original plan dir/worktree instead of deleting it —
+        # never trade a partial salvage for the intact source — and point the
+        # user at the untouched originals still sitting in ``plan_dir``.
+        logger.warning("plan.preserve_generated_failed", exc_info=True)
+        _report_preserved_plans(len(generated), Path(plan_dir))
+        return
+
+    # Every file copied cleanly — the stable copy now stands in for the source,
+    # so the normal cleanup can remove the worktree/temp dir.
+    _report_preserved_plans(len(generated), preserved)
     _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
+
+
+def _report_preserved_plans(count: int, location: Path) -> None:
+    """Point the user at the ``count`` salvaged plan files under ``location``."""
+    console.info(
+        f"Preserved {count} generated plan file(s) — fix the reported "
+        "errors and re-run `wade plan` instead of regenerating from scratch."
+    )
+    console.hint(f"Plan files: {location}")

--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -13,7 +13,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-from enum import StrEnum
 from pathlib import Path
 
 import structlog
@@ -23,7 +22,6 @@ from crossby.ai_tools.transcript import (
     read_transcript_excerpt,
 )
 from crossby.models.ai import AIToolID, EffortLevel, TokenUsage
-from pydantic import BaseModel
 
 from wade.config.loader import load_config
 from wade.models.config import ProjectConfig
@@ -50,6 +48,13 @@ from wade.services.task_service import (
 from wade.ui import prompts
 from wade.ui.console import console
 from wade.utils.markdown import append_session_to_body
+from wade.utils.plan_validation import PlanDiagnostic as PlanDiagnostic
+from wade.utils.plan_validation import PlanDiagnosticLevel as PlanDiagnosticLevel
+from wade.utils.plan_validation import PlanValidationResult as PlanValidationResult
+from wade.utils.plan_validation import discover_plan_files as discover_plan_files
+from wade.utils.plan_validation import has_valid_plan as has_valid_plan
+from wade.utils.plan_validation import plan_done as plan_done
+from wade.utils.plan_validation import validate_plan_dir as validate_plan_dir
 from wade.utils.process import run_with_transcript
 from wade.utils.terminal import (
     compose_plan_title,
@@ -102,13 +107,13 @@ def _build_issue_context_header(issue: Task) -> str:
 # ---------------------------------------------------------------------------
 # Plan file discovery and validation
 # ---------------------------------------------------------------------------
-
-
-def discover_plan_files(plan_dir: Path) -> list[Path]:
-    """Find PLAN*.md files in the plan directory, sorted by name."""
-    if not plan_dir.is_dir():
-        return []
-    return sorted(plan_dir.glob("PLAN*.md"))
+#
+# ``discover_plan_files`` / ``validate_plan_dir`` / ``plan_done`` and the
+# diagnostic types now live in :mod:`wade.utils.plan_validation` (a lean,
+# UI-free module the ``wade-hook`` Stop path can import cheaply); they are
+# re-exported at the top of this module for back-compat. ``validate_plan_files``
+# stays here because it calls ``console.warn`` — a UI dependency that must not
+# leak into ``utils/``.
 
 
 def validate_plan_files(plan_dir: Path) -> list[PlanFile]:
@@ -129,129 +134,80 @@ def validate_plan_files(plan_dir: Path) -> list[PlanFile]:
     return valid
 
 
-# ---------------------------------------------------------------------------
-# Plan-done validation (deterministic gate for planning sessions)
-# ---------------------------------------------------------------------------
+def _select_valid_plans(
+    plan_dir: Path,
+    plan_files: list[PlanFile],
+    *,
+    yolo: bool,
+) -> list[PlanFile] | None:
+    """Strict-validate discovered plans before wade turns them into issues.
 
-_RECOMMENDED_SECTIONS = ("tasks", "acceptance criteria")
+    This is the enforcement that makes ``## Complexity`` + a conventional-commit
+    title mandatory on the issue-creation path — independent of whether the agent
+    ran ``wade plan-session done``. ``plan_files`` are the title-parseable files
+    from :func:`validate_plan_files`; here we drop any that fail the *strict*
+    :func:`validate_plan_dir` gate (missing/invalid complexity, bad title prefix).
 
-_CONVENTIONAL_COMMIT_RE = re.compile(
-    r"^(feat|fix|docs|refactor|chore|style|perf|test|ci|build|revert|update)(\(.+\))?!?:\s+\S"
-)
+    Returns:
+        - The filtered ``list[PlanFile]`` (only files with no error diagnostics)
+          when at least one valid file remains and the user did not abort.
+        - ``[]`` when **no** valid files remain.
+        - ``None`` when the run is interactive, some files are valid and some are
+          not, and the user declined the partial run.
 
+    For both ``[]`` and ``None`` the caller creates nothing, returns ``False``,
+    and cleans up the plan dir/worktree like every other ``plan()`` failure path.
+    The plan is *not* preserved — re-running ``wade plan`` regenerates it; this
+    helper's job is only to keep invalid plans from silently becoming issues.
 
-class PlanDiagnosticLevel(StrEnum):
-    ERROR = "error"
-    WARNING = "warning"
-
-
-class PlanDiagnostic(BaseModel):
-    """A single diagnostic message for a plan file."""
-
-    file: str
-    level: PlanDiagnosticLevel
-    message: str
-
-
-class PlanValidationResult(BaseModel):
-    """Aggregated validation result for all plan files in a directory."""
-
-    diagnostics: list[PlanDiagnostic] = []
-
-    @property
-    def errors(self) -> list[PlanDiagnostic]:
-        return [d for d in self.diagnostics if d.level == PlanDiagnosticLevel.ERROR]
-
-    @property
-    def warnings(self) -> list[PlanDiagnostic]:
-        return [d for d in self.diagnostics if d.level == PlanDiagnosticLevel.WARNING]
-
-    @property
-    def has_errors(self) -> bool:
-        return bool(self.errors)
-
-
-def validate_plan_dir(plan_dir: Path) -> PlanValidationResult:
-    """Validate all plan files in the directory.
-
-    Collects all errors and warnings across every ``.md`` file.
-
-    Errors (exit 1):
-    - No plan files found
-    - Missing ``# Title`` heading
-    - Missing or invalid ``## Complexity`` section
-
-    Warnings (exit 0):
-    - Missing recommended sections (``## Tasks``, ``## Acceptance Criteria``)
+    Every error is surfaced loudly via ``console.error`` (invalid files are never
+    silently dropped); warnings via ``console.warn`` do not exclude a file. In a
+    non-TTY or ``yolo`` run the valid subset proceeds after the loud warning, so
+    headless runs never hang on the confirmation prompt.
     """
-    result = PlanValidationResult()
-    md_files = discover_plan_files(plan_dir)
+    result = validate_plan_dir(plan_dir)
+    errors_by_file: dict[str, list[str]] = {}
+    for diag in result.errors:
+        errors_by_file.setdefault(diag.file, []).append(diag.message)
+    for diag in result.warnings:
+        console.warn(f"{diag.file}: {diag.message}")
 
-    if not md_files:
-        result.diagnostics.append(
-            PlanDiagnostic(
-                file="(none)",
-                level=PlanDiagnosticLevel.ERROR,
-                message="No plan files (.md) found in the plan directory.",
-            )
+    valid: list[PlanFile] = []
+    invalid: list[PlanFile] = []
+    for plan in plan_files:
+        file_errors = errors_by_file.get(plan.path.name)
+        if file_errors:
+            invalid.append(plan)
+            for message in file_errors:
+                console.error(f"{plan.path.name}: {message}")
+        else:
+            valid.append(plan)
+
+    if not valid:
+        console.error(
+            f"No valid plan files — all {len(invalid)} failed validation "
+            "(need a '## Complexity' and a conventional-commit title prefix)."
         )
-        return result
+        return []
 
-    for md_file in md_files:
-        try:
-            plan = PlanFile.from_markdown(md_file)
-        except (ValueError, OSError) as e:
-            result.diagnostics.append(
-                PlanDiagnostic(file=md_file.name, level=PlanDiagnosticLevel.ERROR, message=str(e))
+    if invalid:
+        console.warn(
+            f"{len(invalid)} plan file(s) failed validation and will be skipped: "
+            f"{', '.join(p.path.name for p in invalid)}"
+        )
+        if prompts.is_tty() and not yolo:
+            proceed = prompts.confirm(
+                f"{len(invalid)} plan file(s) failed validation and will be skipped — "
+                f"continue with the {len(valid)} valid one(s)?",
+                default=True,
             )
-            continue
-
-        if plan.complexity is None:
-            result.diagnostics.append(
-                PlanDiagnostic(
-                    file=md_file.name,
-                    level=PlanDiagnosticLevel.ERROR,
-                    message=(
-                        "Missing or invalid '## Complexity' section. "
-                        "Must be one of: easy, medium, complex, very_complex."
-                    ),
+            if not proceed:
+                console.info(
+                    "Aborted — no issues created. Re-run `wade plan` to regenerate the plan."
                 )
-            )
+                return None
 
-        if not _CONVENTIONAL_COMMIT_RE.match(plan.title):
-            result.diagnostics.append(
-                PlanDiagnostic(
-                    file=md_file.name,
-                    level=PlanDiagnosticLevel.ERROR,
-                    message=(
-                        f"Title '{plan.title}' does not start with a conventional commit prefix. "
-                        "Use: feat, fix, docs, refactor, chore, style, perf, test, ci, build, "
-                        "revert, update. Example: 'feat: add retry logic to task provider'."
-                    ),
-                )
-            )
-
-        for section in _RECOMMENDED_SECTIONS:
-            if section not in plan.sections:
-                heading = section.title()
-                result.diagnostics.append(
-                    PlanDiagnostic(
-                        file=md_file.name,
-                        level=PlanDiagnosticLevel.WARNING,
-                        message=f"Missing recommended section: '## {heading}'.",
-                    )
-                )
-
-    return result
-
-
-def plan_done(plan_dir: Path) -> PlanValidationResult:
-    """Validate plan files and return aggregated diagnostics.
-
-    The caller is responsible for rendering results and determining the exit code.
-    Use ``result.has_errors`` to check whether validation passed.
-    """
-    return validate_plan_dir(plan_dir)
+    return valid
 
 
 # ---------------------------------------------------------------------------
@@ -550,48 +506,56 @@ def plan(
     # decided the work should be split into multiple issues.
     if existing_issue is not None:
         plan_files = validate_plan_files(Path(plan_dir))
-        if plan_files:
-            console.info(f"Found {len(plan_files)} plan file(s)")
-            if len(plan_files) == 1:
-                _attach_plan_to_existing_issue(
+        if not plan_files:
+            console.warn("No plan files found — the AI session may not have produced output.")
+        else:
+            # Strict gate — drop plans missing complexity / a valid title prefix.
+            # ``None`` (user aborted) or ``[]`` (all invalid) both fall through to
+            # the shared cleanup tail below (the helper already reported why),
+            # mutating no issue — the "No plan files found" line above is skipped.
+            selected = _select_valid_plans(Path(plan_dir), plan_files, yolo=resolved_yolo)
+            if selected:
+                plan_files = selected
+                console.info(f"Found {len(plan_files)} plan file(s)")
+                if len(plan_files) == 1:
+                    _attach_plan_to_existing_issue(
+                        provider=provider,
+                        config=config,
+                        issue=existing_issue,
+                        plan_file=plan_files[0],
+                        repo_root=repo_root,
+                    )
+                    finalize_issue_numbers = [existing_issue.id]
+                else:
+                    finalize_issue_numbers = _supersede_issue_with_plans(
+                        provider=provider,
+                        config=config,
+                        issue=existing_issue,
+                        plan_files=plan_files,
+                        repo_root=repo_root,
+                        yolo=resolved_yolo,
+                    )
+                stop_title_keeper()
+                if not finalize_issue_numbers:
+                    console.warn("No issues were created from plan files.")
+                    _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
+                    return False
+                offer_result = _finalize_issues(
                     provider=provider,
                     config=config,
-                    issue=existing_issue,
-                    plan_file=plan_files[0],
+                    issue_numbers=finalize_issue_numbers,
+                    ai_tool=resolved_tool,
+                    model=resolved_model,
+                    usage=usage,
                     repo_root=repo_root,
-                )
-                finalize_issue_numbers = [existing_issue.id]
-            else:
-                finalize_issue_numbers = _supersede_issue_with_plans(
-                    provider=provider,
-                    config=config,
-                    issue=existing_issue,
-                    plan_files=plan_files,
-                    repo_root=repo_root,
+                    planning_worktree=planning_worktree,
+                    effort=resolved_effort,
                     yolo=resolved_yolo,
                 )
-            stop_title_keeper()
-            if not finalize_issue_numbers:
-                console.warn("No issues were created from plan files.")
                 _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
-                return False
-            offer_result = _finalize_issues(
-                provider=provider,
-                config=config,
-                issue_numbers=finalize_issue_numbers,
-                ai_tool=resolved_tool,
-                model=resolved_model,
-                usage=usage,
-                repo_root=repo_root,
-                planning_worktree=planning_worktree,
-                effort=resolved_effort,
-                yolo=resolved_yolo,
-            )
-            _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
-            if offer_result is not None:
-                return offer_result
-            return True
-        console.warn("No plan files found — the AI session may not have produced output.")
+                if offer_result is not None:
+                    return offer_result
+                return True
         _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
         stop_title_keeper()
         return False
@@ -600,32 +564,39 @@ def plan(
     plan_files = validate_plan_files(Path(plan_dir))
 
     if plan_files:
-        console.info(f"Found {len(plan_files)} plan file(s)")
-        created_numbers, _failed_files = _create_issues_from_plans(
-            provider=provider,
-            config=config,
-            plan_files=plan_files,
-            repo_root=repo_root,
-        )
-        if created_numbers:
-            stop_title_keeper()
-            offer_result = _finalize_issues(
+        # Strict gate — invalid plans (missing complexity / bad title prefix)
+        # never silently become issues. ``None`` (aborted) or ``[]`` (all invalid)
+        # fall through to the shared cleanup tail below; the helper already
+        # surfaced the reason loudly.
+        selected = _select_valid_plans(Path(plan_dir), plan_files, yolo=resolved_yolo)
+        if selected:
+            plan_files = selected
+            console.info(f"Found {len(plan_files)} plan file(s)")
+            created_numbers, _failed_files = _create_issues_from_plans(
                 provider=provider,
                 config=config,
-                issue_numbers=created_numbers,
-                ai_tool=resolved_tool,
-                model=resolved_model,
-                usage=usage,
+                plan_files=plan_files,
                 repo_root=repo_root,
-                planning_worktree=planning_worktree,
-                effort=resolved_effort,
-                yolo=resolved_yolo,
             )
-            _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
-            if offer_result is not None:
-                return offer_result
-            return True
-        console.warn("No issues were created from plan files.")
+            if created_numbers:
+                stop_title_keeper()
+                offer_result = _finalize_issues(
+                    provider=provider,
+                    config=config,
+                    issue_numbers=created_numbers,
+                    ai_tool=resolved_tool,
+                    model=resolved_model,
+                    usage=usage,
+                    repo_root=repo_root,
+                    planning_worktree=planning_worktree,
+                    effort=resolved_effort,
+                    yolo=resolved_yolo,
+                )
+                _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
+                if offer_result is not None:
+                    return offer_result
+                return True
+            console.warn("No issues were created from plan files.")
     else:
         console.warn("No plan files found.")
         console.hint("The AI session may not have produced any output.")

--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -155,10 +155,11 @@ def _select_valid_plans(
         - ``None`` when the run is interactive, some files are valid and some are
           not, and the user declined the partial run.
 
-    For both ``[]`` and ``None`` the caller creates nothing, returns ``False``,
-    and cleans up the plan dir/worktree like every other ``plan()`` failure path.
-    The plan is *not* preserved — re-running ``wade plan`` regenerates it; this
-    helper's job is only to keep invalid plans from silently becoming issues.
+    For both ``[]`` and ``None`` the caller creates nothing and returns ``False``,
+    but the generated ``PLAN*.md`` are first salvaged to a stable temp dir (see
+    :func:`_preserve_generated_plans`) so a trivial validation miss doesn't force a
+    full re-run — this helper's job is only to keep invalid plans from silently
+    becoming issues, not to decide their fate.
 
     Every error is surfaced loudly via ``console.error`` (invalid files are never
     silently dropped); warnings via ``console.warn`` do not exclude a file. In a
@@ -510,9 +511,9 @@ def plan(
             console.warn("No plan files found — the AI session may not have produced output.")
         else:
             # Strict gate — drop plans missing complexity / a valid title prefix.
-            # ``None`` (user aborted) or ``[]`` (all invalid) both fall through to
-            # the shared cleanup tail below (the helper already reported why),
-            # mutating no issue — the "No plan files found" line above is skipped.
+            # ``None`` (user aborted) or ``[]`` (all invalid) both bail below via
+            # _preserve_generated_plans (the helper already reported why), mutating
+            # no issue — the "No plan files found" line above is skipped.
             selected = _select_valid_plans(Path(plan_dir), plan_files, yolo=resolved_yolo)
             if selected:
                 plan_files = selected
@@ -556,6 +557,15 @@ def plan(
                 if offer_result is not None:
                     return offer_result
                 return True
+            # Strict gate rejected the batch (all invalid, or the user aborted a
+            # partial run). Preserve the generated files — the helper already
+            # surfaced the reason — so a validation miss doesn't force a full
+            # AI re-planning run.
+            _preserve_generated_plans(plan_dir, repo_root, planning_worktree)
+            stop_title_keeper()
+            return False
+        # Reached only when the session produced no plan files (nothing to
+        # preserve) — clean up like every other failure path.
         _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)
         stop_title_keeper()
         return False
@@ -566,7 +576,7 @@ def plan(
     if plan_files:
         # Strict gate — invalid plans (missing complexity / bad title prefix)
         # never silently become issues. ``None`` (aborted) or ``[]`` (all invalid)
-        # fall through to the shared cleanup tail below; the helper already
+        # take the preserve-then-bail else branch below; the helper already
         # surfaced the reason loudly.
         selected = _select_valid_plans(Path(plan_dir), plan_files, yolo=resolved_yolo)
         if selected:
@@ -597,6 +607,14 @@ def plan(
                     return offer_result
                 return True
             console.warn("No issues were created from plan files.")
+        else:
+            # Strict gate rejected the batch (all invalid, or the user aborted a
+            # partial run). Preserve the generated files — the helper already
+            # surfaced the reason — so a validation miss doesn't force a full
+            # AI re-planning run.
+            _preserve_generated_plans(plan_dir, repo_root, planning_worktree)
+            stop_title_keeper()
+            return False
     else:
         console.warn("No plan files found.")
         console.hint("The AI session may not have produced any output.")
@@ -1024,3 +1042,35 @@ def _cleanup_plan_dir(plan_dir: str) -> None:
     """Remove the temporary plan directory."""
     with contextlib.suppress(Exception):
         shutil.rmtree(plan_dir, ignore_errors=True)
+
+
+def _preserve_generated_plans(
+    plan_dir: str,
+    repo_root: Path | None,
+    planning_worktree: Path | None,
+) -> None:
+    """Salvage generated ``PLAN*.md`` before the normal cleanup, then clean up.
+
+    Used when the strict gate (:func:`_select_valid_plans`) rejects a batch — every
+    file failed validation, or the user aborted a partial run. Deleting the plan
+    dir/worktree outright would discard output the user can often repair by hand (a
+    missing ``## Complexity`` header is a one-line edit), forcing a full AI
+    re-planning session for a trivial fix. So copy the files to a stable temp dir
+    first — the same copy-then-clean approach :func:`_warn_token_extraction` uses
+    for transcripts — point the user at them, and only then run the usual cleanup,
+    which keeps the worktree/temp dir from lingering.
+    """
+    generated = discover_plan_files(Path(plan_dir))
+    if generated:
+        try:
+            preserved = Path(tempfile.mkdtemp(prefix="wade-plans-"))
+            for plan_file in generated:
+                shutil.copy2(plan_file, preserved / plan_file.name)
+            console.info(
+                f"Preserved {len(generated)} generated plan file(s) — fix the reported "
+                "errors and re-run `wade plan` instead of regenerating from scratch."
+            )
+            console.hint(f"Plan files: {preserved}")
+        except OSError:
+            logger.warning("plan.preserve_generated_failed", exc_info=True)
+    _cleanup_plan_dir_or_worktree(plan_dir, repo_root, planning_worktree)

--- a/src/wade/utils/plan_validation.py
+++ b/src/wade/utils/plan_validation.py
@@ -1,0 +1,184 @@
+"""Lean plan-file validation core — pure, import-cheap, no UI/crossby deps.
+
+Extracted from :mod:`wade.services.plan_service` so the lean ``wade-hook`` entry
+point (:mod:`wade.hooks.cli`) can reuse the strict validator on the Stop path
+**without** importing ``plan_service`` — which eagerly pulls in
+``crossby.ai_tools`` (~450ms cold start). Everything here imports only stdlib +
+pydantic + :class:`wade.models.task.PlanFile` (itself stdlib + pydantic), so
+importing it adds negligible cost on top of pydantic, which is already loaded.
+
+``plan_service`` re-exports these names for back-compat, so existing
+``from wade.services.plan_service import validate_plan_dir, plan_done, …`` imports
+keep working. The one validator that stays in ``plan_service`` is
+``validate_plan_files`` — it calls ``console.warn`` (a UI dependency that must not
+leak into ``utils/``).
+
+Layering: ``utils/`` may import ``models/``; ``hooks/policies.py`` already imports
+``wade.utils.markers``, so a second lean ``wade.utils`` module on the hook path is
+consistent.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from wade.models.task import PlanFile
+
+# ---------------------------------------------------------------------------
+# Plan file discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_plan_files(plan_dir: Path) -> list[Path]:
+    """Find PLAN*.md files in the plan directory, sorted by name."""
+    if not plan_dir.is_dir():
+        return []
+    return sorted(plan_dir.glob("PLAN*.md"))
+
+
+# ---------------------------------------------------------------------------
+# Plan-done validation (deterministic gate for planning sessions)
+# ---------------------------------------------------------------------------
+
+_RECOMMENDED_SECTIONS = ("tasks", "acceptance criteria")
+
+_CONVENTIONAL_COMMIT_RE = re.compile(
+    r"^(feat|fix|docs|refactor|chore|style|perf|test|ci|build|revert|update)(\(.+\))?!?:\s+\S"
+)
+
+
+class PlanDiagnosticLevel(StrEnum):
+    ERROR = "error"
+    WARNING = "warning"
+
+
+class PlanDiagnostic(BaseModel):
+    """A single diagnostic message for a plan file."""
+
+    file: str
+    level: PlanDiagnosticLevel
+    message: str
+
+
+class PlanValidationResult(BaseModel):
+    """Aggregated validation result for all plan files in a directory."""
+
+    diagnostics: list[PlanDiagnostic] = []
+
+    @property
+    def errors(self) -> list[PlanDiagnostic]:
+        return [d for d in self.diagnostics if d.level == PlanDiagnosticLevel.ERROR]
+
+    @property
+    def warnings(self) -> list[PlanDiagnostic]:
+        return [d for d in self.diagnostics if d.level == PlanDiagnosticLevel.WARNING]
+
+    @property
+    def has_errors(self) -> bool:
+        return bool(self.errors)
+
+
+def validate_plan_dir(plan_dir: Path) -> PlanValidationResult:
+    """Validate all plan files in the directory.
+
+    Collects all errors and warnings across every ``.md`` file.
+
+    Errors (exit 1):
+    - No plan files found
+    - Missing ``# Title`` heading
+    - Missing or invalid ``## Complexity`` section
+
+    Warnings (exit 0):
+    - Missing recommended sections (``## Tasks``, ``## Acceptance Criteria``)
+    """
+    result = PlanValidationResult()
+    md_files = discover_plan_files(plan_dir)
+
+    if not md_files:
+        result.diagnostics.append(
+            PlanDiagnostic(
+                file="(none)",
+                level=PlanDiagnosticLevel.ERROR,
+                message="No plan files (.md) found in the plan directory.",
+            )
+        )
+        return result
+
+    for md_file in md_files:
+        try:
+            plan = PlanFile.from_markdown(md_file)
+        except (ValueError, OSError) as e:
+            result.diagnostics.append(
+                PlanDiagnostic(file=md_file.name, level=PlanDiagnosticLevel.ERROR, message=str(e))
+            )
+            continue
+
+        if plan.complexity is None:
+            result.diagnostics.append(
+                PlanDiagnostic(
+                    file=md_file.name,
+                    level=PlanDiagnosticLevel.ERROR,
+                    message=(
+                        "Missing or invalid '## Complexity' section. "
+                        "Must be one of: easy, medium, complex, very_complex."
+                    ),
+                )
+            )
+
+        if not _CONVENTIONAL_COMMIT_RE.match(plan.title):
+            result.diagnostics.append(
+                PlanDiagnostic(
+                    file=md_file.name,
+                    level=PlanDiagnosticLevel.ERROR,
+                    message=(
+                        f"Title '{plan.title}' does not start with a conventional commit prefix. "
+                        "Use: feat, fix, docs, refactor, chore, style, perf, test, ci, build, "
+                        "revert, update. Example: 'feat: add retry logic to task provider'."
+                    ),
+                )
+            )
+
+        for section in _RECOMMENDED_SECTIONS:
+            if section not in plan.sections:
+                heading = section.title()
+                result.diagnostics.append(
+                    PlanDiagnostic(
+                        file=md_file.name,
+                        level=PlanDiagnosticLevel.WARNING,
+                        message=f"Missing recommended section: '## {heading}'.",
+                    )
+                )
+
+    return result
+
+
+def plan_done(plan_dir: Path) -> PlanValidationResult:
+    """Validate plan files and return aggregated diagnostics.
+
+    The caller is responsible for rendering results and determining the exit code.
+    Use ``result.has_errors`` to check whether validation passed.
+    """
+    return validate_plan_dir(plan_dir)
+
+
+def has_valid_plan(plan_dir: Path) -> bool:
+    """True iff at least one ``PLAN*.md`` file has **no error-level** diagnostics.
+
+    This is the per-file notion the plan Stop guard needs: a single parseable
+    title (with a conventional-commit prefix) **and** a valid ``## Complexity`` is
+    enough to say "the session produced something wade can turn into an issue".
+
+    Note this differs from ``validate_plan_dir(...).has_errors``, which is ``True``
+    if *any* file is invalid even when a valid one also exists — that aggregate is
+    the right gate for ``plan-session done`` (fix everything), but the wrong one
+    for the Stop nudge (did the session produce *anything* usable).
+    """
+    md_files = discover_plan_files(plan_dir)
+    if not md_files:
+        return False
+    files_with_errors = {d.file for d in validate_plan_dir(plan_dir).errors}
+    return any(md_file.name not in files_with_errors for md_file in md_files)

--- a/src/wade/utils/plan_validation.py
+++ b/src/wade/utils/plan_validation.py
@@ -85,7 +85,7 @@ class PlanValidationResult(BaseModel):
 def validate_plan_dir(plan_dir: Path) -> PlanValidationResult:
     """Validate all plan files in the directory.
 
-    Collects all errors and warnings across every ``.md`` file.
+    Collects all errors and warnings across every discovered ``PLAN*.md`` file.
 
     Errors (exit 1):
     - No plan files found
@@ -103,7 +103,7 @@ def validate_plan_dir(plan_dir: Path) -> PlanValidationResult:
             PlanDiagnostic(
                 file="(none)",
                 level=PlanDiagnosticLevel.ERROR,
-                message="No plan files (.md) found in the plan directory.",
+                message="No plan files (PLAN*.md) found in the plan directory.",
             )
         )
         return result

--- a/tests/e2e/test_plan_contract.py
+++ b/tests/e2e/test_plan_contract.py
@@ -59,7 +59,7 @@ if plan_dir is not None:
     (plan_dir / "PLAN-001-deterministic-plan.md").write_text(
         "\\n".join(
             [
-                "# Deterministic plan from fake claude",
+                "# feat: deterministic plan from fake claude",
                 "",
                 "## Complexity",
                 "easy",
@@ -112,7 +112,7 @@ class TestPlanCommand:
 
         issue = issues.get("1")
         assert isinstance(issue, dict)
-        assert issue.get("title") == "Deterministic plan from fake claude"
+        assert issue.get("title") == "feat: deterministic plan from fake claude"
         labels = issue.get("labels", [])
         assert isinstance(labels, list)
         assert "feature-plan" in labels
@@ -124,7 +124,7 @@ class TestPlanCommand:
 
         _assert_gh_called_with(
             mock_gh_cli["log_file"],
-            ["issue", "create", "--title", "Deterministic plan from fake claude"],
+            ["issue", "create", "--title", "feat: deterministic plan from fake claude"],
         )
         _assert_gh_called_with(
             mock_gh_cli["log_file"],

--- a/tests/unit/test_hooks/test_hook_cli.py
+++ b/tests/unit/test_hooks/test_hook_cli.py
@@ -292,6 +292,67 @@ class TestStopGuardCLI:
         assert json.loads(r.stdout) == {"continue": True}
 
 
+_VALID_PLAN = "# feat: add retry logic\n\n## Complexity\ncomplex\n\n## Tasks\n- Do it\n"
+
+
+class TestPlanStopGuardCLI:
+    """The ``plan-complete`` Stop guard — nudges when a plan session wrote no plan.
+
+    Unlike ``session-complete`` it needs no git facts: it reads ``has_valid_plan``
+    on ``<root>/.wade/plans``, so a plain temp dir exercises the block path.
+    """
+
+    def _run_stop(self, tool: str, stdin: str, root: str):
+        return _run("stop", "plan-complete", tool, stdin, root=root)
+
+    def _write_valid_plan(self, root: Path) -> None:
+        plans = root / ".wade" / "plans"
+        plans.mkdir(parents=True, exist_ok=True)
+        (plans / "PLAN.md").write_text(_VALID_PLAN)
+
+    def test_blocks_when_no_valid_plan_and_writes_marker(self, tmp_path: Path) -> None:
+        r = self._run_stop("claude", json.dumps({"stop_hook_active": False}), str(tmp_path))
+        assert r.returncode == 0  # Stop blocks via the JSON decision, not exit code
+        payload = json.loads(r.stdout)
+        assert payload["decision"] == "block"
+        assert "PLAN" in payload["reason"]
+        assert (tmp_path / ".wade" / "stop-nudged").is_file()
+
+    def test_allows_when_valid_plan_present(self, tmp_path: Path) -> None:
+        self._write_valid_plan(tmp_path)
+        r = self._run_stop("claude", json.dumps({"stop_hook_active": False}), str(tmp_path))
+        assert r.returncode == 0
+        assert json.loads(r.stdout) == {"continue": True}
+
+    def test_plan_at_root_not_in_plans_dir_still_blocks(self, tmp_path: Path) -> None:
+        # The plan dir is <root>/.wade/plans — a PLAN.md at the worktree root is
+        # not where plan() writes, so it must not satisfy the guard.
+        (tmp_path / "PLAN.md").write_text(_VALID_PLAN)
+        r = self._run_stop("claude", json.dumps({}), str(tmp_path))
+        assert json.loads(r.stdout)["decision"] == "block"
+
+    def test_single_shot_across_tools(self, tmp_path: Path) -> None:
+        # First Stop (no valid plan) blocks and writes the .wade marker...
+        r1 = self._run_stop("claude", json.dumps({}), str(tmp_path))
+        assert json.loads(r1.stdout)["decision"] == "block"
+        assert (tmp_path / ".wade" / "stop-nudged").is_file()
+        # ...so a second Stop is allowed even on a tool that never sends
+        # stop_hook_active (Codex) — the tool-agnostic single-shot.
+        r2 = self._run_stop("codex", json.dumps({}), str(tmp_path))
+        assert r2.returncode == 0
+        assert json.loads(r2.stdout) == {"continue": True}
+
+    def test_missing_root_fails_open(self) -> None:
+        r = _run("stop", "plan-complete", "claude", json.dumps({}), root=None)
+        assert r.returncode == 0
+        assert json.loads(r.stdout) == {"continue": True}
+
+    def test_block_via_lean_entry(self, tmp_path: Path) -> None:
+        r = _run_lean("stop", "plan-complete", "claude", json.dumps({}), str(tmp_path))
+        assert r.returncode == 0
+        assert json.loads(r.stdout)["decision"] == "block"
+
+
 class TestStopReadErrorFailsOpen:
     def test_unreadable_stdin_fails_open(self, monkeypatch, tmp_path: Path) -> None:
         # A stdin read error on the Stop guard must fail open, not block — the

--- a/tests/unit/test_hooks/test_policies.py
+++ b/tests/unit/test_hooks/test_policies.py
@@ -9,6 +9,7 @@ from crossby.hooks.runtime import HookEvent
 
 from wade.hooks.policies import (
     plan_artifact_only,
+    plan_complete,
     session_complete,
     shell_containment,
     worktree_containment,
@@ -477,3 +478,76 @@ class TestSessionComplete:
             commits_ahead=1,
         )
         assert d.action == "allow"
+
+
+class TestPlanComplete:
+    def test_blocks_when_no_valid_plan(self, tmp_path: Path) -> None:
+        # No valid PLAN*.md + no prior nudge -> nudge to write one.
+        d = plan_complete(HookEvent(event="stop"), worktree_root=tmp_path, has_valid_plan=False)
+        assert d.action == "deny"  # deny == block the stop
+        assert "PLAN" in d.reason
+        assert "Complexity" in d.reason
+
+    def test_allows_when_valid_plan_present(self, tmp_path: Path) -> None:
+        # The session already produced something wade can turn into an issue.
+        d = plan_complete(HookEvent(event="stop"), worktree_root=tmp_path, has_valid_plan=True)
+        assert d.action == "allow"
+
+    def test_allows_when_stop_hook_already_fired(self, tmp_path: Path) -> None:
+        # No valid plan, but Claude's Stop hook already fired -> never loop.
+        d = plan_complete(
+            HookEvent(event="stop", stop_hook_active=True),
+            worktree_root=tmp_path,
+            has_valid_plan=False,
+        )
+        assert d.action == "allow"
+
+    def test_allows_when_nudge_marker_present(self, tmp_path: Path) -> None:
+        # Tool-agnostic single-shot: once the shared marker exists, allow even
+        # without Claude's stop_hook_active — the same marker session_complete uses.
+        from wade.hooks.policies import stop_nudge_marker_path
+
+        marker = stop_nudge_marker_path(tmp_path)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("")
+        d = plan_complete(HookEvent(event="stop"), worktree_root=tmp_path, has_valid_plan=False)
+        assert d.action == "allow"
+
+    def test_symlinked_marker_not_trusted(self, tmp_path: Path) -> None:
+        # A planted symlink at the marker path must not count as "already nudged".
+        from wade.hooks.policies import stop_nudge_marker_path
+
+        real = tmp_path / "elsewhere"
+        real.write_text("")
+        marker = stop_nudge_marker_path(tmp_path)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.symlink_to(real)
+        d = plan_complete(HookEvent(event="stop"), worktree_root=tmp_path, has_valid_plan=False)
+        assert d.action == "deny"
+
+    def test_symlinked_wade_dir_not_trusted(self, tmp_path: Path) -> None:
+        # A symlinked .wade directory must not let an outside file skip the nudge.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "stop-nudged").write_text("")
+        (tmp_path / ".wade").symlink_to(outside)
+        d = plan_complete(HookEvent(event="stop"), worktree_root=tmp_path, has_valid_plan=False)
+        assert d.action == "deny"
+
+
+class TestPlanModeSourceWriteRegression:
+    """E2 acceptance: a source-file write during a plan session is blocked on every
+    tool — via ``Edit``/``Write``, via unrecognized write tools (``apply_patch``),
+    and via a shell redirect. The plan-artifact guard already contains these
+    post-#356; these tests pin that so E2 enforcement rests on a verified base.
+    """
+
+    @pytest.mark.parametrize("tool_name", ["Edit", "Write", "apply_patch", "write_to_file"])
+    def test_write_tool_to_source_denied_in_plan_mode(self, tool_name: str) -> None:
+        d = plan_artifact_only(_write("/repo/wt/src/app.py", tool_name), worktree_root=WT)
+        assert d.action == "deny"
+        assert "plan-session guard" in d.reason
+
+    def test_shell_redirect_to_source_denied_in_plan_mode(self) -> None:
+        d = shell_containment(_shell("printf x > src/app.py"), worktree_root=WT, plan_mode=True)
+        assert d.action == "deny"

--- a/tests/unit/test_services/test_bootstrap_allowlist.py
+++ b/tests/unit/test_services/test_bootstrap_allowlist.py
@@ -391,9 +391,11 @@ class TestBootstrapPlanMode:
         parsed = tomllib.loads(config.read_text("utf-8"))
         assert parsed["features"]["codex_hooks"] is True
 
-    def test_stop_hook_installed_for_implement_not_plan(self, tmp_path: Path) -> None:
-        """Implement/review sessions install a Stop completion hook; plan sessions do not."""
-        # Implement (worktree) mode → Stop hook present for Stop-capable Claude.
+    def test_stop_hook_guard_differs_by_mode(self, tmp_path: Path) -> None:
+        """Impl/review sessions install a ``session-complete`` Stop hook; plan
+        sessions install a ``plan-complete`` one. Neither carries the other's guard.
+        """
+        # Implement (worktree) mode → session-complete Stop hook for Claude.
         wt = tmp_path / "impl"
         wt.mkdir()
         repo = tmp_path / "repo"
@@ -405,13 +407,17 @@ class TestBootstrapPlanMode:
             "wade-hook stop --guard session-complete" in c and "--tool claude" in c
             for c in commands
         )
+        assert not any("plan-complete" in c for c in commands)
 
-        # Plan mode → no Stop hook.
+        # Plan mode → plan-complete Stop hook (still installed, different guard).
         wt2 = tmp_path / "plan"
         wt2.mkdir()
         with patch("subprocess.run"):
             bootstrap_worktree(wt2, self._config(), repo, plan_mode=True)
         commands2 = self._claude_hook_commands(wt2)
+        assert any(
+            "wade-hook stop --guard plan-complete" in c and "--tool claude" in c for c in commands2
+        )
         assert not any("session-complete" in c for c in commands2)
 
     def test_stop_hook_installed_for_antigravity_cli(self, tmp_path: Path) -> None:

--- a/tests/unit/test_services/test_plan_service.py
+++ b/tests/unit/test_services/test_plan_service.py
@@ -11,12 +11,16 @@ import pytest
 from crossby.models.ai import TokenUsage
 
 from wade.models.config import AIConfig, ProjectConfig
-from wade.models.task import CloseReason, PlanFile, Task
+from wade.models.task import CloseReason, Complexity, PlanFile, Task
 from wade.services.ai_resolution import resolve_ai_tool, resolve_model
 from wade.services.plan_service import (
+    PlanDiagnostic,
+    PlanDiagnosticLevel,
+    PlanValidationResult,
     _attach_plan_to_existing_issue,
     _finalize_issues,
     _offer_to_implement,
+    _select_valid_plans,
     _supersede_issue_with_plans,
     _with_supersede_banner,
     discover_plan_files,
@@ -741,6 +745,11 @@ class TestPlanOrchestrator:
                 return_value=TokenUsage(total_tokens=123),
             ),
             patch("wade.services.plan_service.validate_plan_files", return_value=[plan_file]),
+            # Strict gate sees no error diagnostics → the plan file passes through.
+            patch(
+                "wade.services.plan_service.validate_plan_dir",
+                return_value=PlanValidationResult(),
+            ),
             patch(
                 "wade.services.plan_service._create_issues_from_plans",
                 return_value=(["101"], []),
@@ -1142,6 +1151,11 @@ class TestPlanExistingIssueBranch:
                 return_value=TokenUsage(total_tokens=123),
             ),
             patch("wade.services.plan_service.validate_plan_files", return_value=plan_files),
+            # Strict gate sees no error diagnostics → all plan files pass through.
+            patch(
+                "wade.services.plan_service.validate_plan_dir",
+                return_value=PlanValidationResult(),
+            ),
             patch("wade.services.plan_service._cleanup_plan_dir_or_worktree"),
             patch("wade.services.plan_service.set_terminal_title"),
             patch("wade.services.plan_service.start_title_keeper"),
@@ -1251,3 +1265,326 @@ class TestPlanExistingIssueBranch:
             assert plan(project_root=tmp_path, issue_id="330") is False
 
         mock_finalize.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _select_valid_plans — the strict gate before issue creation (E2)
+# ---------------------------------------------------------------------------
+
+_GATE_VALID = "# feat: add retry logic\n\n## Complexity\ncomplex\n\n## Tasks\n- a\n"
+_GATE_NO_COMPLEXITY = "# feat: add retry logic\n\n## Tasks\n- a\n"
+_GATE_BAD_TITLE = "# add retry logic\n\n## Complexity\ncomplex\n\n## Tasks\n- a\n"
+
+
+class TestSelectValidPlans:
+    """Unit tests for the strict validation gate that runs on real plan dirs."""
+
+    def _plan(self, plan_dir: Path, name: str, content: str) -> PlanFile:
+        p = plan_dir / name
+        p.write_text(content)
+        return PlanFile.from_markdown(p)
+
+    def test_all_valid_returns_all_without_prompt(self, tmp_path: Path) -> None:
+        a = self._plan(tmp_path, "PLAN.md", _GATE_VALID)
+        b = self._plan(tmp_path, "PLAN-2.md", _GATE_VALID)
+        with (
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console"),
+        ):
+            result = _select_valid_plans(tmp_path, [a, b], yolo=False)
+        assert result == [a, b]
+        mock_prompts.confirm.assert_not_called()  # nothing invalid → no prompt
+
+    def test_all_invalid_returns_empty_and_surfaces_errors(self, tmp_path: Path) -> None:
+        a = self._plan(tmp_path, "PLAN.md", _GATE_NO_COMPLEXITY)
+        b = self._plan(tmp_path, "PLAN-2.md", _GATE_BAD_TITLE)
+        with (
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console") as mock_console,
+        ):
+            result = _select_valid_plans(tmp_path, [a, b], yolo=False)
+        assert result == []
+        mock_prompts.confirm.assert_not_called()
+        assert mock_console.error.called  # errors are surfaced loudly
+
+    def test_mixed_non_tty_proceeds_with_valid_subset(self, tmp_path: Path) -> None:
+        good = self._plan(tmp_path, "PLAN.md", _GATE_VALID)
+        bad = self._plan(tmp_path, "PLAN-2.md", _GATE_NO_COMPLEXITY)
+        with (
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console"),
+        ):
+            mock_prompts.is_tty.return_value = False
+            result = _select_valid_plans(tmp_path, [good, bad], yolo=False)
+        assert result == [good]
+        mock_prompts.confirm.assert_not_called()  # never hang headless
+
+    def test_mixed_yolo_proceeds_with_valid_subset(self, tmp_path: Path) -> None:
+        good = self._plan(tmp_path, "PLAN.md", _GATE_VALID)
+        bad = self._plan(tmp_path, "PLAN-2.md", _GATE_BAD_TITLE)
+        with (
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console"),
+        ):
+            mock_prompts.is_tty.return_value = True
+            result = _select_valid_plans(tmp_path, [good, bad], yolo=True)
+        assert result == [good]
+        mock_prompts.confirm.assert_not_called()  # yolo skips the prompt
+
+    def test_mixed_tty_confirm_proceeds(self, tmp_path: Path) -> None:
+        good = self._plan(tmp_path, "PLAN.md", _GATE_VALID)
+        bad = self._plan(tmp_path, "PLAN-2.md", _GATE_NO_COMPLEXITY)
+        with (
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console"),
+        ):
+            mock_prompts.is_tty.return_value = True
+            mock_prompts.confirm.return_value = True
+            result = _select_valid_plans(tmp_path, [good, bad], yolo=False)
+        assert result == [good]
+        mock_prompts.confirm.assert_called_once()
+
+    def test_mixed_tty_decline_aborts_with_none(self, tmp_path: Path) -> None:
+        good = self._plan(tmp_path, "PLAN.md", _GATE_VALID)
+        bad = self._plan(tmp_path, "PLAN-2.md", _GATE_NO_COMPLEXITY)
+        with (
+            patch("wade.services.plan_service.prompts") as mock_prompts,
+            patch("wade.services.plan_service.console"),
+        ):
+            mock_prompts.is_tty.return_value = True
+            mock_prompts.confirm.return_value = False
+            result = _select_valid_plans(tmp_path, [good, bad], yolo=False)
+        assert result is None  # abort → caller creates nothing
+
+
+class TestStrictValidationGateWiring:
+    """plan() wires the strict gate at both issue-creation call sites (E2)."""
+
+    def _adapter(self) -> MagicMock:
+        adapter = MagicMock()
+        adapter.capabilities.return_value = MagicMock(blocks_until_exit=True)
+        return adapter
+
+    def _valid(self, tmp_path: Path, name: str = "PLAN.md") -> PlanFile:
+        return PlanFile(
+            path=tmp_path / name,
+            title="feat: good",
+            complexity=Complexity.COMPLEX,
+            body="body",
+            sections={},
+        )
+
+    def _invalid(self, tmp_path: Path, name: str = "PLAN-2.md") -> PlanFile:
+        # Title-parseable (survives validate_plan_files) but strict-invalid.
+        return PlanFile(
+            path=tmp_path / name,
+            title="bad title without prefix",
+            complexity=None,
+            body="body",
+            sections={},
+        )
+
+    def _errors_for(self, *names: str) -> PlanValidationResult:
+        return PlanValidationResult(
+            diagnostics=[
+                PlanDiagnostic(
+                    file=n,
+                    level=PlanDiagnosticLevel.ERROR,
+                    message="Missing or invalid '## Complexity' section.",
+                )
+                for n in names
+            ]
+        )
+
+    def _base_patches(
+        self,
+        tmp_path: Path,
+        provider: MagicMock,
+        adapter: MagicMock,
+        plan_files: list[PlanFile],
+        validation: PlanValidationResult,
+    ) -> list[contextlib.AbstractContextManager[MagicMock]]:
+        return [
+            patch(
+                "wade.services.plan_service.load_config",
+                return_value=ProjectConfig(ai=AIConfig(default_tool="claude")),
+            ),
+            patch("wade.services.plan_service.get_provider", return_value=provider),
+            patch("wade.services.plan_service.resolve_ai_tool", return_value="claude"),
+            patch("wade.services.plan_service.resolve_model", return_value=None),
+            patch(
+                "wade.services.plan_service.confirm_ai_selection",
+                return_value=("claude", None, None, False),
+            ),
+            patch("wade.services.plan_service.ensure_task_label"),
+            patch("wade.services.plan_service.run_ai_planning_session", return_value=0),
+            patch("wade.services.plan_service.AbstractAITool.get", return_value=adapter),
+            patch(
+                "wade.services.plan_service._extract_token_usage",
+                return_value=TokenUsage(total_tokens=123),
+            ),
+            patch("wade.services.plan_service.validate_plan_files", return_value=plan_files),
+            patch("wade.services.plan_service.validate_plan_dir", return_value=validation),
+            patch("wade.services.plan_service._cleanup_plan_dir_or_worktree"),
+            patch("wade.services.plan_service.set_terminal_title"),
+            patch("wade.services.plan_service.start_title_keeper"),
+            patch("wade.services.plan_service.stop_title_keeper"),
+            patch("wade.services.plan_service.console"),
+            patch("wade.git.repo.get_repo_root", return_value=tmp_path),
+        ]
+
+    def test_new_issue_invalid_plan_skipped_only_valid_created(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        adapter = self._adapter()
+        good = self._valid(tmp_path)
+        bad = self._invalid(tmp_path)
+        validation = self._errors_for("PLAN-2.md")
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, [good, bad], validation):
+                stack.enter_context(p)
+            mock_prompts = stack.enter_context(patch("wade.services.plan_service.prompts"))
+            mock_prompts.is_tty.return_value = False
+            create = stack.enter_context(
+                patch(
+                    "wade.services.plan_service._create_issues_from_plans",
+                    return_value=(["101"], []),
+                )
+            )
+            stack.enter_context(
+                patch("wade.services.plan_service._finalize_issues", return_value=None)
+            )
+
+            assert plan(project_root=tmp_path) is True
+
+        create.assert_called_once()
+        assert create.call_args.kwargs["plan_files"] == [good]  # invalid dropped
+
+    def test_new_issue_all_invalid_creates_nothing(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        adapter = self._adapter()
+        bad = self._invalid(tmp_path, "PLAN.md")
+        validation = self._errors_for("PLAN.md")
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, [bad], validation):
+                stack.enter_context(p)
+            mock_prompts = stack.enter_context(patch("wade.services.plan_service.prompts"))
+            mock_prompts.is_tty.return_value = False
+            create = stack.enter_context(
+                patch("wade.services.plan_service._create_issues_from_plans")
+            )
+
+            assert plan(project_root=tmp_path) is False
+
+        create.assert_not_called()
+
+    def test_new_issue_mixed_abort_creates_nothing(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        adapter = self._adapter()
+        good = self._valid(tmp_path)
+        bad = self._invalid(tmp_path)
+        validation = self._errors_for("PLAN-2.md")
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, [good, bad], validation):
+                stack.enter_context(p)
+            mock_prompts = stack.enter_context(patch("wade.services.plan_service.prompts"))
+            mock_prompts.is_tty.return_value = True
+            mock_prompts.confirm.return_value = False  # user declines the partial run
+            create = stack.enter_context(
+                patch("wade.services.plan_service._create_issues_from_plans")
+            )
+
+            assert plan(project_root=tmp_path) is False
+
+        create.assert_not_called()
+
+    def test_new_issue_all_valid_passes(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        adapter = self._adapter()
+        good = self._valid(tmp_path)
+        clean = PlanValidationResult()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, [good], clean):
+                stack.enter_context(p)
+            mock_prompts = stack.enter_context(patch("wade.services.plan_service.prompts"))
+            mock_prompts.is_tty.return_value = True
+            create = stack.enter_context(
+                patch(
+                    "wade.services.plan_service._create_issues_from_plans",
+                    return_value=(["101"], []),
+                )
+            )
+            stack.enter_context(
+                patch("wade.services.plan_service._finalize_issues", return_value=None)
+            )
+
+            assert plan(project_root=tmp_path) is True
+
+        create.assert_called_once()
+        assert create.call_args.kwargs["plan_files"] == [good]
+        mock_prompts.confirm.assert_not_called()  # nothing invalid → no prompt
+
+    def test_existing_issue_path_filters_invalid(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        existing = Task(id="330", title="Some bug", body="Original")
+        provider.read_task.return_value = existing
+        adapter = self._adapter()
+        good = self._valid(tmp_path)
+        bad = self._invalid(tmp_path)
+        validation = self._errors_for("PLAN-2.md")
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, [good, bad], validation):
+                stack.enter_context(p)
+            mock_prompts = stack.enter_context(patch("wade.services.plan_service.prompts"))
+            mock_prompts.is_tty.return_value = False
+            mock_attach = stack.enter_context(
+                patch("wade.services.plan_service._attach_plan_to_existing_issue")
+            )
+            mock_supersede = stack.enter_context(
+                patch("wade.services.plan_service._supersede_issue_with_plans")
+            )
+            stack.enter_context(
+                patch("wade.services.plan_service._finalize_issues", return_value=None)
+            )
+
+            assert plan(project_root=tmp_path, issue_id="330") is True
+
+        # One valid file remains → single-plan attach, not supersede.
+        mock_attach.assert_called_once()
+        assert mock_attach.call_args.kwargs["plan_file"] is good
+        mock_supersede.assert_not_called()
+
+    def test_existing_issue_all_invalid_mutates_nothing(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        existing = Task(id="330", title="Some bug", body="Original")
+        provider.read_task.return_value = existing
+        adapter = self._adapter()
+        bad = self._invalid(tmp_path, "PLAN.md")
+        validation = self._errors_for("PLAN.md")
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(tmp_path, provider, adapter, [bad], validation):
+                stack.enter_context(p)
+            mock_prompts = stack.enter_context(patch("wade.services.plan_service.prompts"))
+            mock_prompts.is_tty.return_value = False
+            # Override the base console patch so we can inspect the messages.
+            mock_console = stack.enter_context(patch("wade.services.plan_service.console"))
+            mock_attach = stack.enter_context(
+                patch("wade.services.plan_service._attach_plan_to_existing_issue")
+            )
+            mock_supersede = stack.enter_context(
+                patch("wade.services.plan_service._supersede_issue_with_plans")
+            )
+
+            assert plan(project_root=tmp_path, issue_id="330") is False
+
+        mock_attach.assert_not_called()
+        mock_supersede.assert_not_called()
+        # Files WERE produced (just invalid), so the misleading "No plan files
+        # found" message must not fire — the helper already reported the reason.
+        warn_msgs = " ".join(str(c.args[0]) for c in mock_console.warn.call_args_list if c.args)
+        assert "No plan files found" not in warn_msgs

--- a/tests/unit/test_services/test_plan_service.py
+++ b/tests/unit/test_services/test_plan_service.py
@@ -1396,6 +1396,33 @@ class TestPreserveGeneratedPlans:
         mock_mkdtemp.assert_not_called()  # nothing to preserve
         mock_cleanup.assert_called_once_with(str(plan_dir), None, None)
 
+    def test_copy_failure_retains_source_and_skips_cleanup(self, tmp_path: Path) -> None:
+        # A mid-copy failure must never cost the user their generated plans: the
+        # temp dir may hold only a partial batch, so the original plan
+        # dir/worktree is retained (cleanup skipped) and its path reported —
+        # never deleted after a partial salvage.
+        plan_dir = tmp_path / "plans"
+        plan_dir.mkdir()
+        (plan_dir / "PLAN.md").write_text(_GATE_VALID)
+        (plan_dir / "PLAN-2.md").write_text(_GATE_NO_COMPLEXITY)
+        preserved_dir = tmp_path / "preserved"
+        preserved_dir.mkdir()
+
+        with (
+            patch("wade.services.plan_service.tempfile.mkdtemp", return_value=str(preserved_dir)),
+            patch("wade.services.plan_service.shutil.copy2", side_effect=OSError("disk full")),
+            patch("wade.services.plan_service._cleanup_plan_dir_or_worktree") as mock_cleanup,
+            patch("wade.services.plan_service.console") as mock_console,
+        ):
+            _preserve_generated_plans(str(plan_dir), None, None)
+
+        # Cleanup is skipped, so the intact originals survive in place...
+        mock_cleanup.assert_not_called()
+        assert (plan_dir / "PLAN.md").is_file()
+        assert (plan_dir / "PLAN-2.md").is_file()
+        # ...and the user is pointed at where they still live, not the temp dir.
+        mock_console.hint.assert_called_once_with(f"Plan files: {plan_dir}")
+
 
 class TestStrictValidationGateWiring:
     """plan() wires the strict gate at both issue-creation call sites (E2)."""

--- a/tests/unit/test_services/test_plan_service.py
+++ b/tests/unit/test_services/test_plan_service.py
@@ -20,6 +20,7 @@ from wade.services.plan_service import (
     _attach_plan_to_existing_issue,
     _finalize_issues,
     _offer_to_implement,
+    _preserve_generated_plans,
     _select_valid_plans,
     _supersede_issue_with_plans,
     _with_supersede_banner,
@@ -1357,6 +1358,45 @@ class TestSelectValidPlans:
         assert result is None  # abort → caller creates nothing
 
 
+class TestPreserveGeneratedPlans:
+    """The strict-gate reject path salvages generated plans before cleanup (E2)."""
+
+    def test_copies_plan_files_to_stable_dir_then_cleans(self, tmp_path: Path) -> None:
+        plan_dir = tmp_path / "plans"
+        plan_dir.mkdir()
+        (plan_dir / "PLAN.md").write_text(_GATE_VALID)
+        (plan_dir / "PLAN-2.md").write_text(_GATE_NO_COMPLEXITY)
+        preserved_dir = tmp_path / "preserved"
+        preserved_dir.mkdir()
+
+        with (
+            patch("wade.services.plan_service.tempfile.mkdtemp", return_value=str(preserved_dir)),
+            patch("wade.services.plan_service._cleanup_plan_dir_or_worktree") as mock_cleanup,
+            patch("wade.services.plan_service.console"),
+        ):
+            _preserve_generated_plans(str(plan_dir), None, None)
+
+        # Files are salvaged to the stable dir, and the normal cleanup still runs
+        # afterwards so no worktree/temp dir lingers.
+        assert (preserved_dir / "PLAN.md").is_file()
+        assert (preserved_dir / "PLAN-2.md").is_file()
+        mock_cleanup.assert_called_once_with(str(plan_dir), None, None)
+
+    def test_no_files_skips_copy_but_still_cleans(self, tmp_path: Path) -> None:
+        plan_dir = tmp_path / "plans"
+        plan_dir.mkdir()  # no PLAN*.md written
+
+        with (
+            patch("wade.services.plan_service.tempfile.mkdtemp") as mock_mkdtemp,
+            patch("wade.services.plan_service._cleanup_plan_dir_or_worktree") as mock_cleanup,
+            patch("wade.services.plan_service.console"),
+        ):
+            _preserve_generated_plans(str(plan_dir), None, None)
+
+        mock_mkdtemp.assert_not_called()  # nothing to preserve
+        mock_cleanup.assert_called_once_with(str(plan_dir), None, None)
+
+
 class TestStrictValidationGateWiring:
     """plan() wires the strict gate at both issue-creation call sites (E2)."""
 
@@ -1474,10 +1514,14 @@ class TestStrictValidationGateWiring:
             create = stack.enter_context(
                 patch("wade.services.plan_service._create_issues_from_plans")
             )
+            preserve = stack.enter_context(
+                patch("wade.services.plan_service._preserve_generated_plans")
+            )
 
             assert plan(project_root=tmp_path) is False
 
         create.assert_not_called()
+        preserve.assert_called_once()  # generated plans salvaged, not discarded
 
     def test_new_issue_mixed_abort_creates_nothing(self, tmp_path: Path) -> None:
         provider = MagicMock()
@@ -1495,10 +1539,14 @@ class TestStrictValidationGateWiring:
             create = stack.enter_context(
                 patch("wade.services.plan_service._create_issues_from_plans")
             )
+            preserve = stack.enter_context(
+                patch("wade.services.plan_service._preserve_generated_plans")
+            )
 
             assert plan(project_root=tmp_path) is False
 
         create.assert_not_called()
+        preserve.assert_called_once()  # generated plans salvaged, not discarded
 
     def test_new_issue_all_valid_passes(self, tmp_path: Path) -> None:
         provider = MagicMock()
@@ -1579,11 +1627,15 @@ class TestStrictValidationGateWiring:
             mock_supersede = stack.enter_context(
                 patch("wade.services.plan_service._supersede_issue_with_plans")
             )
+            preserve = stack.enter_context(
+                patch("wade.services.plan_service._preserve_generated_plans")
+            )
 
             assert plan(project_root=tmp_path, issue_id="330") is False
 
         mock_attach.assert_not_called()
         mock_supersede.assert_not_called()
+        preserve.assert_called_once()  # generated plans salvaged, not discarded
         # Files WERE produced (just invalid), so the misleading "No plan files
         # found" message must not fire — the helper already reported the reason.
         warn_msgs = " ".join(str(c.args[0]) for c in mock_console.warn.call_args_list if c.args)

--- a/tests/unit/test_utils/test_plan_validation.py
+++ b/tests/unit/test_utils/test_plan_validation.py
@@ -89,7 +89,9 @@ class TestBackCompatReExports:
         assert plan_done is pv.plan_done
 
     def test_discover_plan_files_still_works_via_re_export(self, tmp_path: Path) -> None:
+        from wade.services.plan_service import discover_plan_files as ps_discover
+
         _write(tmp_path, "PLAN.md", _VALID)
         _write(tmp_path, "PLAN-2.md", _VALID)
-        found = discover_plan_files(tmp_path)
+        found = ps_discover(tmp_path)
         assert [p.name for p in found] == ["PLAN-2.md", "PLAN.md"]

--- a/tests/unit/test_utils/test_plan_validation.py
+++ b/tests/unit/test_utils/test_plan_validation.py
@@ -1,0 +1,95 @@
+"""Tests for the lean plan-validation core (``wade.utils.plan_validation``).
+
+Covers ``has_valid_plan`` (the per-file notion the plan Stop guard needs) plus
+the back-compat re-exports that keep ``from wade.services.plan_service import …``
+working after the extraction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wade.utils.plan_validation import (
+    discover_plan_files,
+    has_valid_plan,
+    validate_plan_dir,
+)
+
+_VALID = "# feat: add retry logic\n\n## Complexity\ncomplex\n\n## Tasks\n- Do it\n"
+_NO_COMPLEXITY = "# feat: add retry logic\n\n## Tasks\n- Do it\n"
+_BAD_TITLE = "# add retry logic\n\n## Complexity\ncomplex\n\n## Tasks\n- Do it\n"
+
+
+def _write(plan_dir: Path, name: str, content: str) -> None:
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    (plan_dir / name).write_text(content, encoding="utf-8")
+
+
+class TestHasValidPlan:
+    def test_true_for_a_single_valid_plan(self, tmp_path: Path) -> None:
+        _write(tmp_path, "PLAN.md", _VALID)
+        assert has_valid_plan(tmp_path) is True
+
+    def test_false_when_dir_missing(self, tmp_path: Path) -> None:
+        assert has_valid_plan(tmp_path / "nope") is False
+
+    def test_false_when_no_plan_files(self, tmp_path: Path) -> None:
+        # A stray non-PLAN markdown file must not count.
+        _write(tmp_path, "README.md", _VALID)
+        assert has_valid_plan(tmp_path) is False
+
+    def test_false_when_complexity_missing(self, tmp_path: Path) -> None:
+        _write(tmp_path, "PLAN.md", _NO_COMPLEXITY)
+        assert has_valid_plan(tmp_path) is False
+
+    def test_false_when_title_prefix_missing(self, tmp_path: Path) -> None:
+        _write(tmp_path, "PLAN.md", _BAD_TITLE)
+        assert has_valid_plan(tmp_path) is False
+
+    def test_true_when_at_least_one_of_many_is_valid(self, tmp_path: Path) -> None:
+        # Mixed batch: one good, two bad — a single valid file is enough.
+        _write(tmp_path, "PLAN.md", _VALID)
+        _write(tmp_path, "PLAN-2.md", _NO_COMPLEXITY)
+        _write(tmp_path, "PLAN-3.md", _BAD_TITLE)
+        assert has_valid_plan(tmp_path) is True
+
+    def test_differs_from_validate_plan_dir_has_errors(self, tmp_path: Path) -> None:
+        # The key distinction: one valid + one invalid file makes the aggregate
+        # ``has_errors`` True, but ``has_valid_plan`` True — the session produced
+        # something usable, which is what the Stop nudge cares about.
+        _write(tmp_path, "PLAN.md", _VALID)
+        _write(tmp_path, "PLAN-2.md", _NO_COMPLEXITY)
+        assert validate_plan_dir(tmp_path).has_errors is True
+        assert has_valid_plan(tmp_path) is True
+
+
+class TestBackCompatReExports:
+    """``plan_service`` must still re-export the validation API after extraction."""
+
+    def test_names_resolve_from_plan_service(self) -> None:
+        from wade.services import plan_service as ps
+
+        # Same object identity — these are re-exports, not copies.
+        assert ps.validate_plan_dir is validate_plan_dir
+        assert ps.discover_plan_files is discover_plan_files
+        assert ps.has_valid_plan is has_valid_plan
+
+    def test_diagnostic_types_re_exported(self) -> None:
+        from wade.services.plan_service import (
+            PlanDiagnostic,
+            PlanDiagnosticLevel,
+            PlanValidationResult,
+            plan_done,
+        )
+        from wade.utils import plan_validation as pv
+
+        assert PlanDiagnostic is pv.PlanDiagnostic
+        assert PlanDiagnosticLevel is pv.PlanDiagnosticLevel
+        assert PlanValidationResult is pv.PlanValidationResult
+        assert plan_done is pv.plan_done
+
+    def test_discover_plan_files_still_works_via_re_export(self, tmp_path: Path) -> None:
+        _write(tmp_path, "PLAN.md", _VALID)
+        _write(tmp_path, "PLAN-2.md", _VALID)
+        found = discover_plan_files(tmp_path)
+        assert [p.name for p in found] == ["PLAN-2.md", "PLAN.md"]


### PR DESCRIPTION
Closes #350

<!-- wade:plan:start -->

## Complexity
complex

## Context / Problem

Part of #348 (E2). Two plan-phase requirements are trust-only today — they only
hold if the agent *chooses* to cooperate:

1. **Strict validation only fires from `plan-session done`.** The post-session
   flow in `plan_service.plan()` reads plan files with `validate_plan_files()`
   (`plan_service.py:114`), which only skips files whose `# Title` won't parse.
   The strict validator `validate_plan_dir()` (`plan_service.py:174` — checks
   `## Complexity` and a conventional-commit title prefix) runs **only** from the
   `wade plan-session done` CLI command. So a plan with no `## Complexity` and a
   title like `Add retry logic` silently becomes an issue with **no complexity
   label**, and the model-by-complexity mapping never applies. Both issue-creation
   call sites are affected: the new-issue path (`plan_service.py:600` →
   `_create_issues_from_plans`) and the existing-issue path
   (`plan_service.py:552` → `_attach_plan_to_existing_issue` /
   `_supersede_issue_with_plans`).

2. **Plan sessions get no Stop hook.** `bootstrap_worktree` calls
   `_install_stop_hook` only when `not plan_mode` (`bootstrap.py:665`). A plan
   session that ends producing zero valid `PLAN*.md` files silently creates zero
   issues, with no nudge.

**Dependency #356 is already satisfied in the current tree**, so this is
enforcement, not theater:
- crossby `>=0.17.1` makes `HookEvent.is_write` a *denylist* — unrecognized write
  tools (`apply_patch`, `write_to_file`) are treated as writes and denied by
  `worktree_containment` / `plan_artifact_only` (covered at
  `tests/unit/test_hooks/test_policies.py:47`).
- `Bash` is in `_GUARD_WRITE_TOOLS` (`bootstrap.py:179`), so a shell redirect
  (`bash -c 'echo … > src/x.py'`) reaches `shell_containment`, which denies it in
  plan mode.

So the plan-artifact write guard already contains source writes on every tool;
this issue adds the plan-*phase* enforcement on top.

## Proposed Solution

Two independent enforcement points plus a small lean-import refactor that both
share.

### A. Lean validation module (shared foundation)

The plan Stop guard runs inside the lean `wade-hook` entry point, which must
**not** import `plan_service` (it eagerly imports `crossby.ai_tools`, ~450ms cold
start — see the module docstring in `hooks/cli.py`). `validate_plan_dir` is pure
and `PlanFile` (`models/task.py`) imports only stdlib + pydantic, so extract the
validation core into a new lean module:

- New `src/wade/utils/plan_validation.py` containing (moved verbatim from
  `plan_service.py`): `PlanDiagnosticLevel`, `PlanDiagnostic`,
  `PlanValidationResult`, `discover_plan_files`, `validate_plan_dir`, `plan_done`,
  and the `_CONVENTIONAL_COMMIT_RE` / `_RECOMMENDED_SECTIONS` constants.
- **New** `has_valid_plan(plan_dir: Path) -> bool` — `True` iff at least one
  `PLAN*.md` file has **no error-level** diagnostics (parseable title **and** a
  valid `## Complexity`). This is the per-file notion the Stop guard needs — note
  it differs from `validate_plan_dir(...).has_errors`, which is `True` if *any*
  file is invalid even when a valid one also exists.
- `plan_service.py` re-imports these names so the existing public API
  (`from wade.services.plan_service import validate_plan_dir, plan_done,
  PlanValidationResult, PlanDiagnostic, discover_plan_files`) keeps working —
  used by `cli/plan_session.py`, `cli/test_done_review_hint.py`, and
  `test_plan_service.py`. `validate_plan_files()` **stays** in `plan_service.py`
  (it calls `console.warn`, a UI dependency that must not leak into `utils/`); it
  simply calls the re-imported `discover_plan_files`.

Layering note: `utils/` may import `models/`; `hooks/policies.py` already imports
`wade.utils.markers`, so importing a second lean `wade.utils` module is
consistent and adds negligible cold-start cost (pydantic is already loaded).

### B. Auto-validate before wade creates issues (`plan_service.py`)

Add a strict-validation gate between "read plan files" and "create issues", at
**both** call sites in `plan()`. New helper:

```
_select_valid_plans(plan_dir, plan_files, *, yolo) -> list[PlanFile] | None
```

Behavior:
1. Run `validate_plan_dir(plan_dir)`; group **error**-level diagnostics by
   `file` basename.
2. Partition `plan_files` (already title-parseable, from `validate_plan_files`)
   into valid (no error diagnostics) and invalid.
3. **Surface every error loudly** via `console.error` — invalid files are never
   silently dropped. Warnings are surfaced via `console.warn` but do not exclude
   a file.
4. If **no** valid files remain → surface errors, return `[]` (caller reports
   "no valid plans", creates nothing, returns `False`, preserves the plan dir).
5. If some valid and some invalid:
   - Interactive TTY and not `yolo`: `prompts.confirm("N plan file(s) failed
     validation and will be skipped — continue with the M valid one(s)?",
     default=True)`. On decline → return `None` (caller aborts, creates nothing,
     preserves plan dir so the user can fix).
   - Non-TTY or `yolo`: proceed with the valid subset after the loud warning
     (deterministic, no hang in headless runs).
6. Return the filtered `list[PlanFile]` (only valid files).

Wire into `plan()`:
- New-issue path (`plan_service.py:600`): replace
  `plan_files = validate_plan_files(...)` result with the filtered list; if the
  helper returns `None` (aborted) or `[]`, skip creation, clean up, return
  `False`.
- Existing-issue path (`plan_service.py:552`): same filtering before the
  single-plan attach vs multi-plan supersede branch. A single invalid plan that
  gets filtered leaves `plan_files == []` → the existing "No plan files found"
  branch handles it (no issue mutated).

This is the enforcement that actually matters: **invalid plan files never
silently become issues**, independent of whether the agent ran
`plan-session done`.

### C. `plan_complete` Stop guard (`policies.py`, `hooks/cli.py`, `bootstrap.py`)

Mirror `session_complete` — a pure predicate fed a fact computed by the CLI.

**`hooks/policies.py`:**
- New pure predicate:
  ```
  plan_complete(event, *, worktree_root, has_valid_plan=False) -> HookDecision
  ```
  Allow order (mirrors `session_complete`): `event.stop_hook_active` → allow;
  `has_valid_plan` → allow; `stop_nudge_present(worktree_root)` → allow;
  otherwise `deny(...)` with an ignorable nudge ("Before finishing: write at
  least one valid `PLAN*.md` (title with a conventional-commit prefix + a
  `## Complexity`) to the plan dir, or disregard if pausing").
- Reuse the existing single-shot `.wade/stop-nudged` marker
  (`stop_nudge_present` / `stop_nudge_marker_path`). A worktree is either a plan
  worktree or an impl worktree, never both, so the two Stop guards never share a
  session — no new marker name needed.
- Add `"plan-complete"` to `GUARD_NAMES` and `__all__`.

**`hooks/cli.py`:**
- Route `plan-complete` on the Stop path. Extend the stop-branch condition from
  `guard == "session-complete"` to also match `guard == "plan-complete"` (the
  `_is_stop_event` fail-open safety net already covers unknown guards on stop
  events, so an unknown `--guard` still fails open — never traps the agent).
- Inside the stop branch, dispatch by guard:
  - `session-complete` → existing `_stop_git_facts` path.
  - `plan-complete` → compute `has_valid_plan(Path(root) / ".wade" / "plans")`
    via a **lazy (function-local) import** of `wade.utils.plan_validation`, so
    the hot PreToolUse write path never imports it (only the Stop path does);
    any exception → fail-open (allow). Missing `--root` → fail-open (already
    handled).
  - On a `deny`, call `_mark_stop_nudged(Path(root))` (writes `.wade/stop-nudged`)
    so the nudge is single-shot across tools — same as `session-complete`.
- The plan dir is `<worktree>/.wade/plans` because `plan()` sets
  `plan_output_dir = planning_worktree / ".wade" / "plans"`
  (`plan_service.py:498`) and the Stop hook is installed with
  `--root <planning_worktree>`.

**`bootstrap.py`:**
- Parameterize the installer: `_install_stop_hook(worktree_path, *, guard:
  str = "session-complete")`, emitting `wade-hook stop --guard {guard} …`.
- In `bootstrap_worktree`: when `plan_mode`, call
  `_install_stop_hook(worktree_path, guard="plan-complete")`. Keep the existing
  `not plan_mode` branch (session-complete Stop hook + pre-push backstop)
  unchanged. The Stop hook is still fail-open (no `fail_closed`), installed only
  for tools with `supports_stop_hook`.

**`cli/hook.py`:** update the `--guard` help text to include `plan-complete`.

## Tasks

- [ ] Create `src/wade/utils/plan_validation.py`: move `PlanDiagnosticLevel`,
      `PlanDiagnostic`, `PlanValidationResult`, `discover_plan_files`,
      `validate_plan_dir`, `plan_done`, and the regex/section constants from
      `plan_service.py`; add `has_valid_plan(plan_dir)`.
- [ ] Re-import those names in `plan_service.py` for back-compat; keep
      `validate_plan_files` there (it uses `console`), pointing at the re-imported
      `discover_plan_files`.
- [ ] Add `_select_valid_plans(plan_dir, plan_files, *, yolo)` to
      `plan_service.py`; surface errors loudly, filter invalid, confirm on
      partial (interactive), return `None` on abort / `[]` on all-invalid.
- [ ] Wire `_select_valid_plans` into both issue-creation call sites in `plan()`
      (new-issue path and existing-issue path), handling the abort / empty cases
      with cleanup + `return False`.
- [ ] Add `plan_complete(event, *, worktree_root, has_valid_plan=False)` to
      `hooks/policies.py`; add `"plan-complete"` to `GUARD_NAMES` and `__all__`.
- [ ] Route `plan-complete` in `hooks/cli.py` Stop path: compute
      `has_valid_plan(root/.wade/plans)` via lean import, fail-open on error /
      missing root, mark `stop-nudged` on deny.
- [ ] Parameterize `_install_stop_hook(guard=…)` in `bootstrap.py`; install
      `plan-complete` Stop hook in plan mode; leave impl-mode path unchanged.
- [ ] Update `cli/hook.py` `--guard` help text to list `plan-complete`.
- [ ] Tests — policies: `plan_complete` allow/deny matrix; plan-mode source-write
      regression via `plan_artifact_only` (Edit/Write + `apply_patch`) and
      `shell_containment(plan_mode=True)` (redirect to `src/x.py`).
- [ ] Tests — `test_hook_cli.py`: `plan-complete` blocks once with no valid plan
      + writes `.wade/stop-nudged`; allows when a valid `PLAN.md` is present;
      single-shot across tools; missing `--root` fails open.
- [ ] Tests — `test_plan_service.py`: invalid plan (missing complexity / bad
      title) is skipped and never created; all-invalid creates nothing; valid
      plan passes; mixed batch prompts and proceeds/aborts; existing-issue path
      filters too.
- [ ] Tests — new `test_utils/test_plan_validation.py`: `has_valid_plan` true /
      false / mixed; back-compat imports from `wade.services.plan_service` still
      resolve.
- [ ] Update `test_bootstrap_allowlist.py::test_stop_hook_installed_for_implement_not_plan`:
      plan mode now installs a `plan-complete` Stop hook; impl mode installs
      `session-complete` (and neither carries the other's guard name).
- [ ] Docs: note the new `plan-complete` guard where guard names are documented
      (e.g. `docs/dev/` hooks reference and the `policies.py`/`bootstrap.py`
      docstrings). Do **not** touch `plan-session/SKILL.md` — dropping the
      "don't skip `plan-session done`" wording is deferred to #355.
- [ ] `./scripts/check-all.sh` (test + lint + strict mypy) passes.

## Acceptance Criteria

- [ ] Invalid plan files (missing/invalid `## Complexity`, or a title without a
      conventional-commit prefix) never silently become issues — they are dropped
      with a loud error on both the new-issue and existing-issue paths, without
      relying on the agent running `wade plan-session done`.
- [ ] A plan session that ends with no valid `PLAN*.md` gets exactly **one** Stop
      nudge (single-shot via `.wade/stop-nudged`); a session with at least one
      valid plan passes cleanly (no nudge).
- [ ] A source-file write during a plan session is blocked on every tool — via
      `Edit`/`Write`, via `apply_patch`, and via a shell redirect — covered by
      regression tests (guard already contains these post-#356).
- [ ] The plan Stop guard fails **open** on any error (unresolvable plan dir,
      missing `--root`, exception) — a plan session is never trapped.
- [ ] Plan mode installs a `plan-complete` Stop hook; impl/review mode still
      installs `session-complete` — verified by bootstrap tests.
- [ ] Back-compat: `wade plan-session done` and all
      `from wade.services.plan_service import …` validation imports still work
      after the lean-module extraction.
- [ ] `./scripts/check-all.sh` passes.

## Notes / Out of scope

- **Not** removing the `plan-session/SKILL.md` "do not skip `plan-session done`"
  wording — that is #355's follow-up, unblocked once this lands.
- **Not** fixing the plan guard's blanket denial of `>/dev/null` /
  `2>/dev/null` redirects (observed during planning: the plan-mode
  `check_redirect_target` denies any non-artifact target, including the
  always-allowed `/dev/` device prefix). It is a #356-family guard-tuning nit,
  independent of E2 enforcement, and would only relax the guard, so it is tracked
  separately rather than bundled here.
- Marker reuse: `plan-complete` and `session-complete` share the `.wade/stop-nudged`
  single-shot marker because the two guards are never installed in the same
  worktree; no new marker name is introduced.

<!-- wade:plan:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `plan-complete` stop guard for plan sessions.
  - Added strict plan validation for conventional-commit titles and complexity values.
  - Added warnings for skipped or incomplete plan files.
  - Added optional continuation when only some plans are invalid.

- **Bug Fixes**
  - Invalid plans no longer create or modify issues.
  - Failed plans are preserved when no issues are created.
  - Plan and implementation sessions retain separate completion checks.

- **Documentation**
  - Updated documentation with plan validation and guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:summary:start -->

## Summary

## What was done

E2 (issue #350): made two plan-phase requirements *enforced in code* instead of
trust-only. Invalid plan files now never silently become issues, and a plan
session that ends without a usable plan gets a one-shot Stop nudge — neither
depends on the agent choosing to run `wade plan-session done`.

## Changes

**A. Lean shared validation module**
- New `src/wade/utils/plan_validation.py` — moved `discover_plan_files`,
  `validate_plan_dir`, `plan_done`, the diagnostic types, and the regex/section
  constants out of `plan_service.py` (verbatim). It imports only stdlib +
  pydantic + `models.task.PlanFile`, so the lean `wade-hook` Stop path can import
  it without paying crossby's ~450ms cold start.
- Added `has_valid_plan(plan_dir)` — `True` iff at least one `PLAN*.md` has no
  error-level diagnostics (the *per-file* notion the Stop guard needs, distinct
  from `validate_plan_dir(...).has_errors`, which is aggregate).
- `plan_service.py` re-exports these names (explicit `as`-aliases, so mypy-strict
  `no_implicit_reexport` and test patching both keep working); `validate_plan_files`
  stays in `plan_service` because it uses `console`.

**B. Auto-validate before issue creation (`plan_service.py`)**
- New `_select_valid_plans(plan_dir, plan_files, *, yolo)` — runs the strict
  validator, surfaces every error loudly via `console.error`, drops invalid files,
  and returns the valid subset / `[]` (all invalid) / `None` (interactive abort on
  a partial batch). Non-TTY and `yolo` proceed deterministically (no hang).
- Wired into **both** issue-creation call sites in `plan()` (new-issue and
  existing-issue paths); an empty/aborted result cleans up and returns `False`
  without mutating any issue.

**C. `plan-complete` Stop guard**
- `hooks/policies.py`: new pure `plan_complete(event, *, worktree_root,
  has_valid_plan=False)` mirroring `session_complete`; added `plan-complete` to
  `GUARD_NAMES`/`__all__`.
- `hooks/cli.py`: routes `plan-complete` on the Stop path, computing
  `has_valid_plan(<root>/.wade/plans)` via a **lazy** import (kept off the hot
  PreToolUse write path); fails open on any error / missing `--root`; marks
  `.wade/stop-nudged` on deny (shared single-shot marker with `session-complete`).
- `bootstrap.py`: `_install_stop_hook(..., guard: StopGuard = ...)` is
  parameterized on the shared `StopGuard` enum (see review round below); plan
  sessions install `plan-complete`, impl/review keep `session-complete` + the
  pre-push backstop.
- `cli/hook.py`: `--guard` help text lists `plan-complete`.

**Docs**: `docs/dev/architecture.md` (guards table, utils tree, narrative) and
`README.md` (session-guards table + strict-validation note).

## Review feedback addressed (round 1)

Five CodeRabbit comments, each verified against the code before fixing; all
threads resolved.

1. **Preserve generated plans on strict-gate reject (🟠 Major, `plan_service.py`).**
   When `_select_valid_plans()` returned `None` (aborted partial) or `[]` (all
   invalid), `plan()` deleted the plan dir / worktree — discarding `PLAN*.md` a
   user could fix by hand. New `_preserve_generated_plans()` copies them to a
   stable temp dir first (the `_warn_token_extraction` copy-then-clean pattern),
   points the user at them, then runs the normal cleanup — salvaging output
   without leaving an orphaned worktree. Wired at both call sites; docstring +
   call-site comments updated.
2. **`PLAN*.md` wording (🟡 Minor, `plan_validation.py`).** `validate_plan_dir`'s
   docstring and no-files error said "`.md`"; discovery is `PLAN*.md`. Both now
   say `PLAN*.md`.
3. **Type the stop-guard selector (🔵 Trivial).** New `StopGuard(StrEnum)` in
   `hooks/policies.py`; `_install_stop_hook` takes `guard: StopGuard`, and the
   CLI's `_STOP_GUARDS` + `GUARD_NAMES` derive from it — one source of truth, a
   typo is now a mypy error. Emitted commands/behavior unchanged. (No argparse
   `choices=`: the CLI deliberately hand-rolls fail-open/closed semantics for
   unknown guards.)
4. **README interactive-confirm + abort outcome (🟡 Minor).** Documented the
   mixed pass/fail prompt (`--yolo`/non-interactive skip it), the no-issues-created
   outcome, and — reflecting fix #1 — that plans are preserved for manual fixing.
5. **Honest re-export test (🟡 Minor, `test_plan_validation.py`).**
   `test_discover_plan_files_still_works_via_re_export` now imports
   `discover_plan_files` from `plan_service` so it actually exercises the re-export.

New/updated tests: `TestPreserveGeneratedPlans` (copy-then-clean + empty-dir
no-op); three `TestStrictValidationGateWiring` reject-path tests now assert
`_preserve_generated_plans` is invoked.

## Review feedback addressed (round 2)

Two CodeRabbit comments, each verified against the code before fixing; both
threads resolved.

1. **Move `StopGuard` to a leaf models module (🟠 Major, `bootstrap.py`).**
   Round-1 fix #3 introduced `StopGuard` in `hooks/policies.py`, but `bootstrap.py`
   is service-layer code — importing it from `wade.hooks.policies` created a
   service→hooks dependency the layering rules forbid (services may import
   `models`/`config`, not `hooks`). `StopGuard` is a pure `StrEnum`, so it now
   lives in a new leaf module `src/wade/models/hooks.py` (exported from
   `wade.models`); `bootstrap.py`, `hooks/cli.py`, and `hooks/policies.py` all
   import it from there. Behavior and guard values unchanged — a pure relocation
   that removes the layering violation.
2. **Retain generated plans on preservation-copy failure (🟠 Major, `plan_service.py`).**
   `_preserve_generated_plans()` (added in round 1) ran `_cleanup_plan_dir_or_worktree`
   unconditionally, so an `OSError` from `shutil.copy2` *after* `mkdtemp` deleted
   the original plan dir/worktree following a partial salvage — discarding the very
   plans it exists to protect. Now: on copy failure it skips cleanup, leaves the
   intact originals in place, and points the user at them (via a small
   `_report_preserved_plans` helper shared with the success path). The empty-dir
   and success paths are unchanged. New test
   `test_copy_failure_retains_source_and_skips_cleanup` forces `copy2` to raise and
   asserts cleanup is skipped, the originals survive, and the source path is reported.

## Testing

- New `tests/unit/test_utils/test_plan_validation.py`: `has_valid_plan`
  true/false/mixed, the per-file-vs-aggregate distinction, and back-compat
  re-exports resolving from `plan_service`.
- `test_policies.py`: `plan_complete` allow/deny matrix (incl. symlink-marker
  trust) + a plan-mode source-write regression (`Edit`/`Write`/`apply_patch` and a
  shell redirect to `src/app.py`).
- `test_hook_cli.py`: `plan-complete` blocks once + writes `.wade/stop-nudged`,
  allows with a valid plan, single-shot across tools, plan-at-root doesn't count,
  missing `--root` fails open (alias + lean entry).
- `test_plan_service.py`: `_select_valid_plans` matrix + `plan()` wiring (invalid
  skipped, all-invalid creates nothing, mixed abort, existing-issue path filters).
- `test_bootstrap_allowlist.py`: renamed/updated to assert plan mode installs
  `plan-complete` and impl mode `session-complete`, neither carrying the other's guard.
- Updated the `test_plan_contract.py` E2E fixture to emit a valid
  conventional-commit plan title (the old fixture only passed because validation
  wasn't enforced on the creation path — the E2E failure confirmed the enforcement
  works end-to-end).
- Round 2: `test_copy_failure_retains_source_and_skips_cleanup` (copy-failure
  path retains originals + skips cleanup); `StopGuard` relocation is import-only
  (existing `test_hook_cli.py`/`test_bootstrap_allowlist.py` still green).
- Full suite green: `./scripts/test.sh` (2703 passed, 1 xfailed);
  `./scripts/check.sh` (ruff + ruff-format + mypy --strict) clean.

## Notes for reviewers

- Out of scope (per plan): removing the "don't skip `plan-session done`" wording
  in `plan-session/SKILL.md` (deferred to #355) and the plan-guard `>/dev/null`
  redirect nit (#356-family).
- Dependency #356 is already satisfied in-tree, so this is enforcement on top of a
  guard that already contains source writes on every tool.

<!-- wade:summary:end -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **334,402** |
| Input tokens | **334,400** |
| Output tokens | **2** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **215,000** |
| Input tokens | **213,700** |
| Output tokens | **1,300** |
| Cached tokens | **0** |

### Session 2

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **120,000** |
| Input tokens | **118,900** |
| Output tokens | **1,100** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `caf239f1-a665-472f-a621-ec745237539d` |
| Review | `claude` | `bfd2f6d1-b444-43da-a847-b760a99c1c0c` |
| Review | `claude` | `61f19ebd-6a9b-430a-9c03-624732a5b6f0` |

<!-- wade:sessions:end -->
