### PR TITLE
fix: bound implementation-session review loop with a code-enforced 2-pass cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ escape hatch under a `done:` block in `.wade.yml` (all default on):
 |------|---------------|-------|
 | PR-SUMMARY | `PR-SUMMARY.md` is missing, empty, or still a template placeholder (implementation only) | `done.require_pr_summary: false` |
 | Sync | the branch is behind main — auto-syncs first, refuses only on conflict (implementation only) | `done.require_sync: false` |
-| Review ran | `wade review implementation` did not run for the current commit | `--skip-review`, `done.require_review: false` (auto-off when `ai.review_implementation.enabled: false`) |
+| Review ran | `wade review implementation` did not run for the current commit. **Implementation sessions bound this loop:** after `done.max_review_passes` (default 2) review→fix→re-review cycles, `done` completes anyway with a notice instead of looping forever | `--skip-review`, `done.require_review: false` (auto-off when `ai.review_implementation.enabled: false`) |
 | Resolved threads | unresolved PR review threads remain (review-comments only) | `done.require_resolved_threads: false` |
 
 A **pre-push git hook** (`done.pre_push_backstop`, default on) backs the gate up:

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -283,7 +283,15 @@ HEAD, so any sha-keyed check must precede it):
    session type) — a transient provider error is non-blocking.
 3. **review-ran** (both) — `marker_present(worktree, "reviewed", pre-sync HEAD)`.
    Checked against the pre-sync HEAD so a clean main-merge doesn't invalidate the
-   review just performed.
+   review just performed. **Implementation sessions add a code-enforced 2-pass cap
+   (#384):** past the exact-sha fast path, the gate counts distinct
+   `review-pass@<sha>` markers (written by each delegation-backed
+   `wade review implementation`, independent of its success — so a headless
+   timeout still counts) and, once `done.max_review_passes` (default 2) is
+   reached, completes anyway with a notice rather than looping. A listdir failure
+   counts as 0 (fail toward re-gating). `review-pr-comments` keeps the unbounded
+   fast-path-or-refuse behavior — the gate is shared, so the cap branch is
+   scoped to `session_type == "implementation"`.
 4. **sync** (implementation only) — auto-sync via the existing `do_sync` service
    when `behind > 0`, refuse only on conflict.
 5. `_done_via_pr` writes `.wade/done@<post-sync HEAD>` immediately before pushing.
@@ -378,6 +386,7 @@ done:                        # completion-gate toggles (all default true)
   require_review: true
   require_resolved_threads: true
   pre_push_backstop: true
+  max_review_passes: 2       # impl-session review→fix loop cap (#384); positive int
 ```
 
 **`done` section** (`DoneConfig`): completion-gate escape hatches, all default

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -286,8 +286,9 @@ HEAD, so any sha-keyed check must precede it):
    session type) — a transient provider error is non-blocking.
 3. **review-ran** (both) — `marker_present(worktree, "reviewed", pre-sync HEAD)`.
    Checked against the pre-sync HEAD so a clean main-merge doesn't invalidate the
-   review just performed. **Implementation sessions add a code-enforced 2-pass cap
-   (#384):** past the exact-sha fast path, the gate counts distinct
+   review just performed. **Implementation sessions add a code-enforced review-pass
+   cap (`done.max_review_passes`, default 2) (#384):** past the exact-sha fast
+   path, the gate counts distinct
    `review-pass@<sha>` markers (written by each delegation-backed
    `wade review implementation`, independent of its success — so a headless
    timeout still counts) and, once `done.max_review_passes` (default 2) is

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -218,12 +218,15 @@ Spaced `git -C <dir>` is buffered: `git -C ../crossby log` (a read subcommand) i
 allowed, but a git *write* subcommand after an outside `-C` (`git -C /outside
 clean -fd`, `git -C /outside checkout -- file`) is denied — there is no later path
 operand to catch it otherwise. It also unglues paths from flags
-(`--output=/tmp/x`, `-o/tmp/x`, `of=/tmp/x`, `git -C/tmp/other`) and keeps those
+(`--output=/etc/x`, `-o/etc/x`, `of=/etc/x`, `git -C/etc/other`) and keeps those
 **glued** forms contained in every mode (a tokenizer cannot tell a glued read flag
 from a glued write flag, so a few glued reads are denied too), treats bash's
 `>&file` as a write while skipping true fd duplication (`2>&1`), denies a bare
-`cd` (it lands in `$HOME`), and exempts character devices so `>/dev/null 2>&1`
-still works.
+`cd` (it lands in `$HOME`), and exempts character devices (`>/dev/null 2>&1`) plus
+system temp dirs (`/tmp`, `$TMPDIR`) — shared scratch space where writes are always
+allowed (plan mode still denies them as non-artifacts). The temp exemption is
+scoped to `shell_containment` (via `_ALWAYS_ALLOWED_PATH_PREFIXES`); the file-path
+guard `worktree_containment` stays strictly worktree-only.
 
 **It is defense-in-depth, not a completeness guarantee.** It stops the
 non-obfuscated cases an agent actually produces. Documented residual gaps
@@ -400,7 +403,7 @@ accepted automatically.
 
 **Model complexity mapping**: The `models` section maps AI tool names to complexity-tiered model IDs (`easy`, `medium`, `complex`, `very_complex`). When `wade implement` is invoked, the service reads the `complexity:X` label from the issue (falling back to `## Complexity` in the body), maps it to the appropriate configured model, and passes it as `--model` to the AI tool — unless the user explicitly passed `--model` themselves.
 
-**Per-command AI tool and model overrides**: The `ai` section supports `plan`, `deps`, `implement`, `review_plan`, `review_implementation`, and `review_batch` sub-sections, with optional `tool`, `model`, `mode`, `effort`, `enabled`, `yolo`, `permission_mode`, and `timeout` keys as applicable. The fallback chain is: CLI `--ai`/`--model` flag -> command-specific config -> global `default_tool`. This is implemented in `ProjectConfig.get_ai_tool(command)` and `ProjectConfig.get_model(command)`. When `mode` is omitted, `review_plan` and `review_implementation` default to `prompt`, while `review_batch` defaults to `interactive`.
+**Per-command AI tool and model overrides**: The `ai` section supports `plan`, `deps`, `implement`, `review_plan`, `review_implementation`, and `review_batch` sub-sections, with optional `tool`, `model`, `mode`, `effort`, `enabled`, `yolo`, `permission_mode`, and `timeout` keys as applicable. `timeout` bounds a headless subprocess (seconds) and defaults to **600s** (`DelegationRequest.timeout`) — large enough for a high-effort review/deps run over a big diff to finish rather than tripping mid-run. The fallback chain is: CLI `--ai`/`--model` flag -> command-specific config -> global `default_tool`. This is implemented in `ProjectConfig.get_ai_tool(command)` and `ProjectConfig.get_model(command)`. When `mode` is omitted, `review_plan` and `review_implementation` default to `prompt`, while `review_batch` defaults to `interactive`.
 
 **Permission (autonomy) mode vs. delegation `mode` — two orthogonal axes**: The `mode` key (`DelegationMode`: `prompt`/`interactive`/`headless`, `models/delegation.py`) governs *how* a tool is dispatched. `permission_mode` (`PermissionMode`: `default`/`accept-edits`/`auto`/`yolo`, `models/permission.py`) governs *how much* the tool may do without prompting — the autonomy axis crossby exposes via the `yolo`/`auto`/`accept_edits` launch booleans. Do **not** conflate them: they live in separate modules on purpose. Resolution (`resolve_permission_mode()` in `ai_resolution.py`) follows CLI `--permission-mode` > `--yolo` alias > command config > global config > `default`; `permission_mode` wins over the legacy `yolo` alias at any level, and `get_yolo()`/`resolve_yolo()` are thin shims that derive from the resolved mode so the alias has a single source of truth. WADE forwards only the *requested* tier and does **not** gate on per-tool capability — crossby owns capability-aware downgrades and warnings (`_autonomy_launch_args`), so `auto` on a non-Claude tool downgrades to `accept-edits` instead of WADE silently disabling it. The headless delegation path always forces `default` (no autonomy grant) regardless of config, since `deps`/`review_*` are read/analytical. `plan` is intentionally excluded from `PermissionMode` (WADE drives plan mode separately via `plan_service` → `plan_mode=True`); a configured or CLI-supplied `permission_mode: plan` (or any invalid value) warns and falls back to `default`.
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -292,7 +292,10 @@ HEAD, so any sha-keyed check must precede it):
    `review-pass@<sha>` markers (written by each delegation-backed
    `wade review implementation`, independent of its success — so a headless
    timeout still counts) and, once `done.max_review_passes` (default 2) is
-   reached, completes anyway with a notice rather than looping. A listdir failure
+   reached, completes anyway with a notice rather than looping. `wade review
+   implementation` surfaces the running budget after each pass ("review pass N of
+   M — K left"), so the count is visible from the command rather than only from
+   the skill prose or the `done`-time notice. A listdir failure
    counts as 0 — as does a symlinked `.wade` or a platform without descriptor-based
 directory reads (fail closed toward re-gating, so tampering can't satisfy the
 cap). `review-pr-comments` keeps the unbounded

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -289,7 +289,9 @@ HEAD, so any sha-keyed check must precede it):
    `wade review implementation`, independent of its success — so a headless
    timeout still counts) and, once `done.max_review_passes` (default 2) is
    reached, completes anyway with a notice rather than looping. A listdir failure
-   counts as 0 (fail toward re-gating). `review-pr-comments` keeps the unbounded
+   counts as 0 — as does a symlinked `.wade` or a platform without descriptor-based
+directory reads (fail closed toward re-gating, so tampering can't satisfy the
+cap). `review-pr-comments` keeps the unbounded
    fast-path-or-refuse behavior — the gate is shared, so the cap branch is
    scoped to `session_type == "implementation"`.
 4. **sync** (implementation only) — auto-sync via the existing `do_sync` service
@@ -386,7 +388,7 @@ done:                        # completion-gate toggles (all default true)
   require_review: true
   require_resolved_threads: true
   pre_push_backstop: true
-  max_review_passes: 2       # impl-session review→fix loop cap (#384); positive int
+  max_review_passes: 2       # impl-session review→fix loop cap (#384); strict positive int
 ```
 
 **`done` section** (`DoneConfig`): completion-gate escape hatches, all default

--- a/src/wade/config/loader.py
+++ b/src/wade/config/loader.py
@@ -307,8 +307,9 @@ def _build_config(raw: dict[str, Any], config_path: Path) -> ProjectConfig:
     # `max_review_passes` is an int (default 2), not a bool — it must NOT use
     # `_done_flag` (which normalizes null to the bool default `True`). An explicit
     # null normalizes to the documented default 2; any other value is passed
-    # through so a bad one (0 / -1 / non-int) fails loudly at DoneConfig
-    # construction via its PositiveInt bound rather than being silently accepted.
+    # through raw so a bad one (0 / -1 / bool / str / float) fails loudly at
+    # DoneConfig construction via its *strict* positive-int bound rather than
+    # being coerced (a plain PositiveInt would accept `true`/`"2"`/`2.0`).
     _max_passes = done_raw.get("max_review_passes", 2)
     if _max_passes is None:
         _max_passes = 2

--- a/src/wade/config/loader.py
+++ b/src/wade/config/loader.py
@@ -304,12 +304,22 @@ def _build_config(raw: dict[str, Any], config_path: Path) -> ProjectConfig:
         value = done_raw.get(key, True)
         return True if value is None else value
 
+    # `max_review_passes` is an int (default 2), not a bool — it must NOT use
+    # `_done_flag` (which normalizes null to the bool default `True`). An explicit
+    # null normalizes to the documented default 2; any other value is passed
+    # through so a bad one (0 / -1 / non-int) fails loudly at DoneConfig
+    # construction via its PositiveInt bound rather than being silently accepted.
+    _max_passes = done_raw.get("max_review_passes", 2)
+    if _max_passes is None:
+        _max_passes = 2
+
     done = DoneConfig(
         require_pr_summary=_done_flag("require_pr_summary"),
         require_sync=_done_flag("require_sync"),
         require_review=_done_flag("require_review"),
         require_resolved_threads=_done_flag("require_resolved_threads"),
         pre_push_backstop=_done_flag("pre_push_backstop"),
+        max_review_passes=_max_passes,
     )
 
     return ProjectConfig(

--- a/src/wade/hooks/policies.py
+++ b/src/wade/hooks/policies.py
@@ -26,6 +26,7 @@ import os
 import posixpath
 import re
 import shlex
+import tempfile
 from pathlib import Path
 
 from crossby.hooks.runtime import HookDecision, HookEvent
@@ -224,9 +225,33 @@ _IN_PLACE_FLAG_RE = re.compile(r"^--in-place(=.*)?$|^-i(\..*)?$")
 # rule 5 only — the worktree rules still apply, so it cannot escape the root.
 _IN_PLACE_COMMANDS = frozenset({"sed", "gsed", "perl", "ruby", "yq"})
 
+
+def _temp_write_prefixes() -> tuple[str, ...]:
+    """Resolved system-temp path prefixes writes may always target.
+
+    System temp dirs sit outside the worktree but are legitimate shared scratch
+    space — agents and wade itself stage throwaway files there (headless-review
+    logs, patches, ``mktemp`` output). Resolved so macOS's ``/tmp``→``/private/tmp``
+    and ``$TMPDIR`` (``/var/folders/…``, itself under a ``/private`` symlink) match
+    the *resolved* path :func:`_contained` compares against; each ends in a
+    separator so ``/tmp/`` never matches a sibling like ``/tmpfoo``.
+    """
+    prefixes: set[str] = set()
+    for raw in ("/tmp", tempfile.gettempdir()):
+        try:
+            resolved = str(Path(raw).resolve())
+        except (OSError, ValueError, RuntimeError):
+            resolved = raw
+        prefixes.add(resolved.rstrip("/") + "/")
+    return tuple(sorted(prefixes))
+
+
 # Character devices are not worktree escapes — `>/dev/null 2>&1` is the single most
-# common shell idiom an agent emits, and denying it breaks ordinary sessions.
-_ALWAYS_ALLOWED_PATH_PREFIXES = ("/dev/",)
+# common shell idiom an agent emits — and system temp dirs are shared scratch space
+# outside the worktree. Writes to either are always allowed; every real
+# project/source path outside the root stays contained. Plan mode is unaffected: a
+# temp path is still not a plan artifact, so the stricter plan gate keeps denying it.
+_ALWAYS_ALLOWED_PATH_PREFIXES = ("/dev/", *_temp_write_prefixes())
 
 # Commands whose path operands are *writes*, so their operands stay contained even
 # after the read relaxation. In plan mode those operands must additionally be plan
@@ -372,7 +397,12 @@ def _resolve_shell_path(token: str, *, base: Path) -> Path | None:
 
 
 def _contained(path: Path, root: Path) -> bool:
-    """True when ``path`` is inside ``root`` (or is an always-allowed device node)."""
+    """True when ``path`` is inside ``root`` (or an always-allowed prefix).
+
+    Always-allowed prefixes (:data:`_ALWAYS_ALLOWED_PATH_PREFIXES`) cover device
+    nodes (``/dev/…``) and system temp dirs (``/tmp``, ``$TMPDIR``) — shared
+    scratch space that is safe to write even though it is outside ``root``.
+    """
     if str(path).startswith(_ALWAYS_ALLOWED_PATH_PREFIXES):
         return True
     try:
@@ -400,6 +430,12 @@ def shell_containment(
     a sibling repo (``cat ../crossby/x``, ``grep -r foo ../crossby``,
     ``git -C ../crossby log``) never mutates state, so a read operand may resolve
     anywhere. The guard's job is to keep *writes* inside the root.
+
+    **System temp dirs are the one write exception.** ``/tmp`` and ``$TMPDIR`` are
+    shared scratch space (:func:`_temp_write_prefixes`, via
+    :data:`_ALWAYS_ALLOWED_PATH_PREFIXES`), so writes there resolve as "contained"
+    even though they sit outside the root — plan mode still denies them as
+    non-artifacts.
 
     Rules, in order (any match denies):
 

--- a/src/wade/models/config.py
+++ b/src/wade/models/config.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 from enum import StrEnum
 
 from crossby.models.config import ComplexityModelMapping as ComplexityModelMapping
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PositiveInt
 
 from wade.models.permission import PermissionMode, coerce_permission_mode
 from wade.models.session import MergeStrategy
@@ -218,6 +218,12 @@ class DoneConfig(BaseModel):
       (review-pr-comments sessions).
     - ``pre_push_backstop`` — install the per-worktree pre-push git hook that
       refuses a push lacking a current ``.wade/done@<sha>`` marker.
+    - ``max_review_passes`` — cap on the review→fix→re-review loop for
+      **implementation sessions** (#384). Once this many distinct commits have
+      been reviewed without an exact-sha ``reviewed`` marker for the current tip,
+      ``done`` completes anyway (with a notice) rather than looping forever. A
+      ``PositiveInt`` — a ``0`` / negative value is rejected at load, not silently
+      accepted.
     """
 
     require_pr_summary: bool = True
@@ -225,6 +231,7 @@ class DoneConfig(BaseModel):
     require_review: bool = True
     require_resolved_threads: bool = True
     pre_push_backstop: bool = True
+    max_review_passes: PositiveInt = 2
 
 
 class ProjectSettings(BaseModel):

--- a/src/wade/models/config.py
+++ b/src/wade/models/config.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 from enum import StrEnum
 
 from crossby.models.config import ComplexityModelMapping as ComplexityModelMapping
-from pydantic import BaseModel, Field, PositiveInt
+from pydantic import BaseModel, Field, StrictInt
 
 from wade.models.permission import PermissionMode, coerce_permission_mode
 from wade.models.session import MergeStrategy
@@ -222,8 +222,9 @@ class DoneConfig(BaseModel):
       **implementation sessions** (#384). Once this many distinct commits have
       been reviewed without an exact-sha ``reviewed`` marker for the current tip,
       ``done`` completes anyway (with a notice) rather than looping forever. A
-      ``PositiveInt`` — a ``0`` / negative value is rejected at load, not silently
-      accepted.
+      **strict** positive integer — ``0``/negative *and* non-int YAML scalars
+      (``true``, ``"2"``, ``2.0``) are rejected at load, not coerced (a plain
+      ``PositiveInt`` would silently accept ``true``→1, ``"2"``→2, ``2.0``→2).
     """
 
     require_pr_summary: bool = True
@@ -231,7 +232,7 @@ class DoneConfig(BaseModel):
     require_review: bool = True
     require_resolved_threads: bool = True
     pre_push_backstop: bool = True
-    max_review_passes: PositiveInt = 2
+    max_review_passes: StrictInt = Field(default=2, gt=0)
 
 
 class ProjectSettings(BaseModel):

--- a/src/wade/models/delegation.py
+++ b/src/wade/models/delegation.py
@@ -27,7 +27,10 @@ class DelegationRequest(BaseModel):
     model: str | None = None
     effort: str | None = None
     cwd: Path | None = None
-    timeout: int = 300
+    # Default headless subprocess budget, in seconds. 600s (not 300s) so a
+    # high-effort review/deps run over a large diff finishes rather than tripping
+    # the budget mid-run. Override per command via ``ai.<command>.timeout``.
+    timeout: int = 600
     output_file: Path | None = None
     trusted_dirs: list[str] = Field(default_factory=list)
     allowed_commands: list[str] = Field(default_factory=list)

--- a/src/wade/services/check_service.py
+++ b/src/wade/services/check_service.py
@@ -742,12 +742,14 @@ def _validate_knowledge_section(
 
 
 def _validate_done_section(done: dict[str, Any], errors: list[str]) -> None:
-    """Validate the ``done`` completion-gate section (all fields are booleans).
+    """Validate the ``done`` completion-gate section.
 
-    Iterating ``done.items()`` only sees keys the user explicitly wrote, so an
-    explicit null (``require_sync:`` with no value) is a user mistake, not an
-    "unset" default — reject it. This keeps `wade check` aligned with the loader,
-    which normalizes such a null to the documented default rather than crashing.
+    Every field is a boolean gate toggle **except** ``max_review_passes``, which
+    is a positive int (#384). Iterating ``done.items()`` only sees keys the user
+    explicitly wrote, so an explicit null (``require_sync:`` with no value) is a
+    user mistake, not an "unset" default — reject it. This keeps `wade check`
+    aligned with the loader, which normalizes such a null to the documented
+    default rather than crashing.
     """
     for key, value in done.items():
         if key not in _VALID_DONE_KEYS:
@@ -755,5 +757,10 @@ def _validate_done_section(done: dict[str, Any], errors: list[str]) -> None:
                 f"done.{key}: unsupported key. "
                 f"Supported keys: {', '.join(sorted(_VALID_DONE_KEYS))}"
             )
+        elif key == "max_review_passes":
+            # Reject bool explicitly — it is an int subclass, so a bare
+            # `isinstance(value, int)` would wrongly accept `true`/`false`.
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                errors.append(f"done.{key}: must be a positive integer")
         elif not isinstance(value, bool):
             errors.append(f"done.{key}: must be true or false")

--- a/src/wade/services/implementation_service/done.py
+++ b/src/wade/services/implementation_service/done.py
@@ -426,12 +426,16 @@ def _gate_review_ran(
     limit = config.done.max_review_passes
     if passes >= limit:
         console.warn(
-            f"Review-pass safety limit reached ({passes} of {limit}) — the latest "
-            "commit(s) were NOT re-reviewed."
+            f"Review-pass safety limit reached ({passes} of {limit}) — the current "
+            "commit was not re-reviewed."
         )
-        console.detail("Completing anyway to avoid an unbounded review→fix→re-review loop.")
+        console.detail(
+            f"{passes} commit(s) have been reviewed on this worktree; the cap bounds "
+            "the review→fix→re-review loop so `done` can't be blocked indefinitely. "
+            "Completing without requiring another review."
+        )
         console.hint(
-            "For an explicit full bypass instead, run "
+            "Raise the cap with `done.max_review_passes`, or bypass this run with "
             "`wade implementation-session done --skip-review`."
         )
         return True

--- a/src/wade/services/implementation_service/done.py
+++ b/src/wade/services/implementation_service/done.py
@@ -321,12 +321,18 @@ def _run_completion_gates(
     if session_type == "review-pr-comments":
         if not _gate_resolved_threads(config, provider, repo_root, branch):
             return False
-        return _gate_review_ran(config, worktree_root, pre_sync_head, skip_review)
+        # review-pr-comments keeps the unbounded fast-path-or-refuse behavior:
+        # the 2-pass cap (#384) is scoped to the implementation path only.
+        return _gate_review_ran(
+            config, worktree_root, pre_sync_head, skip_review, session_type=session_type
+        )
 
     # Default: implementation session.
     if not _gate_pr_summary(config, worktree_root):
         return False
-    if not _gate_review_ran(config, worktree_root, pre_sync_head, skip_review):
+    if not _gate_review_ran(
+        config, worktree_root, pre_sync_head, skip_review, session_type=session_type
+    ):
         return False
     return _gate_sync(config, repo_root, worktree_root, branch, main_branch, session_type)
 
@@ -377,8 +383,27 @@ def _gate_review_ran(
     worktree_root: Path,
     head_sha: str,
     skip_review: bool,
+    *,
+    session_type: str = "implementation",
 ) -> bool:
     """Refuse unless ``wade review implementation`` ran for ``head_sha``.
+
+    Fast path (**both** session types): an exact-sha ``reviewed@<head_sha>``
+    marker means done — a review for the current commit always passes on the
+    first try.
+
+    Implementation sessions additionally apply a **code-enforced pass cap** so the
+    review→fix→re-review loop is bounded (#384). Committing after the last review
+    moves the tip sha and invalidates the exact-sha marker; without a bound the
+    agent re-reviews, re-commits, and loops forever. Once
+    ``done.max_review_passes`` distinct commits have carried a delegation-backed
+    ``review-pass@<sha>`` marker, ``done`` completes **anyway** — with a prominent
+    notice — rather than looping. ``review-pr-comments`` sessions keep the
+    unbounded fast-path-or-refuse behavior; #384 is scoped to impl sessions and
+    this gate is shared (knowledge 851bb6ec), so the cap branch is impl-only.
+
+    The pass count is the number of distinct ``review-pass@*`` markers; a listdir
+    failure yields ``0`` (fail toward re-gating), never a false "cap reached".
 
     Auto-skipped when reviews are disabled (``review_implementation.enabled:
     false``) — the marker is not written then either. Hatches: ``--skip-review``
@@ -390,6 +415,42 @@ def _gate_review_ran(
         return True
     if markers.marker_present(worktree_root, "reviewed", head_sha):
         return True
+
+    # review-pr-comments: unchanged fast-path-or-refuse (no cap — out of scope).
+    if session_type != "implementation":
+        _print_review_refusal()
+        return False
+
+    # Implementation session: apply the bounded 2-pass cap.
+    passes = markers.count_review_passes(worktree_root)
+    limit = config.done.max_review_passes
+    if passes >= limit:
+        console.warn(
+            f"Review-pass safety limit reached ({passes} of {limit}) — the latest "
+            "commit(s) were NOT re-reviewed."
+        )
+        console.detail("Completing anyway to avoid an unbounded review→fix→re-review loop.")
+        console.hint(
+            "For an explicit full bypass instead, run "
+            "`wade implementation-session done --skip-review`."
+        )
+        return True
+
+    console.error(f"Review has not run for the current commit (review pass {passes} of {limit}).")
+    console.hint("Run `wade review implementation` (or pass --skip-review), then re-run done.")
+    console.detail(
+        "A clean merge of main is accepted without re-review, but new commits "
+        "require a fresh review — the marker is keyed to the commit sha."
+    )
+    console.hint(
+        "If review keeps looping, break it with `wade implementation-session done --skip-review`."
+    )
+    console.hint("Bypass: set `done.require_review: false` in .wade.yml.")
+    return False
+
+
+def _print_review_refusal() -> None:
+    """Print the standard review-ran refusal (fast-path-or-refuse, no cap)."""
     console.error("Review has not run for the current commit.")
     console.hint("Run `wade review implementation` (or pass --skip-review), then re-run done.")
     console.detail(
@@ -397,7 +458,6 @@ def _gate_review_ran(
         "require a fresh review — the marker is keyed to the commit sha."
     )
     console.hint("Bypass: set `done.require_review: false` in .wade.yml.")
-    return False
 
 
 def _behind_count(repo_root: Path, main_branch: str, branch: str) -> int | None:

--- a/src/wade/services/implementation_service/done.py
+++ b/src/wade/services/implementation_service/done.py
@@ -322,7 +322,7 @@ def _run_completion_gates(
         if not _gate_resolved_threads(config, provider, repo_root, branch):
             return False
         # review-pr-comments keeps the unbounded fast-path-or-refuse behavior:
-        # the 2-pass cap (#384) is scoped to the implementation path only.
+        # the review-pass cap (#384) is scoped to the implementation path only.
         return _gate_review_ran(
             config, worktree_root, pre_sync_head, skip_review, session_type=session_type
         )
@@ -421,7 +421,7 @@ def _gate_review_ran(
         _print_review_refusal()
         return False
 
-    # Implementation session: apply the bounded 2-pass cap.
+    # Implementation session: apply the bounded review-pass cap (done.max_review_passes).
     passes = markers.count_review_passes(worktree_root)
     limit = config.done.max_review_passes
     if passes >= limit:

--- a/src/wade/services/review_delegation_service.py
+++ b/src/wade/services/review_delegation_service.py
@@ -21,7 +21,7 @@ from wade.services.ai_resolution import (
 from wade.services.delegation_service import delegate, resolve_mode
 from wade.skills.installer import load_prompt_template
 from wade.ui.console import console
-from wade.utils.markers import write_marker
+from wade.utils.markers import record_review_pass, write_marker
 
 logger = structlog.get_logger()
 
@@ -42,6 +42,25 @@ def _mark_reviewed() -> None:
         logger.debug("review.reviewed_marker_skipped", exc_info=True)
         return
     write_marker(repo_root, "reviewed", head)
+
+
+def _record_review_pass() -> None:
+    """Count one delegation-backed implementation-review pass for the cap (#384).
+
+    Writes a ``.wade/review-pass@<HEAD>`` marker **independent of the review's
+    success** — even a headless timeout (which exits non-zero and writes no
+    ``reviewed`` marker) still consumed a real review→fix cycle, so it must
+    advance the pass count that the ``done`` gate's 2-pass cap reads. Per-sha and
+    idempotent, so re-running review on the same HEAD does not inflate the count.
+    Best-effort: a git failure is logged and skipped.
+    """
+    try:
+        repo_root = git_repo.get_repo_root(Path.cwd())
+        head = git_repo.rev_parse(repo_root, "HEAD")
+    except GitError:
+        logger.debug("review.review_pass_marker_skipped", exc_info=True)
+        return
+    record_review_pass(repo_root, head)
 
 
 def _load_review_config(
@@ -295,6 +314,11 @@ def review_implementation(
         model_explicit=model_explicit,
         effort_explicit=effort_explicit,
     )
+    # Count this delegation-backed pass toward the `done` review cap regardless
+    # of success — a headless timeout still consumed a review→fix cycle, so it
+    # must advance the count (#384). This runs only past the no-diff early return
+    # above, so an empty review never spends a cap slot. Per-sha and idempotent.
+    _record_review_pass()
     # Record the review-ran marker on any non-hard-failure result (success),
     # keyed to the current HEAD sha. The `done` review-ran gate reads it.
     if result.success:

--- a/src/wade/services/review_delegation_service.py
+++ b/src/wade/services/review_delegation_service.py
@@ -50,7 +50,7 @@ def _record_review_pass() -> None:
     Writes a ``.wade/review-pass@<HEAD>`` marker **independent of the review's
     success** — even a headless timeout (which exits non-zero and writes no
     ``reviewed`` marker) still consumed a real review→fix cycle, so it must
-    advance the pass count that the ``done`` gate's 2-pass cap reads. Per-sha and
+    advance the pass count that the ``done`` gate's review-pass cap reads. Per-sha and
     idempotent, so re-running review on the same HEAD does not inflate the count.
     Best-effort: a git failure is logged and skipped.
     """

--- a/src/wade/services/review_delegation_service.py
+++ b/src/wade/services/review_delegation_service.py
@@ -21,7 +21,7 @@ from wade.services.ai_resolution import (
 from wade.services.delegation_service import delegate, resolve_mode
 from wade.skills.installer import load_prompt_template
 from wade.ui.console import console
-from wade.utils.markers import record_review_pass, write_marker
+from wade.utils.markers import count_review_passes, record_review_pass, write_marker
 
 logger = structlog.get_logger()
 
@@ -44,7 +44,7 @@ def _mark_reviewed() -> None:
     write_marker(repo_root, "reviewed", head)
 
 
-def _record_review_pass() -> None:
+def _record_review_pass() -> int | None:
     """Count one delegation-backed implementation-review pass for the cap (#384).
 
     Writes a ``.wade/review-pass@<HEAD>`` marker **independent of the review's
@@ -52,15 +52,43 @@ def _record_review_pass() -> None:
     ``reviewed`` marker) still consumed a real review→fix cycle, so it must
     advance the pass count that the ``done`` gate's review-pass cap reads. Per-sha and
     idempotent, so re-running review on the same HEAD does not inflate the count.
-    Best-effort: a git failure is logged and skipped.
+
+    Returns the resulting distinct-pass count, or ``None`` if the marker could not
+    be recorded (best-effort: a git failure is logged and skipped).
     """
     try:
         repo_root = git_repo.get_repo_root(Path.cwd())
         head = git_repo.rev_parse(repo_root, "HEAD")
     except GitError:
         logger.debug("review.review_pass_marker_skipped", exc_info=True)
-        return
+        return None
     record_review_pass(repo_root, head)
+    return count_review_passes(repo_root)
+
+
+def _announce_review_pass_budget(passes: int, limit: int) -> None:
+    """Surface the implementation-session review-pass budget from the command (#384).
+
+    The ``done`` cap stops requiring re-review of new commits after
+    ``done.max_review_passes`` passes. Printing the running count here means an
+    agent sees its remaining budget directly from ``wade review implementation``
+    rather than from buried skill/prompt prose. Informational only — the cap is
+    enforced (and scoped to implementation sessions) at ``done`` time.
+    """
+    remaining = max(0, limit - passes)
+    if remaining > 0:
+        plural = "" if remaining == 1 else "es"
+        console.info(
+            f"Review pass {passes} of {limit} recorded — {remaining} pass{plural} left "
+            "before `done` stops requiring re-review of new commits in an "
+            "implementation session. Configure the cap with `done.max_review_passes`."
+        )
+    else:
+        console.warn(
+            f"Review pass {passes} of {limit} recorded — the implementation-session "
+            "review-pass cap is now reached. `done` will complete without requiring "
+            "re-review of further commits. Configure with `done.max_review_passes`."
+        )
 
 
 def _load_review_config(
@@ -318,7 +346,13 @@ def review_implementation(
     # of success — a headless timeout still consumed a review→fix cycle, so it
     # must advance the count (#384). This runs only past the no-diff early return
     # above, so an empty review never spends a cap slot. Per-sha and idempotent.
-    _record_review_pass()
+    passes = _record_review_pass()
+    # Surface the running budget from the command itself so the caller sees how
+    # many passes remain before `done` stops requiring re-review — no need to rely
+    # on the "run at most N times" rule buried in the skill/prompt. Guarded by an
+    # int check so a mocked `_record_review_pass` in tests never triggers it.
+    if isinstance(passes, int):
+        _announce_review_pass_budget(passes, config.done.max_review_passes)
     # Record the review-ran marker on any non-hard-failure result (success),
     # keyed to the current HEAD sha. The `done` review-ran gate reads it.
     if result.success:

--- a/src/wade/utils/markers.py
+++ b/src/wade/utils/markers.py
@@ -227,6 +227,66 @@ def clear_markers(worktree_root: Path, name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Review-pass markers (#384) — a distinct, *non-clearing* sha-keyed family
+# ---------------------------------------------------------------------------
+#
+# The implementation-session ``done`` review cap counts how many distinct
+# commits went through a delegation-backed review. Unlike ``write_marker`` (which
+# clears any prior ``<name>@*`` first, keeping exactly one marker), each
+# ``review-pass@<sha>`` must *persist* so the count reflects the number of
+# review→fix→new-commit cycles. The name is deliberately different from
+# ``reviewed`` so ``write_marker(..., "reviewed", ...)``'s clear-prior-same-name
+# cleanup never touches this family.
+
+_REVIEW_PASS_NAME = "review-pass"
+
+
+def record_review_pass(worktree_root: Path, sha: str) -> bool:
+    """Record one delegation-backed implementation review for ``sha`` (#384).
+
+    Writes ``.wade/review-pass@<sha>`` **without** clearing prior
+    ``review-pass@*`` markers, so :func:`count_review_passes` reflects the number
+    of distinct commits that were reviewed — the pass count the ``done`` cap
+    reads. Per-sha writes are idempotent (a re-review of the same HEAD reuses the
+    same filename), so same-commit retries never inflate the count. Best-effort:
+    a failed write returns ``False``.
+    """
+    ok = _atomic_write(worktree_root, f"{_REVIEW_PASS_NAME}@{sha}")
+    if not ok:
+        logger.debug("markers.review_pass_write_failed", sha=sha)
+    return ok
+
+
+def count_review_passes(worktree_root: Path) -> int:
+    """Number of distinct ``.wade/review-pass@<sha>`` markers (#384).
+
+    The pass count the implementation-session ``done`` gate compares against the
+    2-pass cap. A directory-listing failure (or a missing/symlinked ``.wade``)
+    yields ``0`` — fail toward re-gating, never a false "cap already reached",
+    matching this module's best-effort convention. ``*.tmp`` scratch files left by
+    a partial :func:`_atomic_write` are excluded.
+    """
+    prefix = f"{_REVIEW_PASS_NAME}@"
+    wade_dir = _wade_dir(worktree_root)
+    if _read_dir_fd_supported() and os.listdir in os.supports_fd:
+        dir_fd = None
+        try:
+            dir_fd = os.open(wade_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+            entries = os.listdir(dir_fd)
+        except OSError:
+            return 0
+        finally:
+            if dir_fd is not None:
+                os.close(dir_fd)
+    else:
+        try:
+            entries = [p.name for p in wade_dir.iterdir()]
+        except OSError:
+            return 0
+    return sum(1 for e in entries if e.startswith(prefix) and not e.endswith(".tmp"))
+
+
+# ---------------------------------------------------------------------------
 # Public single-shot flag API (generalizes ``.wade/stop-nudged``)
 # ---------------------------------------------------------------------------
 

--- a/src/wade/utils/markers.py
+++ b/src/wade/utils/markers.py
@@ -261,10 +261,11 @@ def count_review_passes(worktree_root: Path) -> int:
     """Number of distinct ``.wade/review-pass@<sha>`` markers (#384).
 
     The pass count the implementation-session ``done`` gate compares against the
-    2-pass cap. A directory-listing failure (or a missing/symlinked ``.wade``)
-    yields ``0`` — fail toward re-gating, never a false "cap already reached",
-    matching this module's best-effort convention. ``*.tmp`` scratch files left by
-    a partial :func:`_atomic_write` are excluded.
+    2-pass cap. A directory-listing failure, a missing/symlinked ``.wade``, or a
+    platform without descriptor-based directory reads all yield ``0`` — fail
+    toward re-gating, never a false "cap already reached", matching this module's
+    best-effort convention. ``*.tmp`` scratch files left by a partial
+    :func:`_atomic_write` are excluded.
     """
     prefix = f"{_REVIEW_PASS_NAME}@"
     wade_dir = _wade_dir(worktree_root)
@@ -279,10 +280,12 @@ def count_review_passes(worktree_root: Path) -> int:
             if dir_fd is not None:
                 os.close(dir_fd)
     else:
-        try:
-            entries = [p.name for p in wade_dir.iterdir()]
-        except OSError:
-            return 0
+        # No safe, descriptor-based directory read available. Fail closed rather
+        # than fall back to path-based ``iterdir()``, which follows a symlinked
+        # ``.wade`` — a crafted worktree could then expose attacker-controlled
+        # ``review-pass@*`` entries and satisfy the cap. Returning 0 keeps the
+        # fail-toward-re-gating convention (never a false "cap already reached").
+        return 0
     return sum(1 for e in entries if e.startswith(prefix) and not e.endswith(".tmp"))
 
 

--- a/src/wade/utils/markers.py
+++ b/src/wade/utils/markers.py
@@ -261,7 +261,8 @@ def count_review_passes(worktree_root: Path) -> int:
     """Number of distinct ``.wade/review-pass@<sha>`` markers (#384).
 
     The pass count the implementation-session ``done`` gate compares against the
-    2-pass cap. A directory-listing failure, a missing/symlinked ``.wade``, or a
+    configured review-pass cap (``done.max_review_passes``, default 2). A
+    directory-listing failure, a missing/symlinked ``.wade``, or a
     platform without descriptor-based directory reads all yield ``0`` — fail
     toward re-gating, never a false "cap already reached", matching this module's
     best-effort convention. ``*.tmp`` scratch files left by a partial

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -12,20 +12,17 @@ Run `wade review implementation` to review your changes and check the exit code:
 For staged-only review: `wade review implementation --staged`.
 
 **Headless review can be slow.** When `review_implementation.mode` is `headless`,
-this launches an external AI subprocess that may run for a few minutes. wade
-prints the exact budget when it starts ("can take up to Ns"). Keep the command in
-the foreground and allow more than that before timing out — raise your shell/tool
-timeout if needed. Do not kill it early or move it to the background; a premature
-kill is an infra timeout, not a review result. The budget is
-`ai.review_implementation.timeout` in `.wade.yml` (default 300s).
+it launches an external AI subprocess that may run for a few minutes. wade prints
+the budget when it starts ("can take up to Ns"). Keep it in the foreground and
+allow more than that before timing out. Do not kill it early or background it — a
+premature kill is an infra timeout, not a review result. Budget:
+`ai.review_implementation.timeout` (300s).
 
-**Run at most 2 times total**:
-- If findings are **minor** (style, small fixes): Address them and proceed to
-  Step 2; no re-review needed.
-- If findings are **major** (logic errors, architectural issues): Address them
-  and re-run once. Always proceed to Step 2 after the 2nd run, regardless of
-  new findings.
-- Do not run a third time.
+**Run at most 2 times — code-enforced.** Minor findings: fix and proceed. Major
+findings: fix, re-run once, then proceed regardless of new findings. `done`
+counts distinct reviewed commits and, after `done.max_review_passes` (default 2)
+review→fix cycles, completes anyway (with a notice) instead of looping. Stuck in
+that loop? Break it with `wade implementation-session done --skip-review`.
 
 **This step is mandatory when `review_implementation.enabled` is not `false`.
 Do NOT proceed to Step 2 until this step is complete and any actionable

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -18,12 +18,12 @@ allow more than that before timing out. Do not kill it early or background it �
 premature kill is an infra timeout, not a review result. Budget:
 `ai.review_implementation.timeout` (600s).
 
-**Run at most 2 times — code-enforced.** After fixing a finding, commit and
-re-review before proceeding (the commit stales the `reviewed` marker). Major
-findings: re-run once, then proceed regardless. After `done.max_review_passes`
-(default 2) review→fix cycles, `done` completes anyway (with a notice) instead of
-looping. Break a stuck loop with `wade implementation-session done
---skip-review`.
+**Run at most `done.max_review_passes` times (default 2) — code-enforced.** After
+fixing a finding, commit and re-review before proceeding (the commit stales the
+`reviewed` marker). Major findings: re-run once, then proceed regardless. After
+`done.max_review_passes` review→fix cycles, `done` completes anyway (with a
+notice) instead of looping. Break a stuck loop with `wade
+implementation-session done --skip-review`.
 
 **This step is mandatory when `review_implementation.enabled` is not `false`.
 Do NOT proceed to Step 2 until this step is complete and any actionable

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -18,12 +18,12 @@ allow more than that before timing out. Do not kill it early or background it �
 premature kill is an infra timeout, not a review result. Budget:
 `ai.review_implementation.timeout` (600s).
 
-**Run at most `done.max_review_passes` times (default 2) — code-enforced.** After
-fixing a finding, commit and re-review before proceeding (the commit stales the
-`reviewed` marker). Major findings: re-run once, then proceed regardless. After
-`done.max_review_passes` review→fix cycles, `done` completes anyway (with a
-notice) instead of looping. Break a stuck loop with `wade
-implementation-session done --skip-review`.
+**Bounded by `done.max_review_passes` (default 2) — code-enforced.** `wade review
+implementation` prints your budget each pass ("review pass N of M — K left").
+After fixing a finding, commit and re-review (the commit stales the `reviewed`
+marker); major findings, re-run once. Once spent, `done` completes anyway (with a
+notice) instead of looping — break a stuck loop with `wade implementation-session
+done --skip-review`.
 
 **This step is mandatory when `review_implementation.enabled` is not `false`.
 Do NOT proceed to Step 2 until this step is complete and any actionable

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -16,7 +16,7 @@ it launches an external AI subprocess that may run for a few minutes. wade print
 the budget when it starts ("can take up to Ns"). Keep it in the foreground and
 allow more than that before timing out. Do not kill it early or background it — a
 premature kill is an infra timeout, not a review result. Budget:
-`ai.review_implementation.timeout` (300s).
+`ai.review_implementation.timeout` (600s).
 
 **Run at most 2 times — code-enforced.** After fixing a finding, commit and
 re-review before proceeding (the commit stales the `reviewed` marker). Major

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -18,11 +18,12 @@ allow more than that before timing out. Do not kill it early or background it �
 premature kill is an infra timeout, not a review result. Budget:
 `ai.review_implementation.timeout` (300s).
 
-**Run at most 2 times — code-enforced.** Minor findings: fix and proceed. Major
-findings: fix, re-run once, then proceed regardless of new findings. `done`
-counts distinct reviewed commits and, after `done.max_review_passes` (default 2)
-review→fix cycles, completes anyway (with a notice) instead of looping. Stuck in
-that loop? Break it with `wade implementation-session done --skip-review`.
+**Run at most 2 times — code-enforced.** After fixing a finding, commit and
+re-review before proceeding (the commit stales the `reviewed` marker). Major
+findings: re-run once, then proceed regardless. After `done.max_review_passes`
+(default 2) review→fix cycles, `done` completes anyway (with a notice) instead of
+looping. Break a stuck loop with `wade implementation-session done
+--skip-review`.
 
 **This step is mandatory when `review_implementation.enabled` is not `false`.
 Do NOT proceed to Step 2 until this step is complete and any actionable

--- a/tests/e2e/test_implement_work_done_contract.py
+++ b/tests/e2e/test_implement_work_done_contract.py
@@ -316,6 +316,104 @@ class TestWorkDoneCommand:
         assert isinstance(pr_data, dict)
         assert "Part of #100" in str(pr_data.get("body", ""))
 
+    def test_done_escapes_review_loop_after_two_passes(
+        self,
+        e2e_repo: Path,
+        mock_gh_cli: MockGhCli,
+    ) -> None:
+        """#384: review→commit→done refuses once, then completes on the 2nd pass.
+
+        The default review mode is ``prompt`` (self-review, no AI subprocess), so
+        each ``wade review implementation`` exits 2 and records a delegation-backed
+        ``review-pass@<HEAD>`` marker. Committing after each review invalidates the
+        exact-sha ``reviewed`` marker — the exact loop the cap must bound.
+        """
+        issue_number = 84
+        issue_title = "Bound the review loop"
+        _seed_mock_issue(
+            mock_gh_cli["state_file"],
+            issue_number=issue_number,
+            title=issue_title,
+            body="## Tasks\n- Cap the review loop\n",
+        )
+        origin_repo = _init_origin_remote(e2e_repo)
+        branch_name = "feat/84-bound-the-review-loop"
+
+        start_result = _run(["implement", str(issue_number), "--cd"], cwd=e2e_repo)
+        assert start_result.returncode == 0
+        worktree_path = Path(start_result.stdout.strip())
+        assert worktree_path.is_dir()
+
+        (worktree_path / "PR-SUMMARY.md").write_text(
+            "Bounded the implementation-session review loop with a 2-pass cap.\n",
+            encoding="utf-8",
+        )
+
+        def _commit(content: str) -> None:
+            (worktree_path / "impl.txt").write_text(content, encoding="utf-8")
+            _git(["add", "-A"], cwd=worktree_path)
+            _git(["commit", "-m", f"feat: impl {content.strip()}"], cwd=worktree_path)
+
+        # --- Pass 1: review, commit AFTER the review, then done must REFUSE. ---
+        _commit("v1\n")
+        review1 = _run(["review", "implementation"], cwd=worktree_path)
+        assert review1.returncode == 2, review1.stdout + review1.stderr
+
+        _commit("v2\n")  # new commit → the reviewed@<sha> marker is now stale
+        done1 = _run(["implementation-session", "done"], cwd=worktree_path)
+        out1 = " ".join((done1.stdout + done1.stderr).split())
+        assert done1.returncode != 0, out1
+        assert "review pass 1 of 2" in out1
+        # Nothing was finalized on the refusal.
+        assert _count_gh_calls(mock_gh_cli["log_file"], ["pr", "ready"]) == 0
+
+        # --- Pass 2: review again, commit again — done SUCCEEDS at the cap. ---
+        review2 = _run(["review", "implementation"], cwd=worktree_path)
+        assert review2.returncode == 2, review2.stdout + review2.stderr
+
+        _commit("v3\n")  # still a newer, un-reviewed commit — but the cap is hit
+        done2 = _run(["implementation-session", "done"], cwd=worktree_path)
+        out2 = " ".join((done2.stdout + done2.stderr).split())
+        assert done2.returncode == 0, out2
+        assert "safety limit reached" in out2
+        assert _remote_has_branch(origin_repo, branch_name)
+
+    def test_review_pass_count_survives_second_implement(
+        self,
+        e2e_repo: Path,
+        mock_gh_cli: MockGhCli,
+    ) -> None:
+        """#384: the review-pass count persists across a second `wade implement`.
+
+        The markers live in the worktree's ``.wade/`` and no code path (bootstrap
+        included) clears the ``review-pass@*`` family, so the idempotent
+        worktree-reuse re-run must not reset the cap to 0.
+        """
+        issue_number = 85
+        _seed_mock_issue(
+            mock_gh_cli["state_file"],
+            issue_number=issue_number,
+            title="Persist review passes",
+            body="## Tasks\n- Keep the count\n",
+        )
+        _init_origin_remote(e2e_repo)
+
+        start_result = _run(["implement", str(issue_number), "--cd"], cwd=e2e_repo)
+        assert start_result.returncode == 0
+        worktree_path = Path(start_result.stdout.strip())
+        assert worktree_path.is_dir()
+
+        # Simulate a completed delegation-backed review pass.
+        marker = worktree_path / ".wade" / ("review-pass@" + "d" * 40)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("", encoding="utf-8")
+
+        again_result = _run(["implement", str(issue_number), "--cd"], cwd=e2e_repo)
+        assert again_result.returncode == 0
+        assert Path(again_result.stdout.strip()) == worktree_path
+        # The marker (and thus the pass count) survived the re-bootstrap.
+        assert marker.is_file()
+
     def test_work_done_fails_when_managed_claude_files_were_force_committed(
         self,
         e2e_repo: Path,

--- a/tests/unit/test_config/test_loader.py
+++ b/tests/unit/test_config/test_loader.py
@@ -259,6 +259,28 @@ class TestParseConfigFile:
         with pytest.raises(ConfigError):
             parse_config_file(config_path)
 
+    def test_max_review_passes_bool_rejected_at_load(self, tmp_path: Path) -> None:
+        # StrictInt rejects YAML `true` at load — a plain PositiveInt would coerce
+        # it to 1 (bool is an int subclass), silently accepting an invalid value.
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\ndone:\n  max_review_passes: true\n")
+        with pytest.raises(ConfigError):
+            parse_config_file(config_path)
+
+    def test_max_review_passes_string_rejected_at_load(self, tmp_path: Path) -> None:
+        # StrictInt rejects a YAML string; a plain PositiveInt would coerce "2"→2.
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text('version: 2\ndone:\n  max_review_passes: "2"\n')
+        with pytest.raises(ConfigError):
+            parse_config_file(config_path)
+
+    def test_max_review_passes_float_rejected_at_load(self, tmp_path: Path) -> None:
+        # StrictInt rejects a YAML float; a plain PositiveInt would coerce 2.0→2.
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\ndone:\n  max_review_passes: 2.0\n")
+        with pytest.raises(ConfigError):
+            parse_config_file(config_path)
+
     def test_empty_file(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
         config_path.write_text("")

--- a/tests/unit/test_config/test_loader.py
+++ b/tests/unit/test_config/test_loader.py
@@ -227,6 +227,38 @@ class TestParseConfigFile:
         config = parse_config_file(config_path)
         assert config.done.require_sync is True
 
+    def test_max_review_passes_default(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\n")
+        config = parse_config_file(config_path)
+        assert config.done.max_review_passes == 2
+
+    def test_max_review_passes_override(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\ndone:\n  max_review_passes: 5\n")
+        config = parse_config_file(config_path)
+        assert config.done.max_review_passes == 5
+
+    def test_max_review_passes_null_normalized_to_default(self, tmp_path: Path) -> None:
+        # An explicit null (not a bool default) must normalize to 2, not crash.
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\ndone:\n  max_review_passes:\n")
+        config = parse_config_file(config_path)
+        assert config.done.max_review_passes == 2
+
+    def test_max_review_passes_zero_rejected_at_load(self, tmp_path: Path) -> None:
+        # PositiveInt bound makes a 0 fail loudly at load (wrapped as ConfigError).
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\ndone:\n  max_review_passes: 0\n")
+        with pytest.raises(ConfigError):
+            parse_config_file(config_path)
+
+    def test_max_review_passes_negative_rejected_at_load(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text("version: 2\ndone:\n  max_review_passes: -1\n")
+        with pytest.raises(ConfigError):
+            parse_config_file(config_path)
+
     def test_empty_file(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
         config_path.write_text("")

--- a/tests/unit/test_hooks/test_policies.py
+++ b/tests/unit/test_hooks/test_policies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import tempfile
 from pathlib import Path
 
@@ -168,7 +169,7 @@ class TestShellContainment:
     def test_system_tmpdir_writes_allowed(self) -> None:
         """``$TMPDIR`` — not just the literal ``/tmp`` — is allowed, cross-platform."""
         target = f"{tempfile.gettempdir()}/wade-scratch.log"
-        d = shell_containment(_shell(f"printf x > {target}"), worktree_root=WT)
+        d = shell_containment(_shell(f"printf x > {shlex.quote(target)}"), worktree_root=WT)
         assert d.action == "allow"
 
     def test_temp_dir_writes_still_denied_in_plan_mode(self) -> None:

--- a/tests/unit/test_hooks/test_policies.py
+++ b/tests/unit/test_hooks/test_policies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -80,26 +81,26 @@ class TestShellContainment:
     @pytest.mark.parametrize(
         "command",
         [
-            "printf 'x' > /tmp/out.txt",  # spaced redirect
-            "printf 'x' >/tmp/out.txt",  # glued redirect
+            "printf 'x' > /etc/out.txt",  # spaced redirect
+            "printf 'x' >/etc/out.txt",  # glued redirect
             "printf x >>../main/file",  # relative traversal, glued append
-            'printf x > "/tmp/quoted"',  # quoting does not hide the target
-            "printf x > /tmp/esc\\ aped",  # escaped space
+            'printf x > "/etc/quoted"',  # quoting does not hide the target
+            "printf x > /etc/esc\\ aped",  # escaped space
             "cd /etc && rm x",  # cd outside rebases later writes
             "cd ..",  # bare .. carries no slash
             "cd ../../elsewhere",
-            "cp a /tmp/b",
+            "cp a /etc/b",
             "git checkout -- ../main-repo/x",
             "echo a | tee /etc/p",
             "sed -i '' s/a/b/ ../main/file",  # in-place edit outside (impl mode)
-            "true; cp a /tmp/b",  # ;-chained segment
-            "true && cp a /tmp/b",  # &&-chained segment
-            "mkdir /tmp/outside-dir",  # mkdir creates outside
-            "git clone https://example.com/r.git /tmp/outside",  # positional write
-            "git init /tmp/outside",
-            "git worktree add /tmp/outside main",  # literal worktree escape
-            "git -C /tmp/outside clean -fd",  # spaced -C + git write subcommand
-            "git -C /tmp/outside checkout -- file",
+            "true; cp a /etc/b",  # ;-chained segment
+            "true && cp a /etc/b",  # &&-chained segment
+            "mkdir /etc/outside-dir",  # mkdir creates outside
+            "git clone https://example.com/r.git /etc/outside",  # positional write
+            "git init /etc/outside",
+            "git worktree add /etc/outside main",  # literal worktree escape
+            "git -C /etc/outside clean -fd",  # spaced -C + git write subcommand
+            "git -C /etc/outside checkout -- file",
         ],
     )
     def test_outside_worktree_denied(self, command: str) -> None:
@@ -145,11 +146,41 @@ class TestShellContainment:
         """``>/dev/null 2>&1`` is the commonest shell idiom there is, not an escape."""
         assert shell_containment(_shell(command), worktree_root=WT).action == "allow"
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "printf 'x' > /tmp/out.txt",  # spaced redirect to temp
+            "printf 'x' >/tmp/scratch.log",  # glued redirect
+            "cp README.md /tmp/backup",  # write command operand into temp
+            "mkdir /tmp/wade-scratch",
+            "sort --output=/tmp/pwn file",  # glued write flag to temp
+        ],
+    )
+    def test_temp_dir_writes_allowed(self, command: str) -> None:
+        """System temp dirs (``/tmp``, ``$TMPDIR``) are shared scratch space — writes to a
+        file *under* them are allowed even though they resolve outside the worktree.
+
+        The dir prefix carries a trailing separator so ``/tmp/`` can't match a sibling
+        like ``/tmpfoo``; that also means the bare dir (``cd /tmp``) is not itself a
+        target, which is fine — the use case is staging scratch *files*."""
+        assert shell_containment(_shell(command), worktree_root=WT).action == "allow"
+
+    def test_system_tmpdir_writes_allowed(self) -> None:
+        """``$TMPDIR`` — not just the literal ``/tmp`` — is allowed, cross-platform."""
+        target = f"{tempfile.gettempdir()}/wade-scratch.log"
+        d = shell_containment(_shell(f"printf x > {target}"), worktree_root=WT)
+        assert d.action == "allow"
+
+    def test_temp_dir_writes_still_denied_in_plan_mode(self) -> None:
+        """Plan mode stays artifact-only — a temp write is not a plan artifact."""
+        d = shell_containment(_shell("printf x > /tmp/o"), worktree_root=WT, plan_mode=True)
+        assert d.action == "deny"
+
     @pytest.mark.parametrize("command", ["echo hi 2>&1", "echo hi >&2", "exec 3>&-"])
     def test_fd_duplication_names_no_file(self, command: str) -> None:
         assert shell_containment(_shell(command), worktree_root=WT).action == "allow"
 
-    @pytest.mark.parametrize("command", ["printf x >&/tmp/pwn", "printf x >>&/tmp/pwn"])
+    @pytest.mark.parametrize("command", ["printf x >&/etc/pwn", "printf x >>&/etc/pwn"])
     def test_glued_ampersand_redirect_to_file_denied(self, command: str) -> None:
         """bash's ``>&word`` with a filename is a real write, not an fd dup."""
         assert shell_containment(_shell(command), worktree_root=WT).action == "deny"
@@ -157,11 +188,11 @@ class TestShellContainment:
     @pytest.mark.parametrize(
         "command",
         [
-            "sort --output=/tmp/pwn file",
-            "tar --file=/tmp/pwn.tar -c .",
-            "curl -o/tmp/pwn https://example.com",
-            "dd of=/tmp/pwn if=README.md",
-            "git -C/tmp/other init",
+            "sort --output=/etc/pwn file",
+            "tar --file=/etc/pwn.tar -c .",
+            "curl -o/etc/pwn https://example.com",
+            "dd of=/etc/pwn if=README.md",
+            "git -C/etc/other init",
         ],
     )
     def test_paths_glued_to_flags_denied(self, command: str) -> None:
@@ -204,9 +235,9 @@ class TestShellContainment:
     @pytest.mark.parametrize(
         "command",
         [
-            "tee 'a|b' /tmp/pwn",  # quoted '|' must not fake a segment break
-            "tee 'a;b' /tmp/pwn",
-            "grep 'x&y' f && cp a /tmp/b",  # real separator after a quoted one
+            "tee 'a|b' /etc/pwn",  # quoted '|' must not fake a segment break
+            "tee 'a;b' /etc/pwn",
+            "grep 'x&y' f && cp a /etc/b",  # real separator after a quoted one
         ],
     )
     def test_quoted_separators_do_not_hide_the_next_operand(self, command: str) -> None:
@@ -248,7 +279,7 @@ class TestShellContainment:
             "rm -rf src/",
             "rmdir src",
             "unlink src/app.py",
-            "printf x > /tmp/o",  # outside wins regardless
+            "printf x > /tmp/o",  # temp is writable elsewhere, but never a plan artifact
         ],
     )
     def test_plan_mode_denies_non_artifact_writes(self, command: str) -> None:

--- a/tests/unit/test_models/test_delegation.py
+++ b/tests/unit/test_models/test_delegation.py
@@ -27,7 +27,7 @@ class TestDelegationRequest:
         assert req.prompt == "Review this"
         assert req.ai_tool is None
         assert req.model is None
-        assert req.timeout == 300
+        assert req.timeout == 600  # default headless budget (s)
         assert req.trusted_dirs == []
         assert req.allowed_commands == []
         assert req.permission_mode is PermissionMode.DEFAULT

--- a/tests/unit/test_services/test_check.py
+++ b/tests/unit/test_services/test_check.py
@@ -234,6 +234,29 @@ class TestValidateConfig:
         assert result.exit_code == ConfigExitCode.INVALID
         assert any("done.require_sync" in e and "true or false" in e for e in result.errors)
 
+    def test_max_review_passes_positive_int_accepted(self, tmp_path: Path) -> None:
+        # `max_review_passes` is an int, not a bool — a positive int must pass
+        # `wade check` (the old bool-only validator would have flagged it).
+        config = tmp_path / ".wade.yml"
+        config.write_text("version: 2\ndone:\n  max_review_passes: 3\n")
+        result = validate_config(tmp_path)
+        assert result.is_valid, f"Errors: {result.errors}"
+
+    def test_max_review_passes_zero_rejected(self, tmp_path: Path) -> None:
+        config = tmp_path / ".wade.yml"
+        config.write_text("version: 2\ndone:\n  max_review_passes: 0\n")
+        result = validate_config(tmp_path)
+        assert result.exit_code == ConfigExitCode.INVALID
+        assert any("done.max_review_passes" in e and "positive integer" in e for e in result.errors)
+
+    def test_max_review_passes_bool_rejected(self, tmp_path: Path) -> None:
+        # `true` is an int subclass — it must NOT sneak through as a valid count.
+        config = tmp_path / ".wade.yml"
+        config.write_text("version: 2\ndone:\n  max_review_passes: true\n")
+        result = validate_config(tmp_path)
+        assert result.exit_code == ConfigExitCode.INVALID
+        assert any("done.max_review_passes" in e and "positive integer" in e for e in result.errors)
+
     def test_valid_hooks_quality_gate_sections(self, tmp_path: Path) -> None:
         config = tmp_path / ".wade.yml"
         config.write_text(

--- a/tests/unit/test_services/test_done_gates.py
+++ b/tests/unit/test_services/test_done_gates.py
@@ -157,8 +157,11 @@ class TestReviewRanCap:
         assert "not re-reviewed" in text.lower()
         assert "--skip-review" in text
 
-    def test_exact_sha_fast_path_wins_over_cap(self, tmp_path: Path) -> None:
-        # An exact-sha reviewed marker passes on the first try regardless of count.
+    def test_exact_sha_fast_path_wins_over_cap(self, tmp_path: Path, capsys) -> None:
+        # An exact-sha reviewed marker passes even when the review-pass cap is
+        # already exhausted — the fast path precedes the cap check.
+        markers.record_review_pass(tmp_path, "sha1")
+        markers.record_review_pass(tmp_path, "sha2")  # cap (default 2) reached
         markers.write_marker(tmp_path, "reviewed", "head")
         assert (
             _gate_review_ran(
@@ -166,6 +169,8 @@ class TestReviewRanCap:
             )
             is True
         )
+        # Took the exact-sha fast path, not the cap branch (no safety-limit notice).
+        assert "safety limit reached" not in _captured_text(capsys)
 
     def test_custom_max_review_passes_honored(self, tmp_path: Path) -> None:
         config = ProjectConfig(done=DoneConfig(max_review_passes=3))

--- a/tests/unit/test_services/test_done_gates.py
+++ b/tests/unit/test_services/test_done_gates.py
@@ -107,6 +107,114 @@ class TestReviewRanGate:
         assert _gate_review_ran(config, tmp_path, "abc", skip_review=False) is True
 
 
+def _captured_text(capsys) -> str:
+    """Combined stdout+stderr with whitespace collapsed (survives rich wrapping).
+
+    ``console.error``/``warn`` go to stderr while ``hint``/``detail`` go to
+    stdout, and rich soft-wraps long lines — so join both streams and normalize
+    whitespace before substring-matching a phrase.
+    """
+    captured = capsys.readouterr()
+    return " ".join((captured.out + "\n" + captured.err).split())
+
+
+class TestReviewRanCap:
+    """The code-enforced 2-pass cap on the implementation path (#384)."""
+
+    def test_refuses_before_cap_with_pass_count(self, tmp_path: Path, capsys) -> None:
+        # One prior pass, no exact-sha marker, limit 2 → refuse "pass 1 of 2".
+        markers.record_review_pass(tmp_path, "sha1")
+        assert (
+            _gate_review_ran(
+                ProjectConfig(),
+                tmp_path,
+                "newhead",
+                skip_review=False,
+                session_type="implementation",
+            )
+            is False
+        )
+        text = _captured_text(capsys)
+        assert "review pass 1 of 2" in text
+        assert "--skip-review" in text
+
+    def test_passes_at_cap_with_notice(self, tmp_path: Path, capsys) -> None:
+        # Two distinct reviewed commits reach the cap → complete anyway + notice.
+        markers.record_review_pass(tmp_path, "sha1")
+        markers.record_review_pass(tmp_path, "sha2")
+        assert (
+            _gate_review_ran(
+                ProjectConfig(),
+                tmp_path,
+                "newhead",
+                skip_review=False,
+                session_type="implementation",
+            )
+            is True
+        )
+        text = _captured_text(capsys)
+        assert "safety limit reached (2 of 2)" in text
+        assert "not re-reviewed" in text.lower()
+        assert "--skip-review" in text
+
+    def test_exact_sha_fast_path_wins_over_cap(self, tmp_path: Path) -> None:
+        # An exact-sha reviewed marker passes on the first try regardless of count.
+        markers.write_marker(tmp_path, "reviewed", "head")
+        assert (
+            _gate_review_ran(
+                ProjectConfig(), tmp_path, "head", skip_review=False, session_type="implementation"
+            )
+            is True
+        )
+
+    def test_custom_max_review_passes_honored(self, tmp_path: Path) -> None:
+        config = ProjectConfig(done=DoneConfig(max_review_passes=3))
+        markers.record_review_pass(tmp_path, "sha1")
+        markers.record_review_pass(tmp_path, "sha2")
+        # 2 passes < limit 3 → still refuses.
+        assert (
+            _gate_review_ran(
+                config, tmp_path, "newhead", skip_review=False, session_type="implementation"
+            )
+            is False
+        )
+        markers.record_review_pass(tmp_path, "sha3")
+        # 3 passes == limit 3 → passes.
+        assert (
+            _gate_review_ran(
+                config, tmp_path, "newhead", skip_review=False, session_type="implementation"
+            )
+            is True
+        )
+
+    def test_fail_safe_count_never_false_caps(self, tmp_path: Path) -> None:
+        # A `.wade` that is a regular file makes the listing fail → count 0 →
+        # refuse (never a false "cap reached").
+        (tmp_path / ".wade").write_text("")
+        assert (
+            _gate_review_ran(
+                ProjectConfig(), tmp_path, "head", skip_review=False, session_type="implementation"
+            )
+            is False
+        )
+
+    def test_review_pr_comments_path_never_caps(self, tmp_path: Path) -> None:
+        # Even with passes >= limit, the review-pr-comments path keeps the
+        # unbounded fast-path-or-refuse behavior — the cap is impl-only.
+        markers.record_review_pass(tmp_path, "sha1")
+        markers.record_review_pass(tmp_path, "sha2")
+        assert (
+            _gate_review_ran(
+                ProjectConfig(),
+                tmp_path,
+                "newhead",
+                skip_review=False,
+                session_type="review-pr-comments",
+            )
+            is False
+        )
+
+
 # ---------------------------------------------------------------------------
 # review-thread gate (review-pr-comments sessions)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services/test_done_gates.py
+++ b/tests/unit/test_services/test_done_gates.py
@@ -119,7 +119,8 @@ def _captured_text(capsys) -> str:
 
 
 class TestReviewRanCap:
-    """The code-enforced 2-pass cap on the implementation path (#384)."""
+    """The code-enforced review-pass cap (``done.max_review_passes``, default 2) on
+    the implementation path (#384)."""
 
     def test_refuses_before_cap_with_pass_count(self, tmp_path: Path, capsys) -> None:
         # One prior pass, no exact-sha marker, limit 2 → refuse "pass 1 of 2".

--- a/tests/unit/test_services/test_reviewed_marker.py
+++ b/tests/unit/test_services/test_reviewed_marker.py
@@ -94,3 +94,61 @@ class TestReviewImplementationWritesMarker:
         ):
             rds.review_implementation()
         mock_mark.assert_not_called()
+
+
+class TestRecordReviewPass:
+    """The review-pass cap marker (#384): counts delegation-backed passes."""
+
+    def test_writes_review_pass_for_head(self, tmp_path: Path, monkeypatch) -> None:
+        repo = tmp_path / "r"
+        _repo(repo)
+        monkeypatch.chdir(repo)
+        rds._record_review_pass()
+        assert markers.marker_present(repo, "review-pass", _head(repo))
+        assert markers.count_review_passes(repo) == 1
+
+    def test_success_path_records_pass(self, tmp_path: Path) -> None:
+        success = DelegationResult(success=True, feedback="ok", mode=DelegationMode.PROMPT)
+        with (
+            patch.object(rds.git_repo, "get_repo_root", return_value=tmp_path),
+            patch.object(rds.git_repo, "diff_worktree", return_value="diff --git a b"),
+            patch.object(rds, "_run_review_delegation", return_value=success),
+            patch.object(rds, "_record_review_pass") as mock_pass,
+        ):
+            rds.review_implementation()
+        mock_pass.assert_called_once()
+
+    def test_headless_timeout_still_records_pass(self, tmp_path: Path) -> None:
+        # A headless timeout exits non-zero (success=False) and writes NO
+        # `reviewed` marker — but it still consumed a review→fix cycle, so the
+        # pass MUST be recorded (this is what breaks the infinite loop).
+        failure = DelegationResult(
+            success=False,
+            feedback="Headless session timed out",
+            mode=DelegationMode.HEADLESS,
+            exit_code=1,
+        )
+        with (
+            patch.object(rds.git_repo, "get_repo_root", return_value=tmp_path),
+            patch.object(rds.git_repo, "diff_worktree", return_value="diff --git a b"),
+            patch.object(rds, "_run_review_delegation", return_value=failure),
+            patch.object(rds, "_record_review_pass") as mock_pass,
+            patch.object(rds, "_mark_reviewed") as mock_mark,
+        ):
+            rds.review_implementation()
+        mock_pass.assert_called_once()
+        mock_mark.assert_not_called()
+
+    def test_no_diff_path_does_not_record_pass(self, tmp_path: Path) -> None:
+        # The no-diff early return writes the exact-sha `reviewed` marker (which
+        # already satisfies the gate) but must NOT consume a cap slot.
+        with (
+            patch.object(rds.git_repo, "get_repo_root", return_value=tmp_path),
+            patch.object(rds.git_repo, "diff_worktree", return_value=""),
+            patch.object(rds, "_committed_diff_fallback", return_value=""),
+            patch.object(rds, "_mark_reviewed"),
+            patch.object(rds, "_record_review_pass") as mock_pass,
+        ):
+            result = rds.review_implementation()
+        assert result.skipped is True
+        mock_pass.assert_not_called()

--- a/tests/unit/test_services/test_reviewed_marker.py
+++ b/tests/unit/test_services/test_reviewed_marker.py
@@ -33,6 +33,12 @@ def _head(root: Path) -> str:
     ).stdout.strip()
 
 
+def _cap(capsys) -> str:
+    """Combined stdout+stderr with whitespace collapsed (``info``→out, ``warn``→err)."""
+    captured = capsys.readouterr()
+    return " ".join((captured.out + "\n" + captured.err).split())
+
+
 class TestMarkReviewed:
     def test_writes_marker_for_head(self, tmp_path: Path, monkeypatch) -> None:
         repo = tmp_path / "r"
@@ -107,6 +113,18 @@ class TestRecordReviewPass:
         assert markers.marker_present(repo, "review-pass", _head(repo))
         assert markers.count_review_passes(repo) == 1
 
+    def test_returns_resulting_count_and_is_idempotent(self, tmp_path: Path, monkeypatch) -> None:
+        repo = tmp_path / "r"
+        _repo(repo)
+        monkeypatch.chdir(repo)
+        assert rds._record_review_pass() == 1
+        # Same HEAD → idempotent, so the returned count does not inflate.
+        assert rds._record_review_pass() == 1
+
+    def test_returns_none_on_git_failure(self, tmp_path: Path) -> None:
+        with patch.object(rds.git_repo, "get_repo_root", side_effect=rds.GitError("boom")):
+            assert rds._record_review_pass() is None
+
     def test_success_path_records_pass(self, tmp_path: Path) -> None:
         success = DelegationResult(success=True, feedback="ok", mode=DelegationMode.PROMPT)
         with (
@@ -152,3 +170,51 @@ class TestRecordReviewPass:
             result = rds.review_implementation()
         assert result.skipped is True
         mock_pass.assert_not_called()
+
+
+class TestAnnounceReviewPassBudget:
+    """`wade review implementation` surfaces the running review-pass budget (#384)."""
+
+    def test_remaining_budget_message(self, capsys) -> None:
+        rds._announce_review_pass_budget(1, 2)
+        text = _cap(capsys).lower()
+        assert "review pass 1 of 2" in text
+        assert "1 pass left" in text
+        assert "done.max_review_passes" in text
+
+    def test_plural_passes_left(self, capsys) -> None:
+        rds._announce_review_pass_budget(1, 3)
+        assert "2 passes left" in _cap(capsys).lower()
+
+    def test_cap_reached_message(self, capsys) -> None:
+        rds._announce_review_pass_budget(2, 2)
+        text = _cap(capsys).lower()
+        assert "review pass 2 of 2" in text
+        assert "reached" in text
+
+    def test_review_implementation_forwards_the_count(self, tmp_path: Path) -> None:
+        # The command wires the recorded count into the budget announcement.
+        success = DelegationResult(success=True, feedback="ok", mode=DelegationMode.PROMPT)
+        with (
+            patch.object(rds.git_repo, "get_repo_root", return_value=tmp_path),
+            patch.object(rds.git_repo, "diff_worktree", return_value="diff --git a b"),
+            patch.object(rds, "_run_review_delegation", return_value=success),
+            patch.object(rds, "_record_review_pass", return_value=2),
+            patch.object(rds, "_announce_review_pass_budget") as mock_announce,
+        ):
+            rds.review_implementation()
+        mock_announce.assert_called_once()
+        assert mock_announce.call_args.args[0] == 2  # the recorded pass count
+
+    def test_no_announce_when_pass_not_recorded(self, tmp_path: Path) -> None:
+        # A git failure yields no count → nothing to announce (no crash).
+        success = DelegationResult(success=True, feedback="ok", mode=DelegationMode.PROMPT)
+        with (
+            patch.object(rds.git_repo, "get_repo_root", return_value=tmp_path),
+            patch.object(rds.git_repo, "diff_worktree", return_value="diff --git a b"),
+            patch.object(rds, "_run_review_delegation", return_value=success),
+            patch.object(rds, "_record_review_pass", return_value=None),
+            patch.object(rds, "_announce_review_pass_budget") as mock_announce,
+        ):
+            rds.review_implementation()
+        mock_announce.assert_not_called()

--- a/tests/unit/test_utils/test_markers.py
+++ b/tests/unit/test_utils/test_markers.py
@@ -56,6 +56,52 @@ class TestShaKeyedMarkers:
         )
 
 
+class TestReviewPassMarkers:
+    """Review-pass counting for the implementation-session done cap (#384)."""
+
+    def test_record_then_count(self, tmp_path: Path) -> None:
+        assert markers.record_review_pass(tmp_path, _SHA_A) is True
+        assert markers.count_review_passes(tmp_path) == 1
+        assert (tmp_path / ".wade" / f"review-pass@{_SHA_A}").is_file()
+
+    def test_distinct_shas_accumulate(self, tmp_path: Path) -> None:
+        # Unlike write_marker, recording a new sha does NOT clear the prior one —
+        # each review→fix→new-commit cycle adds a distinct marker.
+        markers.record_review_pass(tmp_path, _SHA_A)
+        markers.record_review_pass(tmp_path, _SHA_B)
+        assert markers.count_review_passes(tmp_path) == 2
+        assert markers.marker_present(tmp_path, "review-pass", _SHA_A) is True
+        assert markers.marker_present(tmp_path, "review-pass", _SHA_B) is True
+
+    def test_same_sha_is_idempotent(self, tmp_path: Path) -> None:
+        # Two reviews of the SAME HEAD count as one pass (per-sha filename).
+        markers.record_review_pass(tmp_path, _SHA_A)
+        markers.record_review_pass(tmp_path, _SHA_A)
+        assert markers.count_review_passes(tmp_path) == 1
+
+    def test_count_zero_when_no_markers(self, tmp_path: Path) -> None:
+        assert markers.count_review_passes(tmp_path) == 0
+
+    def test_count_zero_when_listing_fails(self, tmp_path: Path) -> None:
+        # A `.wade` that is a regular file (not a dir) makes both the dir-fd and
+        # the iterdir fallback raise → fail-safe 0, never a false "cap reached".
+        (tmp_path / ".wade").write_text("")
+        assert markers.count_review_passes(tmp_path) == 0
+
+    def test_writing_reviewed_marker_does_not_clear_passes(self, tmp_path: Path) -> None:
+        # The `reviewed` clear-prior-same-name cleanup must not touch the
+        # distinct `review-pass@*` family.
+        markers.record_review_pass(tmp_path, _SHA_A)
+        markers.write_marker(tmp_path, "reviewed", _SHA_B)
+        assert markers.count_review_passes(tmp_path) == 1
+
+    def test_count_ignores_temp_files(self, tmp_path: Path) -> None:
+        markers.record_review_pass(tmp_path, _SHA_A)
+        # A leftover scratch file from a partial write must not be counted.
+        (tmp_path / ".wade" / f"review-pass@{_SHA_B}.tmp").write_text("")
+        assert markers.count_review_passes(tmp_path) == 1
+
+
 class TestSymlinkSafety:
     def test_symlinked_marker_not_trusted(self, tmp_path: Path) -> None:
         # A planted symlink at the marker path must not read as present.


### PR DESCRIPTION
Closes #384

<!-- wade:plan:start -->

## Complexity
complex

## Context / Problem

During an implementation session an agent can get stuck in an infinite review
loop: `wade review implementation` reports findings, the agent fixes them and
commits, then `wade implementation-session done` refuses to complete — telling
the agent to review again — and the cycle repeats without end.

The "run review at most 2 times" rule that is supposed to stop this **exists
today only as prose** in `templates/skills/_partials/review-implementation-closing-step.md:22-28`
(and mirrored in project knowledge `cedeaad0`). Nothing in Python counts review
passes or bounds the loop.

Two concrete mechanics produce the stuck state:

1. **Commit-after-review (by design, but unbounded).** The review writes a
   SHA-keyed marker `.wade/reviewed@<sha>` (`_mark_reviewed`,
   `src/wade/services/review_delegation_service.py:29-44`). The completion gate
   `_gate_review_ran` (`src/wade/services/implementation_service/done.py:375-400`)
   refuses unless a marker exists for the current branch tip
   (`head_sha` = `pre_sync_head`, captured at `done.py:244-248`). Any commit the
   agent makes *after* its last review moves the tip SHA and invalidates the
   marker → "new commits require a fresh review" (`done.py:391-399`) → the agent
   re-reviews, commits again, and loops. Re-reviewing new commits is intended;
   the missing piece is a cap on how many times it can repeat.

2. **Headless review silently drops the marker.** `_mark_reviewed()` is called
   only when `result.success` is true (`review_delegation_service.py:300-301`).
   In headless mode — this repo's config (`.wade.yml:29` `mode: headless`) —
   `success` is just the subprocess exit code
   (`src/wade/services/delegation_service.py:130-144`). A ~300s timeout on a
   large diff exits non-zero (confirmed by knowledge `271cf18f`), so the review
   *ran and produced findings* but **no marker is written**, and `done` then
   refuses forever even though the human/agent saw a completed review.

`--skip-review` already exists on `done`
(`src/wade/cli/implementation_session.py:114-116`, consumed at `done.py:389`) as
a full manual bypass, but relying on the agent to remember a flag is fragile and
skips review entirely rather than bounding it.

## Proposed Solution

Move the 2-pass cap out of skill prose and into the completion gate, so the loop
is bounded in code while re-review of new commits is preserved.

1. **Review-pass count via a per-SHA `review-pass@<sha>` marker family.** Do not
   invent an integer counter file — reuse the existing `markers.py` primitives.
   On every **delegation-backed** review run, write a `review-pass@<HEAD>` marker
   (a distinct name from `reviewed`, so `write_marker`'s clear-prior-same-name
   cleanup does not touch it). The "pass count" is then simply *the number of
   distinct SHAs that carry a `review-pass@*` marker* — count matching filenames,
   defaulting to `0` if the directory listing fails. This design:
   - is **independent of `result.success`** (a headless timeout still writes the
     marker), sidestepping the marker-drop mechanic without certifying an
     unfinished review;
   - is naturally **fail-safe** — there is no numeric content to corrupt, and a
     listdir failure yields `0`, never a false "cap reached";
   - is naturally **idempotent per SHA** — this closes a retry loophole: a plain
     counter would count *retries on the same unchanged commit* (e.g. re-running a
     timed-out review twice on the same HEAD would exhaust a cap of 2 with zero
     real review→fix cycles). Keying to distinct SHAs makes same-commit retries
     free and only spends budget on genuine review→fix→new-commit cycles, which is
     what the cap is meant to bound;
   - requires **no reset logic and no `bootstrap_worktree` change** — markers
     persist naturally across `wade implement` re-runs; just ensure bootstrap does
     not clear `review-pass@*`.

2. **Bounded completion gate.** Rewrite `_gate_review_ran`
   (`src/wade/services/implementation_service/done.py:375-400`) to:
   - **Fast path (unchanged):** if `marker_present(worktree_root, "reviewed",
     head_sha)` → pass. A review for the exact current commit still means done.
   - **Bounded escape (new, implementation session only):** else if review-pass
     count ≥ `max_review_passes` (default 2) → **pass**, printing a prominent
     notice that the 2-pass safety limit was hit, the latest commit(s) were not
     re-reviewed, and completion is being allowed anyway (mention `--skip-review`
     for an explicit full bypass).
   - **Refuse (improved):** else → refuse as today, but the message must state
     "review pass X of N used" and point the agent at both re-running review and
     `wade implementation-session done --skip-review`.
   - **Fail-closed count:** the pass-count is derived from counting `review-pass@*`
     markers; a listing failure yields `0` (never a false "cap reached"),
     consistent with `markers.py`'s best-effort "fail toward re-gating" convention.

3. **Make the cap configurable, bounded at both boundaries.** Add
   `max_review_passes` (default `2`) to `DoneConfig`
   (`src/wade/models/config.py:159-182`) with a **Pydantic constraint**
   (`PositiveInt` or `Field(gt=0)`) so a bad `.wade.yml` value
   (`done.max_review_passes: 0` / `-1`) fails loudly *at load*, not just at
   `wade check`. Parse it in `src/wade/config/loader.py:267-279` with its **own**
   branch — do **not** reuse `_done_flag` (`loader.py:269-273`), which assumes a
   bool default; read `done_raw.get("max_review_passes", 2)` and normalize an
   explicit `null` to `2`. The `wade check` validator (item 7) adds the second,
   lint-boundary guard.

4. **No reset logic required.** Because the count is the number of distinct
   `review-pass@<sha>` markers (item 1), it persists naturally across
   `wade implement` re-runs and needs no `bootstrap_worktree` involvement — which
   is important, since `bootstrap_worktree` runs on *every* invocation, including
   the idempotent worktree-reuse path (`implementation_service/core.py:433` →
   `bootstrap_worktree` at `:492`) and the review re-bootstrap
   (`review_service.py:683`); anything it touched would have to be idempotent
   anyway. Add a test that the count **survives** a second `wade implement`
   invocation on the same worktree.

5. **Correctly scope the cap to the implementation session.** `_gate_review_ran`
   is **shared** — `_run_completion_gates` calls it on *both* the
   `review-pr-comments` path and the implementation path
   (`done.py:321-331`), and `done()` is one service for both session types
   (knowledge `851bb6ec`). Adding counter/cap logic directly inside
   `_gate_review_ran` would therefore change `review-pr-comments-session done`
   too. **Fix:** thread `session_type` (or an explicit bool) into
   `_gate_review_ran` and apply the counter/cap branch only on the implementation
   path; leave `review-pr-comments` on the existing fast-path-or-refuse behavior.

6. **Do not consume a cap slot on the no-diff early return.** `review_implementation`
   already calls `_mark_reviewed()` on its "no changes to review" path
   (`review_delegation_service.py:274`) without going through delegation. That
   path writes the exact-SHA marker (which already satisfies the gate fast path),
   so it must **not** write a `review-pass@<sha>` marker — only a
   delegation-backed review run consumes a cap slot.

7. **Update the `wade check` done validator.** `_validate_done_section`
   (`src/wade/services/check_service.py:657-670`) hard-codes bool-only validation
   (`if not isinstance(value, bool): "must be true or false"`). `_VALID_DONE_KEYS`
   (`check_service.py:266`) auto-picks up the new field so it won't be flagged as
   "unsupported", but any int value (`done.max_review_passes: 3`) will fail
   `wade check`. Special-case `max_review_passes`: accept a positive int, reject
   bool / zero / negative with a clear message.

8. **Sync the skill prose.** Update
   `templates/skills/_partials/review-implementation-closing-step.md:22-28` so it
   states the 2-pass cap is now enforced in code, and tell the agent that a
   genuine unavoidable loop can be broken with
   `wade implementation-session done --skip-review`. Keep the existing exit-code
   guidance (0/1/2) intact. (No renumbering of `## Your role` steps is required —
   only body text of the partial changes.)

**Non-goals:**
- **`review-pr-comments-session` is intentionally out of scope.** The same two
  root-cause mechanics apply to `_gate_review_ran` on that path, but the bug
  report is scoped to implementation sessions and that gate is shared. This change
  caps the implementation path only; `review-pr-comments-session done` can still
  loop and is tracked separately.
- Not changing the `reviewed@<sha>` marker semantics, not altering headless
  success/exit-code handling in `delegation_service`, and not touching the
  `done@<sha>` marker used by the Stop hook / pre-push backstop.

## Tasks
- [ ] Add a helper (in/near `src/wade/utils/markers.py`) that counts distinct
      `review-pass@*` markers, reusing existing marker primitives; a directory
      listing failure returns `0` (fail-safe). Use a name distinct from `reviewed`
      so `write_marker`'s clear-prior-same-name cleanup does not remove it.
- [ ] Write a `review-pass@<HEAD>` marker in `review_implementation`
      (`src/wade/services/review_delegation_service.py`) whenever the **delegation**
      runs, independent of `result.success`. Do **not** write it on the "no
      changes to review" early-return path (`:274`) — it already writes the
      exact-SHA `reviewed` marker and must not consume a cap slot. (Per-SHA writes
      are idempotent, so same-commit retries do not inflate the count.)
- [ ] Add `max_review_passes` (default `2`) to `DoneConfig`
      (`src/wade/models/config.py`) with a Pydantic bound (`PositiveInt` /
      `Field(gt=0)`), and parse it in `src/wade/config/loader.py` with its **own**
      null-handling branch (not `_done_flag`, which is bool-only).
- [ ] Special-case `max_review_passes` in `_validate_done_section`
      (`src/wade/services/check_service.py:657-670`): accept a positive int, reject
      bool / zero / negative, so `wade check` does not fail on
      `done.max_review_passes: 3`.
- [ ] Thread `session_type` (or a bool) into `_gate_review_ran`
      (`done.py:375-400`, both call sites at `done.py:321-331`) and apply the
      fast-path / bounded-escape / improved-refuse logic **only on the
      implementation path**; keep `review-pr-comments` on the existing
      fast-path-or-refuse behavior. Preserve the `skip_review`, `require_review`,
      and `review_implementation.enabled` short-circuits.
- [ ] Confirm `bootstrap_worktree` does **not** clear `review-pass@*` markers
      (it re-runs on the idempotent `wade implement` path, `core.py:433/492`, and
      review re-bootstrap, `review_service.py:683`); the marker family needs no
      dedicated reset logic.
- [ ] Update `templates/skills/_partials/review-implementation-closing-step.md`
      prose to reflect the code-enforced cap and mention `--skip-review` as the
      loop escape.
- [ ] Unit tests: a `review-pass@<sha>` marker is written on a delegation-backed
      review run incl. the headless-timeout (`result.success=False`) path; no marker
      on the no-diff early return; **two reviews on the same HEAD sha count as one
      pass** (idempotent per-SHA); count is `0` when the marker-dir listing fails
      (fail-safe); **count survives a second `wade implement` invocation on the same
      worktree**; gate passes on exact-SHA `reviewed` marker; gate passes after N
      passes with the notice; gate refuses before N with the "pass X of N" message;
      `max_review_passes` config override honored and a `<= 0` value is rejected at
      load (Pydantic) and by `wade check`; **`review-pr-comments-session done` path
      unaffected by the cap**.
- [ ] Deterministic E2E contract test: review → commit → `done` refuses → review
      again → commit → `done` **succeeds** on the 2nd pass instead of looping.
- [ ] Run `./scripts/check-all.sh` (tests + lint + strict mypy) and fix any
      findings.
- [ ] Update `README.md` if the user-facing `done`/`--skip-review` behavior is
      documented there; update `AGENTS.md`/`docs/dev/` only if the gate contract
      changed materially. Consider correcting/refreshing knowledge `851bb6ec` if
      the `_gate_review_ran` sharing detail proves worth recording.

## Acceptance Criteria
- [ ] A commit made after the last review no longer produces an unbounded loop:
      after at most `max_review_passes` (default 2) runs of
      `wade review implementation`, `wade implementation-session done` completes
      instead of refusing.
- [ ] When the cap is reached, `done` prints a clear notice that the 2-pass limit
      was hit, the latest commit(s) were not re-reviewed, and that `--skip-review`
      is the explicit full-bypass.
- [ ] Before the cap, the refuse message states the current pass number out of the
      limit and points the agent at re-running review and at `--skip-review`.
- [ ] A headless review that exits non-zero (e.g. timeout) still counts toward the
      cap, so it cannot cause an infinite loop even though no `reviewed@<sha>`
      marker is written.
- [ ] The existing exact-SHA fast path is unchanged: a review for the current
      commit lets `done` proceed on the first pass.
- [ ] `done.max_review_passes` in `.wade.yml` overrides the default; omitting it
      keeps the default of 2. Setting `done.require_review: false` or
      `ai.review_implementation.enabled: false` still bypasses the gate as today.
- [ ] A `done.max_review_passes` of `0` / negative is rejected both at config load
      (Pydantic) and by `wade check`; a positive int is accepted.
- [ ] Re-running `wade review implementation` on the **same** HEAD sha does not
      advance the pass count (per-SHA markers are idempotent); only a new commit's
      review consumes a slot.
- [ ] The pass count (number of distinct `review-pass@<sha>` markers) **survives** a
      second `wade implement` invocation (and a review re-bootstrap) on the same
      worktree rather than resetting to 0.
- [ ] A failure to list the marker directory yields pass-count 0 (fail-safe), never
      a false "cap already reached".
- [ ] `review-pr-comments-session done` behavior is unchanged (the cap applies to
      the implementation path only).
- [ ] The `review-implementation-closing-step.md` skill partial documents the
      code-enforced cap and the `--skip-review` escape.
- [ ] `./scripts/check-all.sh` passes (tests, lint, strict mypy), including the
      new unit tests and the E2E loop-escape contract test.

<!-- wade:plan:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable implementation review-pass limit, defaulting to two.
  - Review progress persists across reruns, with safe handling for interrupted reviews.
  - Review-comment sessions remain uncapped.
  - Temporary-directory writes are allowed during regular execution, but not plan mode.
  - Increased the default delegation timeout to 600 seconds.

- **Bug Fixes**
  - Prevented indefinite review-and-fix cycles.
  - Invalid review-pass limits are rejected.

- **Documentation**
  - Updated configuration, review guidance, timeout handling, and recovery instructions.

- **Tests**
  - Added coverage for limits, persistence, validation, retries, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:summary:start -->

## Summary

## What was done

Bounds the implementation-session review→fix→re-review loop with a **code-enforced
2-pass cap**. Previously the "run review at most 2 times" rule existed only as
skill prose, so an agent could loop forever: `wade review implementation` reports
findings → agent commits a fix → `wade implementation-session done` refuses (the
new commit invalidates the SHA-keyed `reviewed@<sha>` marker) → repeat. A headless
review that times out (exit non-zero) made it worse — it produced findings but
wrote no marker, so `done` refused indefinitely. The cap now lives in the
completion gate: after `done.max_review_passes` (default 2) genuinely-new commits
have been reviewed, `done` completes with a notice instead of looping, while
re-review of new commits is still preserved.

## Changes

- **`utils/markers.py`** — new `review-pass@<sha>` marker family (distinct name
  from `reviewed`, so `write_marker`'s clear-prior-same-name cleanup never touches
  it). `record_review_pass()` writes it **without** clearing prior markers;
  `count_review_passes()` returns the number of distinct `review-pass@*` markers,
  fail-safe to `0` on any directory-listing failure (never a false "cap reached").
- **`services/review_delegation_service.py`** — `review_implementation` records a
  `review-pass@<HEAD>` marker on every delegation-backed run, **independent of
  `result.success`** (a headless timeout still counts), so the loop can't be
  infinite. Not recorded on the no-diff early return (which already writes the
  exact-SHA `reviewed` marker and must not spend a cap slot). Per-SHA writes are
  idempotent, so re-reviewing the same HEAD does not advance the count.
- **`services/implementation_service/done.py`** — `_gate_review_ran` now takes
  `session_type`. On the implementation path: exact-SHA fast path unchanged →
  else bounded escape at `>= max_review_passes` (prominent notice, mentions
  `--skip-review`) → else refuse with "review pass X of N" and pointers to
  re-running review and `--skip-review`. The shared `review-pr-comments` path keeps
  the existing unbounded fast-path-or-refuse behavior (cap is impl-only, #384 scope).
- **`models/config.py` + `config/loader.py`** — `DoneConfig.max_review_passes:
  StrictInt = Field(default=2, gt=0)` — a `0`/negative **or non-int** value
  (`true`/`"2"`/`2.0`) fails loudly at load (strict, not coerced), parsed with its
  own null-handling branch (not the bool-only `_done_flag`).
- **`services/check_service.py`** — `wade check` special-cases `max_review_passes`
  (accepts a positive int; rejects bool / zero / negative).
- **Skill + docs** — `_partials/review-implementation-closing-step.md` now states
  the cap is code-enforced and points at `--skip-review` as the loop escape (kept
  under the session-start char budget). README completion-gate table and
  `docs/dev/architecture.md` review-ran gate description updated.

## Key technical decisions

- **Count distinct SHAs, not an integer counter.** Reusing the existing marker
  primitives (rather than a counter file) makes the design fail-safe (nothing to
  corrupt; a listdir failure yields 0), idempotent per SHA (same-commit retries are
  free — only real review→fix→new-commit cycles spend a slot), and reset-free
  (markers persist across `wade implement` re-runs, so no `bootstrap_worktree`
  change is needed).
- **Scoped to the implementation session.** `_gate_review_ran` is shared by both
  `done` session types (knowledge 851bb6ec), so the cap branch keys on
  `session_type == "implementation"`; `review-pr-comments-session done` is
  intentionally out of scope and unchanged.

## Testing

- Unit: marker write/count/idempotency/fail-safe; pass recorded on the
  headless-timeout (`success=False`) path and **not** on the no-diff return; gate
  bounded-escape + improved-refuse messages + impl-only scoping; `max_review_passes`
  config load (default/override/null/`<=0` rejected) and `wade check` validation.
- E2E contract: review→commit→`done` **refuses** ("review pass 1 of 2"), then
  review→commit→`done` **succeeds** at the cap ("safety limit reached"); and the
  review-pass count **survives a second `wade implement`** on the same worktree.
- `./scripts/check-all.sh` green — 2796 unit/integration tests pass, ruff clean,
  strict mypy clean; deterministic E2E suite passes (69/69).

## Notes for reviewers

- The exact-SHA fast path and the `--skip-review` / `done.require_review: false` /
  `ai.review_implementation.enabled: false` short-circuits are all preserved.
- The `implement` session-start skill payload is budget-pinned at 8000 chars; the
  closing-step partial's re-review guidance was kept net-neutral (47 chars of
  headroom, unchanged by this review round), so no budget bump was needed.

## Review round (PR #385 — CodeRabbit)

6 threads across 5 files; 5 fixed, 1 declined with a posted reply. All resolved.

**Fixed**

- **Strict `done.max_review_passes` at load** (`config.py`, `loader.py`): the
  `PositiveInt` bound coerced `true`→1, `"2"`→2, `2.0`→2, so normal load silently
  accepted values `wade check` rejects. Now `StrictInt` + `gt=0` rejects them at
  `DoneConfig` construction (→ `ConfigError`). Added loader tests for `true` /
  `"2"` / `2.0`.
- **`count_review_passes` fails closed** (`markers.py`): the path-based `iterdir()`
  fallback followed a symlinked `.wade`, letting a crafted worktree plant
  `review-pass@*` entries to satisfy the cap. Removed the fallback — returns `0`
  when no descriptor-based directory read is available.
- **Re-review after committing any finding** (`review-implementation-closing-step.md`):
  "Minor findings: fix and proceed" was wrong — committing a fix stales the
  exact-sha `reviewed` marker and `done` refuses at pass 1 of 2. Now instructs
  commit + re-review; major-finding flow, cap, and escape hatch preserved.
- **Exact-sha precedence under an exhausted cap** (`test_done_gates.py`): the test
  now records the cap's worth of `review-pass` markers before `reviewed@head` and
  asserts no safety-limit notice, proving the fast path precedes the cap.

**Declined (reply posted on thread)**

- **"Scope review-pass markers per session / clear at fresh `wade implement`
  start."** The count is deliberately worktree-persistent (pinned by
  `test_review_pass_count_survives_second_implement`). Clearing on a fresh
  `implement` would make the cap trivially resettable — re-running `implement`
  would zero it and reinstate the unbounded loop #384 exists to stop. A worktree
  is bound 1:1 to a branch/issue (re-running `implement` is the same task; a
  recreated worktree starts with a fresh `.wade/`), so there is no cross-branch
  counter to scope; the fail-closed fix above covers the symlink-tampering angle.

## Follow-up: friendlier headless defaults (same PR)

Two default changes so headless review/deps stop tripping over infra limits
(the trigger: the review subprocess timed out at 300s while addressing this PR):

- **Default headless subprocess timeout 300s → 600s** (`DelegationRequest.timeout`,
  `models/delegation.py`). Applies to every wade project; per-command
  `ai.<cmd>.timeout` still overrides. A 300s budget killed a high-effort review
  over a large diff mid-run (an infra timeout, not a review result), which wrote
  no `reviewed` marker and stalled `done`.
- **Shell write guard allows system temp dirs** (`hooks/policies.py`). `/tmp` and
  `$TMPDIR` (resolved; trailing separator so `/tmpfoo` can't match `/tmp`) join
  `_ALWAYS_ALLOWED_PATH_PREFIXES`, so agents/wade can stage scratch files there.
  **Scoped to `shell_containment`** — the file-path guard `worktree_containment`
  stays worktree-only (it backs `plan_artifact_only`, where an artifact-named temp
  path such as `/tmp/.claude/plans/x.md` must not escape), and plan mode still
  denies temp writes as non-artifacts.

Docs (`architecture.md`) and the closing-step budget note updated; the
`shell_containment` tests moved their "outside" archetype to `/etc` and added
temp-allowed cases.

## Review round 2 (PR #385 — CodeRabbit)

2 threads across 2 files; both fixed and resolved.

**Fixed**

- **Describe the review-pass cap as configurable, not a hardcoded 2**
  (`markers.py`, `test_done_gates.py`, `review-implementation-closing-step.md`,
  `architecture.md`): `done.max_review_passes` is configurable (default 2), so
  the docstrings, test-class docstring, closing-step template header, and
  architecture gate description now describe the *configured* cap
  (`done.max_review_passes`, default 2) rather than a fixed "2-pass cap". For
  consistency I also dropped the hardcoded "2-pass" phrasing from the remaining
  internal comments (`done.py`, `review_delegation_service.py`) that the reviewer
  didn't list but describe the same cap. The plan-session review loop
  (`review-plan-step.md`, "run at most 2 times") is a separate, genuinely fixed
  constraint and was intentionally left unchanged.
- **Quote the temp-dir redirect target in the shell-containment test**
  (`test_policies.py`): `tempfile.gettempdir()` can return a path with
  whitespace or shell metacharacters, so the unquoted redirect could target a
  different path and pass for the wrong reason. Added `import shlex` and wrapped
  the target in `shlex.quote()`.

**Follow-up — surface the review-pass budget (from the closing `wade review
implementation` self-review)**

The self-review flagged that the cap is enforced silently at `done` time and its
`done`-time notice implied an unbounded loop even when the cap was simply reached
by reviewing distinct commits, while the "run at most N times" rule lived only in
buried skill prose. Rather than re-engineer the count (a reset-on-clean-review
scheme can't be built on the current markers without reintroducing the unbounded
loop, and round 1 already declined a resettable count as gameable), the fix makes
the existing count **visible**:

- `wade review implementation` now prints the running budget after each pass
  (`"review pass N of M — K left"`, or a cap-reached warning) — the count comes
  from the command itself, not buried prose. (`review_delegation_service.py`:
  `_record_review_pass` returns the count; new `_announce_review_pass_budget`.)
- The `done`-time notice now states the honest semantics (N commits reviewed on
  this worktree; current commit not re-reviewed) instead of always implying a
  loop, and points at both `done.max_review_passes` and `--skip-review`.
  (`done.py`.)
- Closing-step skill and `architecture.md` point at the command output instead of
  a hardcoded "run at most N times" rule.
- The count stays cumulative and configurable via `done.max_review_passes`
  (already `StrictInt`, `gt=0`, default 2); counting logic is unchanged. New tests
  in `test_reviewed_marker.py` cover the budget message (remaining/plural/reached)
  and the command wiring.

<!-- wade:summary:end -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **231,400** |
| Input tokens | **230,100** |
| Output tokens | **1,300** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **314,168** |
| Input tokens | **313,200** |
| Output tokens | **968** |

### Session 2

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **209,602** |
| Input tokens | **209,600** |
| Output tokens | **2** |
| Cached tokens | **0** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `1b9dcc11-182c-49d9-8bbd-0f816943ca3e` |
| Review | `claude` | `a59ed06b-c68a-4f7c-b29f-821c887bdd8e` |
| Review | `claude` | `434ee082-6462-4652-8d08-2d68cffaeabd` |

<!-- wade:sessions:end -->
