### PR TITLE
wade review crashes with Rich MarkupError when reviewer feedback contains bracket markup

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -399,3 +399,9 @@ is_head_attached(path) returns False for BOTH a detached HEAD and a non-git-repo
 Under git merge=union, an IDENTICAL add/add of a file (same blob on both branches) resolves cleanly to ONE copy (git dedups identical blobs, no conflict), but a DIVERGENT add/add concatenates both sides' full content. So #358's .ratings.yml->.jsonl migration seed is byte-deterministic (json.dumps sort_keys, no ts) AND read_ratings folds seeds idempotently per entry-id (knowledge_service._fold_jsonl_ratings tracks a 'seeded' set) — belt-and-suspenders, because if two branches also add distinct vote lines the seed block is no longer an identical add/add and union would otherwise double-count it.
 
 ---
+
+## 66c7e8b329cc | 2026-08-08 | implementation | tags: console, error-handling, rich | Issue #394
+
+Never print untrusted AI/delegation output through Rich with markup enabled: `console.out.print(text)` and `console.error(text)` (which wraps its message in `[error]…[/]`) both parse bracketed tokens like `[/]` as markup and raise `MarkupError: closing tag has nothing to close` on quoted source code — crashing *after* the work succeeded. Print such text with `markup=False`, or `rich.markup.escape()` it when it must flow through a method that adds its own markup (`console.error`). Latent twin: `Console.plain()` (src/wade/ui/console.py) sets `highlight=False` but leaves `markup=True`, so it shares the same crash (candidate follow-up); fixed sites are `review_delegation_service.py` success+error branches and `deps_service.py` PROMPT passthrough.
+
+---

--- a/src/wade/services/deps_service.py
+++ b/src/wade/services/deps_service.py
@@ -529,7 +529,10 @@ def analyze_deps(
 
     if delegation_mode == DelegationMode.PROMPT:
         if output:
-            console.out.print(output)
+            # AI-generated analysis is untrusted free-form text that can quote
+            # bracketed markup (e.g. `[/]`); print literally with markup
+            # disabled so Rich doesn't raise MarkupError on it (#394).
+            console.out.print(output, markup=False)
             return DependencyGraph()
         console.error("Could not generate dependency analysis prompt.")
         return None

--- a/src/wade/services/review_delegation_service.py
+++ b/src/wade/services/review_delegation_service.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import structlog
 from crossby.models.ai import EffortLevel
+from rich.markup import escape
 
 from wade.config.loader import load_config
 from wade.git import repo as git_repo
@@ -199,9 +200,16 @@ def _run_review_delegation(
 
     result = delegate(request)
     if result.success:
-        console.out.print(result.feedback)
+        # Delegation feedback is untrusted, model-authored text/markdown that
+        # routinely quotes source code (e.g. `console.print("[x]done[/]")`).
+        # Rich would parse `[/]` as a closing tag with nothing to close and
+        # raise MarkupError, so print it literally with markup disabled (#394).
+        console.out.print(result.feedback, markup=False)
     else:
-        console.error(result.feedback)
+        # `console.error` interpolates the message into its own `[error]…[/]`
+        # wrapper, so `markup=False` can't apply here — escape the feedback so
+        # bracketed tokens render literally while the wrapper still styles (#394).
+        console.error(escape(result.feedback))
     return result
 
 

--- a/tests/unit/test_services/test_deps_service.py
+++ b/tests/unit/test_services/test_deps_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from wade.models.config import ProjectConfig, ProjectSettings
 from wade.models.delegation import DelegationMode, DelegationResult
 from wade.models.deps import DependencyEdge, DependencyGraph
@@ -482,13 +484,64 @@ class TestAnalyzeDepsMode:
         result = analyze_deps(["1", "2"], mode="prompt")
         assert result is not None
         assert result.edges == []
-        mock_print.assert_called_once_with("raw prompt text")
+        # markup=False keeps untrusted AI output from being parsed as Rich
+        # markup (bracketed tokens would otherwise crash — #394).
+        mock_print.assert_called_once_with("raw prompt text", markup=False)
         mock_resolve_tool.assert_not_called()
         mock_resolve_model.assert_not_called()
         mock_resolve_effort.assert_not_called()
         mock_confirm.assert_not_called()
         mock_apply.assert_not_called()
         mock_tracking.assert_not_called()
+
+    @patch("wade.services.deps_service.create_tracking_issue")
+    @patch("wade.services.deps_service.apply_deps_to_issues")
+    @patch("wade.services.deps_service.delegate")
+    @patch("wade.services.deps_service.confirm_ai_selection")
+    @patch("wade.services.deps_service.resolve_effort")
+    @patch("wade.services.deps_service.resolve_model")
+    @patch("wade.services.deps_service.resolve_ai_tool")
+    @patch("wade.services.deps_service.get_provider")
+    @patch("wade.services.deps_service.load_config")
+    def test_prompt_mode_output_with_bracket_markup_does_not_raise(
+        self,
+        mock_config: MagicMock,
+        mock_provider: MagicMock,
+        mock_resolve_tool: MagicMock,
+        mock_resolve_model: MagicMock,
+        mock_resolve_effort: MagicMock,
+        mock_confirm: MagicMock,
+        mock_delegate: MagicMock,
+        mock_apply: MagicMock,
+        mock_tracking: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Bracketed markup in PROMPT-mode output prints literally, not crash (#394).
+
+        Uses the real console (no ``console.out.print`` mock) so Rich actually
+        renders the untrusted AI output. The ``[/]`` is *unbalanced* (nothing to
+        open) — with ``markup=True`` this raised ``rich.errors.MarkupError``.
+        """
+        from wade.models.config import AICommandConfig, AIConfig
+
+        mock_config.return_value = ProjectConfig(ai=AIConfig(deps=AICommandConfig(tool="claude")))
+        provider = MagicMock()
+        provider.read_task.side_effect = [
+            Task(id="1", title="Auth", body="Login"),
+            Task(id="2", title="DB", body="Schema"),
+        ]
+        mock_provider.return_value = provider
+        mock_delegate.return_value = DelegationResult(
+            success=True,
+            feedback="analysis: the token result[/] must stay literal",
+            mode=DelegationMode.PROMPT,
+        )
+
+        result = analyze_deps(["1", "2"], mode="prompt")
+
+        assert result is not None
+        assert result.edges == []
+        assert "[/]" in capsys.readouterr().out
 
     @patch("wade.services.deps_service.create_tracking_issue")
     @patch("wade.services.deps_service.apply_deps_to_issues")

--- a/tests/unit/test_services/test_review_delegation_service.py
+++ b/tests/unit/test_services/test_review_delegation_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from crossby.models.ai import EffortLevel
 
 from wade.git.repo import GitError
@@ -608,6 +609,77 @@ class TestRunReviewDelegationEffort:
 
         call_args = mock_delegate.call_args[0][0]
         assert call_args.effort is None
+
+
+# ---------------------------------------------------------------------------
+# Feedback markup safety (#394)
+# ---------------------------------------------------------------------------
+
+
+class TestFeedbackMarkupSafety:
+    """Untrusted delegation feedback with bracketed tokens must not crash Rich.
+
+    Feedback routinely quotes source code containing Rich-markup-like tokens
+    (e.g. ``console.print("[success]done[/]")``). Printing it with markup
+    enabled made Rich parse ``[/]`` as a closing tag with nothing to close and
+    raise ``rich.errors.MarkupError`` — *after* the review had already run,
+    losing the feedback and the ``reviewed@<sha>`` marker.
+    """
+
+    @patch("wade.services.review_delegation_service.delegate")
+    @patch("wade.services.review_delegation_service.load_config")
+    def test_success_feedback_with_bracket_markup_does_not_raise(
+        self,
+        mock_config: MagicMock,
+        mock_delegate: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Success branch prints bracketed feedback literally instead of crashing.
+
+        The ``[/]`` is intentionally *unbalanced* (a close tag with nothing to
+        open) — exactly the quoted-code shape that made old Rich raise
+        ``MarkupError: closing tag '[/]' ... has nothing to close``.
+        """
+        mock_config.return_value = _review_config(review_plan_mode="prompt")
+        mock_delegate.return_value = DelegationResult(
+            success=True,
+            feedback="Nit: the quoted snippet result[/] should stay literal",
+            mode=DelegationMode.PROMPT,
+        )
+
+        result = _run_review_delegation("prompt text", "review_plan")
+
+        assert result.success is True
+        # The literal token survives to stdout — not swallowed as styling, not crashed.
+        assert "[/]" in capsys.readouterr().out
+
+    @patch("wade.services.review_delegation_service.delegate")
+    @patch("wade.services.review_delegation_service.load_config")
+    def test_failure_feedback_with_bracket_markup_does_not_raise(
+        self,
+        mock_config: MagicMock,
+        mock_delegate: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Error branch escapes bracketed feedback so console.error's wrapper still renders.
+
+        The dangling ``[/]`` (nothing to close) is what crashed old Rich; here
+        it must render literally while ``console.error``'s own ``[error]…[/]``
+        styling still applies.
+        """
+        mock_config.return_value = _review_config(review_plan_mode="prompt")
+        mock_delegate.return_value = DelegationResult(
+            success=False,
+            feedback="failed: the token result[/] has nothing to close",
+            mode=DelegationMode.PROMPT,
+            exit_code=1,
+        )
+
+        result = _run_review_delegation("prompt text", "review_plan")
+
+        assert result.success is False
+        # console.error writes to stderr; the escaped token renders literally.
+        assert "[/]" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #394

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

`wade review implementation` (and any review routed through
`_run_review_delegation`) crashes with a Rich `MarkupError` **after the review
has already completed successfully**, whenever the reviewer's feedback contains
Rich-markup-like tokens such as `[/]`. Because the review succeeds but wade dies
while *printing* the result, the feedback is lost and no `reviewed@<sha>` marker
is written — which blocks `wade implementation-session done` unless
`--skip-review` is used.

This is deterministic for any diff whose feedback quotes bracketed markup, which
is idiomatic in many codebases (e.g. `console.print("[success]done[/]")`).

### Root cause

`src/wade/services/review_delegation_service.py:200-204` prints free-form,
untrusted AI feedback through Rich with **markup enabled**:

```python
result = delegate(request)
if result.success:
    console.out.print(result.feedback)   # markup=True on untrusted free-form text
else:
    console.error(result.feedback)
```

`result.feedback` is model-authored text/markdown that routinely quotes source
code. Any quoted code containing `[style]...[/]` makes Rich try to parse `[/]`
as a closing tag "with nothing to close", raising `MarkupError`:

```
rich.errors.MarkupError: closing tag '[/]' at position 977 has nothing to close
```

### Same crash class in two sibling call sites

While scoping the fix, two more sites print untrusted delegation output with
markup enabled and share the identical failure mode:

1. **The error branch — `review_delegation_service.py:204`.**
   `console.error(feedback)` interpolates the message **into** a markup string
   (`f"  [error]{ERR} Error:[/] {message}"` in `Console.error`), so a *failed*
   delegation whose feedback carries brackets crashes on the same tag mismatch.
2. **`src/wade/services/deps_service.py:532`.**
   `console.out.print(output)` prints AI-generated dependency analysis
   (PROMPT-mode passthrough for `wade task deps`) with markup enabled — the same
   crash for any output containing `[/]`.

Scope confirmed with the user: fix the **full crash class** (all three sites),
not just the single line named in the issue, so `wade task deps` does not
reproduce an identical bug immediately after.

## Proposed Solution

Reviewer/delegation feedback is plain text/markdown, never intended to be Rich
markup, so stop interpreting it as markup at every site that prints it.

- **Success branch** (`review_delegation_service.py:202`): print with markup
  disabled — `console.out.print(result.feedback, markup=False)`.
- **Error branch** (`review_delegation_service.py:204`): escape the feedback so
  `console.error`'s own `[error]…[/]` styling still renders while the message is
  literal — `console.error(escape(result.feedback))` with
  `from rich.markup import escape`. (`markup=False` cannot be used here because
  the text is interpolated inside `Console.error`'s own markup wrapper.)
- **deps passthrough** (`deps_service.py:532`): print with markup disabled —
  `console.out.print(output, markup=False)`.

`markup=False` / `escape()` is preferred over rendering the text as markdown:
the current code path is a plain `print`, not `console.markdown()`, so the only
behavioral change is that bracketed tokens now render literally instead of
crashing — exactly what we want for quoted code.

### Explicit non-goals (avoid scope creep)

- Do **not** globally change `Console.error()` to escape all messages — other
  callers may intentionally embed markup; escaping is applied at the review
  call site only.
- `Console.plain()` (`src/wade/ui/console.py:179-181`) sets `highlight=False`
  but leaves `markup=True`, so it shares the same latent crash. No current code
  path in this fix routes untrusted text through `plain()`, so leave it as-is
  and record it as a follow-up in **Notes for the implementation session**
  rather than fixing it here.

## Tasks

- [ ] In `src/wade/services/review_delegation_service.py`, add
      `from rich.markup import escape` and change the success branch to
      `console.out.print(result.feedback, markup=False)` (line ~202).
- [ ] In the same file, change the error branch to
      `console.error(escape(result.feedback))` (line ~204).
- [ ] In `src/wade/services/deps_service.py`, change the PROMPT-mode passthrough
      to `console.out.print(output, markup=False)` (line ~532).
- [ ] Add regression tests in
      `tests/unit/test_services/test_review_delegation_service.py`: mock
      `delegate` (following the existing `_review_config` /
      `load_prompt_template` patterns) to return
      `DelegationResult(success=True, feedback="quoted: [success]OK[/] done")`
      and assert `_run_review_delegation` does **not** raise and the literal
      `[/]` appears in captured stdout. Add a companion case for
      `success=False` feedback containing `[/]` (error branch does not raise).
- [ ] Add a regression test for the deps passthrough site
      (`tests/unit/test_services/test_deps_service.py`) asserting a PROMPT-mode
      `output` containing `[/]` prints without raising. If the existing test
      scaffolding there makes this disproportionately expensive, note why and
      rely on the review-service tests plus a shared assertion.
- [ ] Run `./scripts/test.sh` and `./scripts/check.sh` (or
      `./scripts/check-all.sh`) — both must pass.

## Acceptance Criteria

- [ ] `wade review implementation` completes and prints feedback containing
      `[/]` (and other bracketed tokens) without raising `MarkupError`; the
      `reviewed@<sha>` marker is written so `wade implementation-session done`
      is not falsely blocked.
- [ ] A failed review whose `feedback` contains bracketed markup is displayed
      via `console.error` without raising.
- [ ] `wade task deps` PROMPT-mode passthrough prints AI output containing
      `[/]` without raising.
- [ ] Bracketed tokens in feedback render **literally** (not swallowed as
      styling and not crashing).
- [ ] New regression test(s) fail against the current code and pass after the
      fix; full suite (`./scripts/test.sh`) and `./scripts/check.sh` pass.
- [ ] No global behavior change to `Console.error()` for non-review callers.

## Notes for the implementation session

Capture this as knowledge (`wade knowledge add`) once implemented — it is a
reusable, non-obvious constraint:

> **Untrusted AI/delegation output must never be printed through Rich with
> markup enabled.** `console.out.print(text)` and `console.error(text)` (which
> interpolates its message into a `[error]…[/]` wrapper) both parse `[/]`-style
> tokens as markup and raise `MarkupError` on quoted code. Print such text with
> `markup=False`, or `rich.markup.escape()` it when it must flow through a
> method that adds its own markup (`console.error`). Note the latent twin:
> `Console.plain()` (`src/wade/ui/console.py`) sets `highlight=False` but leaves
> `markup=True`, so it shares the same crash and is a candidate follow-up. Sites
> fixed by this issue: `review_delegation_service.py` success + error branches
> and `deps_service.py` PROMPT passthrough.

<!-- wade:plan:end -->

<!-- wade:summary:start -->

## Summary

## What was done

Fixed the `MarkupError` crash class where `wade review implementation` (and any
delegation-backed review) died while *printing* reviewer feedback whenever that
feedback quoted Rich-markup-like tokens such as `[/]`. Because the review had
already succeeded, the crash lost the feedback and skipped writing the
`reviewed@<sha>` marker — falsely blocking `wade implementation-session done`
unless `--skip-review` was used. Fixed all three sites that print untrusted
delegation output with markup enabled (#394).

## Changes

- `services/review_delegation_service.py` — success branch now prints feedback
  with `markup=False`; error branch wraps feedback in `rich.markup.escape()` so
  `console.error`'s own `[error]…[/]` styling still renders while the message
  stays literal (`markup=False` can't apply inside that wrapper).
- `services/deps_service.py` — the `wade task deps` PROMPT-mode passthrough
  (`console.out.print(output)`) now prints with `markup=False`; it shared the
  identical crash.
- Regression tests reproducing the exact
  `MarkupError: closing tag '[/]' ... has nothing to close` crash against the
  pre-fix code — for the review success branch, the review error branch, and the
  deps passthrough — plus updated the existing deps prompt-mode assertion for the
  new `markup=False` kwarg.
- Captured the reusable constraint as a knowledge entry (`KNOWLEDGE.md`).

## Key technical decisions

- `markup=False` / `escape()` over rendering feedback as markdown: the existing
  code path is a plain `print`, not `console.markdown()`, so the only behavioral
  change is that bracketed tokens now render **literally** instead of crashing —
  exactly what is wanted for quoted code.
- Scoped narrowly per the plan: `Console.error()` is **not** globally changed to
  escape all messages (other callers may intentionally embed markup); escaping is
  applied only at the review call site.
- `Console.plain()` (`ui/console.py`) has the same latent crash (`highlight=False`
  but `markup=True`); no path in this fix routes untrusted text through it, so it
  is left as a documented follow-up rather than changed here.

## Testing

- New regression tests fail with the real `MarkupError` against the pre-fix
  source and pass after the fix (verified by temporarily stashing the `src/`
  changes).
- `./scripts/test.sh` — full suite passes (2889 tests).
- `./scripts/check.sh` — ruff check, ruff format, and mypy `--strict` all clean.

## Notes for reviewers

`Console.plain()` sharing the same latent `markup=True` crash is intentionally
out of scope (no current path routes untrusted text through it) and noted as a
follow-up in the knowledge entry.

<!-- wade:summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI-generated output containing bracketed text is now displayed literally instead of being interpreted as formatting.
  * Prevented markup-related errors in prompt responses and delegated review feedback, including failure messages.

* **Tests**
  * Added regression coverage for successful and failed responses containing Rich-style markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **111,600** |
| Input tokens | **110,600** |
| Output tokens | **1,000** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `a23daa00-3108-4baf-aa93-b7765c0d4ff4` |

<!-- wade:sessions:end -->
