### PR TITLE
fix: `done` cannot tell a clean review from one that never ran

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -465,3 +465,9 @@ shell_containment's device write-exemption (src/wade/hooks/policies.py) is an EX
 install_worktree_git_hook (singular) and install_pre_push_backstop were removed in #383. The sole per-worktree git-hook install core is now the batch install_worktree_git_hooks(worktree_path, hooks: dict[hook_name, script]), which captures every prior hook to per-hook .chain-<hook_name> files before setting core.hooksPath. Bootstrap's _install_managed_git_hooks (bootstrap.py) loads the pre-push template and owns the missing-template degrade. This supersedes the framing in entry c52fac51 (Issue #352), which described the singular wrapper as "the reusable core."
 
 ---
+
+## 4d419ec6629c | 2026-08-10 | implementation | tags: done, review, markers, pr-body | Issue #367
+
+The durable, human-legible record of session state is the PR body (marker-bounded blocks: wade:summary, wade:review-status, wade:impl-usage), NOT the .wade/ markers — reviewed@<sha>/review-pass@<sha>/done@<sha> are zero-byte, worktree-local, and discarded at session end, so no human ever sees them. To make session state visible to a reviewer, project it into the PR body with a marker-scoped block (build_marked_block + update_body_preserving_markers, idempotent on re-run) rather than a richer on-disk receipt — this is why #367 surfaced review status (reviewed/skipped/gate-disabled + pass count) as a PR-body block. done.py:_classify_review is the single classifier both the review-ran gate and the '## Review Status' renderer read, so the gate decision and the PR-body wording cannot drift.
+
+---

--- a/README.md
+++ b/README.md
@@ -309,6 +309,13 @@ chains to any pre-existing `pre-push` hook. **Honesty:** `git push --no-verify`
 bypasses the backstop in one flag — this is a quality/backstop layer that makes
 the gate hard to skip, not an airtight boundary.
 
+`done` also writes a **`## Review Status`** line into the PR body recording the
+review outcome — reviewed at `<sha>`, skipped via `--skip-review`, gate disabled
+(`done.require_review: false` / `ai.review_implementation.enabled: false`), or
+completed at the review-pass cap — with the review-pass count. A skipped or
+never-run review is therefore visible to reviewers in the PR itself, not just in
+the worktree-local `.wade/` markers that are discarded when the session ends.
+
 ## Task Providers
 
 WADE can pull tasks from three backends — pick one when you run `wade init`:

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -374,7 +374,27 @@ cap). `review-pr-comments` keeps the unbounded
    scoped to `session_type == "implementation"`.
 4. **sync** (implementation only) — auto-sync via the existing `do_sync` service
    when `behind > 0`, refuse only on conflict.
-5. `_done_via_pr` writes `.wade/done@<post-sync HEAD>` immediately before pushing.
+5. `_done_via_pr` writes `.wade/done@<post-sync HEAD>` immediately before pushing,
+   and projects the review outcome into the PR body as a `wade:review-status`
+   block (see below).
+
+**Review status is legible in the PR body (#367).** The `.wade/` markers
+(`reviewed@<sha>`, `review-pass@<sha>`) are zero-byte and **worktree-local** — no
+human ever sees them, so "attempted twice, timed out twice" was indistinguishable
+from "never tried" in the durable artifact. `done` closes that legibility gap:
+after the gates pass, `_classify_review(config, worktree, pre-sync HEAD,
+skip_review, session_type)` — one pure classifier that the review-ran **gate**
+also decides from, so the two can't drift — returns a frozen `ReviewStatus`
+(`kind`, `passes`, `session_type`, `reviewed_sha`) that `_render_review_status`
+turns into a one-line `## Review Status` section wrapped in
+`wade:review-status:start/end` markers. It records reviewed-at-`<sha>` /
+skipped (`--skip-review`) / gate-disabled (`done.require_review: false` or
+`review_implementation.enabled: false`) / cap-reached, and shows the review-pass
+count so a skipped-but-attempted run reads differently from a never-run one. Like
+the `wade:summary` block it is marker-scoped (upserted before the
+`wade:impl-usage` table, idempotent on re-run, preserving any concurrent edit
+outside the markers) — the PR body, not the discarded `.wade/` markers, is the
+durable receipt.
 
 The **done-marker primitive** lives in `utils/markers.py` — a pure-stdlib leaf
 (so the lean `wade-hook` can import it cheaply). A marker is a zero-byte file

--- a/docs/dev/skills-system.md
+++ b/docs/dev/skills-system.md
@@ -144,15 +144,18 @@ or they are not installed. Review needs its **own** `reference/recovery.md` and
 `REVIEW_SKILLS` installs only `review-pr-comments-session`, `task`, and
 `knowledge`. Some duplication between the paired files is expected and correct.
 
-### The ≤ 8,000-char budget test
+### The session-start budget test
 
 `tests/integration/test_skill_context_budget.py` pins the combined size of the
 session-start payload — launch prompt + rendered `SKILL.md` (partials expanded,
-reviews enabled) — at **≤ 8,000 chars** for each of implement / plan / review, so
-the budget cannot silently regress. The unit is **chars** (a deliberate proxy for
-tokens; measured token savings differ slightly). If a skill edit pushes a session
-over budget, move the added detail into a `reference/*.md` and leave a one-line
-pointer rather than inflating the always-loaded `SKILL.md`.
+reviews enabled) — under a fixed char ceiling (`BUDGET_CHARS`, currently **8,400**)
+for each of implement / plan / review, so the budget cannot silently regress. The
+unit is **chars** (a deliberate proxy for tokens; measured token savings differ
+slightly). If a skill edit pushes a session over budget, move the added detail
+into a `reference/*.md` and leave a one-line pointer rather than inflating the
+always-loaded `SKILL.md` — or, for a short load-bearing note that must be
+always-loaded, bump `BUDGET_CHARS` with a documented reason (the ceiling exists to
+force that decision to be explicit and reviewed, not to forbid it).
 
 **Computed placeholders must be rendered, not left literal.** `{doc_targets}` is
 resolved per project at install time (see [Documentation

--- a/src/wade/services/implementation_service/done.py
+++ b/src/wade/services/implementation_service/done.py
@@ -29,10 +29,15 @@ from wade.services.implementation_service.bootstrap import (
 )
 from wade.services.implementation_service.core import _resolve_worktree_from_plan
 from wade.services.implementation_service.lifecycle import (
+    REVIEW_STATUS_MARKER_END,
+    REVIEW_STATUS_MARKER_START,
     SUMMARY_MARKER_END,
     SUMMARY_MARKER_START,
+    ReviewStatus,
+    ReviewStatusKind,
     _apply_pr_refs,
     _build_pr_body,
+    _render_review_status,
     _strip_summary_section,
 )
 from wade.services.implementation_service.usage_tracking import IMPL_USAGE_MARKER_START
@@ -50,6 +55,7 @@ from wade.utils.markdown import remove_marker_block
 logger = structlog.get_logger()
 
 __all__ = [
+    "_classify_review",
     "_done_via_pr",
     "done",
 ]
@@ -279,6 +285,16 @@ def done(
     ):
         return False
 
+    # Gates passed. Re-classify the review outcome (cheap, idempotent marker
+    # reads) against the SAME pre-sync HEAD the review gate used — the sha the
+    # agent actually reviewed, since an impl-only sync may have advanced HEAD
+    # since — and project it into the PR body so the review status (reviewed /
+    # skipped / gate-disabled / attempted-but-not-passed) is legible to a human
+    # reviewer (#367).
+    review_status = _classify_review(
+        config, worktree_root, pre_sync_head, skip_review, session_type
+    )
+
     console.rule(f"done #{issue_number}")
 
     ok = _done_via_pr(
@@ -290,6 +306,7 @@ def done(
         draft=draft,
         config=config,
         worktree_path=wt_path,
+        review_status=review_status,
     )
     if not ok:
         # Finalize failed — leave the worktree exactly as we found it (gitignore
@@ -512,6 +529,48 @@ def _gate_pr_summary(config: ProjectConfig, worktree_root: Path) -> bool:
     return True
 
 
+def _classify_review(
+    config: ProjectConfig,
+    worktree_root: Path,
+    head_sha: str,
+    skip_review: bool,
+    session_type: str = "implementation",
+) -> ReviewStatus:
+    """Classify the review-ran outcome for ``head_sha`` — the single source of
+    truth shared by :func:`_gate_review_ran` (pass/refuse) and the PR-body
+    renderer (:func:`_render_review_status`), so the branching can't drift.
+
+    Pure and side-effect-free: it only reads sha-keyed markers and config. The
+    ``kind`` ordering mirrors the gate's short-circuit order exactly — reviews
+    disabled precedes the ``--skip-review`` / ``require_review`` hatches, which
+    precede the exact-sha fast path, which precedes the impl-only pass cap. The
+    pass count (distinct ``review-pass@*`` markers) is read for **both** session
+    types — a listdir failure yields ``0`` (fail toward re-gating), never a false
+    "cap reached" — and carried on the returned object for honest rendering.
+    """
+    passes = markers.count_review_passes(worktree_root)
+
+    if config.ai.review_implementation.enabled is False:
+        kind = ReviewStatusKind.DISABLED
+    elif skip_review:
+        kind = ReviewStatusKind.SKIPPED_FLAG
+    elif not config.done.require_review:
+        kind = ReviewStatusKind.REQUIRE_OFF
+    elif markers.marker_present(worktree_root, "reviewed", head_sha):
+        kind = ReviewStatusKind.REVIEWED
+    elif session_type == "implementation" and passes >= config.done.max_review_passes:
+        kind = ReviewStatusKind.CAP_REACHED
+    else:
+        kind = ReviewStatusKind.NOT_REVIEWED
+
+    return ReviewStatus(
+        kind=kind,
+        passes=passes,
+        session_type=session_type,
+        reviewed_sha=head_sha,
+    )
+
+
 def _gate_review_ran(
     config: ProjectConfig,
     worktree_root: Path,
@@ -536,35 +595,35 @@ def _gate_review_ran(
     unbounded fast-path-or-refuse behavior; #384 is scoped to impl sessions and
     this gate is shared (knowledge 851bb6ec), so the cap branch is impl-only.
 
-    The pass count is the number of distinct ``review-pass@*`` markers; a listdir
-    failure yields ``0`` (fail toward re-gating), never a false "cap reached".
+    The decision is derived from :func:`_classify_review` so the gate and the
+    PR-body review-status block (#367) share one classification; the branches
+    below only translate each ``kind`` into pass/refuse plus its (unchanged)
+    console output.
 
     Auto-skipped when reviews are disabled (``review_implementation.enabled:
     false``) — the marker is not written then either. Hatches: ``--skip-review``
     and ``done.require_review: false``.
     """
-    if config.ai.review_implementation.enabled is False:
-        return True  # reviews disabled project-wide → gate off (no marker written)
-    if skip_review or not config.done.require_review:
-        return True
-    if markers.marker_present(worktree_root, "reviewed", head_sha):
+    status = _classify_review(config, worktree_root, head_sha, skip_review, session_type)
+    kind = status.kind
+
+    # Hatches, disabled, and the exact-sha fast path all pass silently.
+    if kind in (
+        ReviewStatusKind.DISABLED,
+        ReviewStatusKind.SKIPPED_FLAG,
+        ReviewStatusKind.REQUIRE_OFF,
+        ReviewStatusKind.REVIEWED,
+    ):
         return True
 
-    # review-pr-comments: unchanged fast-path-or-refuse (no cap — out of scope).
-    if session_type != "implementation":
-        _print_review_refusal()
-        return False
-
-    # Implementation session: apply the bounded review-pass cap (done.max_review_passes).
-    passes = markers.count_review_passes(worktree_root)
-    limit = config.done.max_review_passes
-    if passes >= limit:
+    if kind is ReviewStatusKind.CAP_REACHED:
+        limit = config.done.max_review_passes
         console.warn(
-            f"Review-pass safety limit reached ({passes} of {limit}) — the current "
+            f"Review-pass safety limit reached ({status.passes} of {limit}) — the current "
             "commit was not re-reviewed."
         )
         console.detail(
-            f"{passes} commit(s) have been reviewed on this worktree; the cap bounds "
+            f"{status.passes} commit(s) have been reviewed on this worktree; the cap bounds "
             "the review→fix→re-review loop so `done` can't be blocked indefinitely. "
             "Completing without requiring another review."
         )
@@ -574,7 +633,15 @@ def _gate_review_ran(
         )
         return True
 
-    console.error(f"Review has not run for the current commit (review pass {passes} of {limit}).")
+    # NOT_REVIEWED — refuse. review-pr-comments keeps the plain refusal (no cap).
+    if session_type != "implementation":
+        _print_review_refusal()
+        return False
+
+    limit = config.done.max_review_passes
+    console.error(
+        f"Review has not run for the current commit (review pass {status.passes} of {limit})."
+    )
     console.hint("Run `wade review implementation` (or pass --skip-review), then re-run done.")
     console.detail(
         "A clean merge of main is accepted without re-review, but new commits "
@@ -855,6 +922,8 @@ def _done_via_pr(
     draft: bool,
     config: ProjectConfig,
     worktree_path: Path | None = None,
+    *,
+    review_status: ReviewStatus | None = None,
 ) -> bool:
     """Finalize implementation — update existing draft PR or create a new one.
 
@@ -862,7 +931,11 @@ def _done_via_pr(
     or implement). This function:
     1. Pushes the branch
     2. Appends PR-SUMMARY content to the existing PR body
-    3. Marks the draft PR as ready for review
+    3. Writes the review-status block (#367) into the PR body
+    4. Marks the draft PR as ready for review
+
+    ``review_status`` is optional so direct callers/tests need not build one;
+    ``done()`` always supplies it, so a real PR always carries the block.
     """
     provider = get_provider(config)
     pr_url = ""
@@ -989,29 +1062,48 @@ def _done_via_pr(
             logger.debug("implementation.parent_issue_detection_failed", exc_info=True)
 
         def _transform(body: str) -> str:
-            # Keep existing content; refresh close/parent refs; rewrite ONLY the
-            # wade:summary block so a concurrent edit elsewhere survives (A4).
+            # Keep existing content; refresh close/parent refs; rewrite ONLY
+            # wade's own marker blocks so a concurrent edit elsewhere survives (A4).
             body = _apply_pr_refs(body, issue_number, close_issue, parent_issue)
-            # Remove the prior marked block FIRST: the legacy heading stripper is
+            # Remove the prior marked blocks FIRST: the legacy heading stripper is
             # not marker-aware, so running it on a body that still contains the
             # marked block would match the `## Summary` *inside* the block,
             # orphan the start marker, and drop the end marker (leaving an
-            # unbalanced pair remove_marker_block can no longer clean). After the
-            # marked block is gone, strip any genuinely legacy unmarked heading.
+            # unbalanced pair remove_marker_block can no longer clean). Removing
+            # both wade blocks up front also keeps re-runs idempotent (the
+            # review-status block is replaced in place, never duplicated). After
+            # the marked blocks are gone, strip any genuinely legacy unmarked
+            # heading.
             body = remove_marker_block(body, SUMMARY_MARKER_START, SUMMARY_MARKER_END)
+            body = remove_marker_block(body, REVIEW_STATUS_MARKER_START, REVIEW_STATUS_MARKER_END)
             body = _strip_summary_section(body)
-            if not summary_content:
+
+            # Compose wade-owned blocks in order: summary, then review-status.
+            blocks: list[str] = []
+            if summary_content:
+                blocks.append(
+                    build_marked_block(
+                        SUMMARY_MARKER_START, SUMMARY_MARKER_END, f"## Summary\n\n{summary_content}"
+                    )
+                )
+            if review_status is not None:
+                blocks.append(
+                    build_marked_block(
+                        REVIEW_STATUS_MARKER_START,
+                        REVIEW_STATUS_MARKER_END,
+                        _render_review_status(review_status),
+                    )
+                )
+            if not blocks:
                 return body.rstrip("\n") + "\n"
-            block = build_marked_block(
-                SUMMARY_MARKER_START, SUMMARY_MARKER_END, f"## Summary\n\n{summary_content}"
-            )
-            # Keep ordering content → summary → impl-usage.
+            joined = "\n\n".join(blocks)
+            # Keep ordering content → [summary, review-status] → impl-usage.
             marker_pos = body.find(IMPL_USAGE_MARKER_START)
             if marker_pos != -1:
                 before = body[:marker_pos].rstrip("\n")
                 after = body[marker_pos:]
-                return f"{before}\n\n{block}\n\n{after}\n"
-            return body.rstrip("\n") + "\n\n" + block + "\n"
+                return f"{before}\n\n{joined}\n\n{after}\n"
+            return body.rstrip("\n") + "\n\n" + joined + "\n"
 
         if not update_body_preserving_markers(
             read_body=lambda: git_pr.get_pr_body(repo_root, pr_number) or "",
@@ -1051,6 +1143,7 @@ def _done_via_pr(
             pr_summary_path=pr_summary_path,
             close_issue=close_issue,
             parent_issue=parent_issue,
+            review_status=review_status,
         )
 
         console.step("Creating pull request...")

--- a/src/wade/services/implementation_service/done.py
+++ b/src/wade/services/implementation_service/done.py
@@ -35,6 +35,7 @@ from wade.services.implementation_service.lifecycle import (
     SUMMARY_MARKER_START,
     ReviewStatus,
     ReviewStatusKind,
+    SessionType,
     _apply_pr_refs,
     _build_pr_body,
     _render_review_status,
@@ -72,7 +73,7 @@ def done(
     draft: bool = False,
     project_root: Path | None = None,
     *,
-    session_type: str = "implementation",
+    session_type: SessionType | str = SessionType.IMPLEMENTATION,
     skip_review: bool = False,
 ) -> bool:
     """Complete a session — run the completion gates, push, and finalize the PR.
@@ -534,30 +535,33 @@ def _classify_review(
     worktree_root: Path,
     head_sha: str,
     skip_review: bool,
-    session_type: str = "implementation",
+    session_type: SessionType | str = SessionType.IMPLEMENTATION,
 ) -> ReviewStatus:
     """Classify the review-ran outcome for ``head_sha`` — the single source of
     truth shared by :func:`_gate_review_ran` (pass/refuse) and the PR-body
     renderer (:func:`_render_review_status`), so the branching can't drift.
 
     Pure and side-effect-free: it only reads sha-keyed markers and config. The
-    ``kind`` ordering mirrors the gate's short-circuit order exactly — reviews
-    disabled precedes the ``--skip-review`` / ``require_review`` hatches, which
-    precede the exact-sha fast path, which precedes the impl-only pass cap. The
-    pass count (distinct ``review-pass@*`` markers) is read for **both** session
-    types — a listdir failure yields ``0`` (fail toward re-gating), never a false
-    "cap reached" — and carried on the returned object for honest rendering.
+    exact-sha fast path is checked **first** — a ``reviewed@<head_sha>`` marker
+    is positive evidence that review ran, so it outranks the ``--skip-review`` /
+    ``require_review`` hatches and the disabled flag: a reviewed commit must
+    never be reported as skipped/gate-disabled (#367). Only when no marker
+    exists do the hatches and disabled flag take over, followed by the
+    impl-only pass cap. The pass count (distinct ``review-pass@*`` markers) is
+    read for **both** session types — a listdir failure yields ``0`` (fail
+    toward re-gating), never a false "cap reached" — and carried on the
+    returned object for honest rendering.
     """
     passes = markers.count_review_passes(worktree_root)
 
-    if config.ai.review_implementation.enabled is False:
+    if markers.marker_present(worktree_root, "reviewed", head_sha):
+        kind = ReviewStatusKind.REVIEWED
+    elif config.ai.review_implementation.enabled is False:
         kind = ReviewStatusKind.DISABLED
     elif skip_review:
         kind = ReviewStatusKind.SKIPPED_FLAG
     elif not config.done.require_review:
         kind = ReviewStatusKind.REQUIRE_OFF
-    elif markers.marker_present(worktree_root, "reviewed", head_sha):
-        kind = ReviewStatusKind.REVIEWED
     elif session_type == "implementation" and passes >= config.done.max_review_passes:
         kind = ReviewStatusKind.CAP_REACHED
     else:
@@ -566,7 +570,7 @@ def _classify_review(
     return ReviewStatus(
         kind=kind,
         passes=passes,
-        session_type=session_type,
+        session_type=SessionType(session_type),
         reviewed_sha=head_sha,
     )
 

--- a/src/wade/services/implementation_service/lifecycle.py
+++ b/src/wade/services/implementation_service/lifecycle.py
@@ -33,6 +33,7 @@ logger = structlog.get_logger()
 __all__ = [
     "ReviewStatus",
     "ReviewStatusKind",
+    "SessionType",
     "_apply_pr_refs",
     "_build_pr_body",
     "_merge_pr",
@@ -348,6 +349,13 @@ REVIEW_STATUS_MARKER_START = "<!-- wade:review-status:start -->"
 REVIEW_STATUS_MARKER_END = "<!-- wade:review-status:end -->"
 
 
+class SessionType(StrEnum):
+    """The two session kinds the completion gate (``done``) distinguishes."""
+
+    IMPLEMENTATION = "implementation"
+    REVIEW_PR_COMMENTS = "review-pr-comments"
+
+
 class ReviewStatusKind(StrEnum):
     """Outcome of the done-time review-ran classification (#367).
 
@@ -379,7 +387,7 @@ class ReviewStatus(BaseModel):
 
     kind: ReviewStatusKind
     passes: int  # distinct review-pass markers (``count_review_passes()``)
-    session_type: str  # "implementation" | "review-pr-comments"
+    session_type: SessionType
     reviewed_sha: str  # the pre-sync HEAD the agent reviewed (for display)
 
 

--- a/src/wade/services/implementation_service/lifecycle.py
+++ b/src/wade/services/implementation_service/lifecycle.py
@@ -392,8 +392,15 @@ class ReviewStatus(BaseModel):
 
 
 def _review_pass_phrase(passes: int) -> str:
-    """``N review pass(es)`` with correct pluralization."""
-    return f"{passes} review pass{'' if passes == 1 else 'es'}"
+    """``N distinct commit(s) reviewed`` — a count of unique reviewed commits, not
+    review invocations. ``markers.record_review_pass`` is per-sha and idempotent
+    (#384), so retrying review against the same HEAD (e.g. two consecutive
+    headless timeouts) reuses one marker and is never double-counted; the phrase
+    says "commits reviewed" rather than "review passes" so it can't be misread
+    as an attempt count.
+    """
+    noun = "commit" if passes == 1 else "commits"
+    return f"{passes} distinct {noun} reviewed"
 
 
 def _render_review_status(status: ReviewStatus) -> str:
@@ -401,9 +408,13 @@ def _render_review_status(status: ReviewStatus) -> str:
 
     The line makes the review outcome legible to a human reading the PR:
     reviewed / skipped / gate-disabled / cap-reached / not-reviewed. For the
-    non-reviewed outcomes it distinguishes "attempted N times, final commit not
-    reviewed" (``passes > 0``) from "never tried" (``passes == 0``) — the core
-    #367 legibility fix. The pass count is honest for both session types;
+    non-reviewed outcomes it distinguishes "N distinct commit(s) reviewed, final
+    commit not reviewed" (``passes > 0``) from "never tried" (``passes == 0``) —
+    the core #367 legibility fix; see :func:`_review_pass_phrase` for why the
+    count is phrased as distinct commits rather than review attempts. The count
+    is honest for both session types and rendered for the gate-disabled outcomes
+    too (``REQUIRE_OFF``/``DISABLED``), not just the skipped/not-reviewed ones,
+    so a disabled gate never masks an already-recorded review history.
     ``CAP_REACHED`` is only ever produced for implementation sessions (the
     classifier scopes the cap there), so its wording never leaks into a
     review-pr-comments PR.
@@ -416,13 +427,12 @@ def _render_review_status(status: ReviewStatus) -> str:
     elif kind is ReviewStatusKind.SKIPPED_FLAG:
         if status.passes > 0:
             line = (
-                f"⚠️ Review skipped (`--skip-review`); {_review_pass_phrase(status.passes)} "
-                "recorded, but the final commit was not reviewed."
+                f"⚠️ Review skipped (`--skip-review`); {_review_pass_phrase(status.passes)}, "
+                "but the final commit was not reviewed."
             )
         else:
             line = (
-                "⚠️ Review skipped (`--skip-review`); no review passes were recorded "
-                "(review never ran)."
+                "⚠️ Review skipped (`--skip-review`); no commits were reviewed (review never ran)."
             )
     elif kind is ReviewStatusKind.CAP_REACHED:
         line = (
@@ -432,14 +442,15 @@ def _render_review_status(status: ReviewStatus) -> str:
     elif kind is ReviewStatusKind.REQUIRE_OFF:
         # The leading info emoji is intentional PR-body markdown, not an identifier.
         line = "ℹ️ Review gate disabled (`done.require_review: false`)."  # noqa: RUF001
+        if status.passes > 0:
+            line += f" {_review_pass_phrase(status.passes)} before the gate was disabled."
     elif kind is ReviewStatusKind.DISABLED:
         line = "ℹ️ Review gate disabled (`review_implementation.enabled: false`)."  # noqa: RUF001
+        if status.passes > 0:
+            line += f" {_review_pass_phrase(status.passes)} before the gate was disabled."
     else:  # NOT_REVIEWED — rendering fallback (the gate would normally have refused).
         if status.passes > 0:
-            line = (
-                f"⚠️ {_review_pass_phrase(status.passes)} recorded, but the final commit "
-                "was not reviewed."
-            )
+            line = f"⚠️ {_review_pass_phrase(status.passes)}, but the final commit was not reviewed."
         else:
             line = "⚠️ The final commit was not reviewed (review never ran)."
 

--- a/src/wade/services/implementation_service/lifecycle.py
+++ b/src/wade/services/implementation_service/lifecycle.py
@@ -10,9 +10,11 @@ import contextlib
 import re
 import shutil
 import webbrowser
+from enum import StrEnum
 from pathlib import Path
 
 import structlog
+from pydantic import BaseModel
 
 from wade.git import pr as git_pr
 from wade.git import repo as git_repo
@@ -29,6 +31,8 @@ from wade.ui.console import console
 logger = structlog.get_logger()
 
 __all__ = [
+    "ReviewStatus",
+    "ReviewStatusKind",
     "_apply_pr_refs",
     "_build_pr_body",
     "_merge_pr",
@@ -36,6 +40,7 @@ __all__ = [
     "_post_implementation_lifecycle",
     "_post_implementation_lifecycle_pr",
     "_pull_main_after_merge",
+    "_render_review_status",
     "_strip_summary_section",
     "_warn_pull_sync_failed",
 ]
@@ -337,6 +342,101 @@ def _merge_pr(
 SUMMARY_MARKER_START = "<!-- wade:summary:start -->"
 SUMMARY_MARKER_END = "<!-- wade:summary:end -->"
 
+# Review-status block (#367) — projects the done-time review outcome into the PR
+# body so a human reviewer can tell a clean review from a skipped/never-run one.
+REVIEW_STATUS_MARKER_START = "<!-- wade:review-status:start -->"
+REVIEW_STATUS_MARKER_END = "<!-- wade:review-status:end -->"
+
+
+class ReviewStatusKind(StrEnum):
+    """Outcome of the done-time review-ran classification (#367).
+
+    A single value the completion gate (:func:`done._gate_review_ran`) turns into
+    pass/refuse and the PR-body renderer (:func:`_render_review_status`) turns
+    into a human-legible line — one source of truth so the two cannot drift.
+    """
+
+    REVIEWED = "reviewed"  # exact-sha ``reviewed@<head>`` marker present
+    SKIPPED_FLAG = "skipped_flag"  # ``--skip-review`` passed
+    REQUIRE_OFF = "require_off"  # ``done.require_review: false``
+    DISABLED = "disabled"  # ``review_implementation.enabled: false``
+    CAP_REACHED = "cap_reached"  # impl-only; pass cap hit with no fresh review
+    NOT_REVIEWED = "not_reviewed"  # gate would refuse (rendering fallback)
+
+
+class ReviewStatus(BaseModel):
+    """Immutable bundle describing whether review ran for the finalized commit.
+
+    Flows gate → ``done()`` → ``_done_via_pr`` → renderer so the branching is
+    decided once (in ``done._classify_review``) and merely rendered downstream —
+    no separate ``session_type``/``passes`` args threaded across the boundary,
+    they ride inside this object. Distinct from :class:`wade.models.review.
+    PRReviewStatus`, which is about PR-level review threads/submissions; this is
+    only about whether ``wade review implementation`` *ran* for the pushed commit.
+    """
+
+    model_config = {"frozen": True}
+
+    kind: ReviewStatusKind
+    passes: int  # distinct review-pass markers (``count_review_passes()``)
+    session_type: str  # "implementation" | "review-pr-comments"
+    reviewed_sha: str  # the pre-sync HEAD the agent reviewed (for display)
+
+
+def _review_pass_phrase(passes: int) -> str:
+    """``N review pass(es)`` with correct pluralization."""
+    return f"{passes} review pass{'' if passes == 1 else 'es'}"
+
+
+def _render_review_status(status: ReviewStatus) -> str:
+    """Render the review-status block body — a ``## Review Status`` heading + one line.
+
+    The line makes the review outcome legible to a human reading the PR:
+    reviewed / skipped / gate-disabled / cap-reached / not-reviewed. For the
+    non-reviewed outcomes it distinguishes "attempted N times, final commit not
+    reviewed" (``passes > 0``) from "never tried" (``passes == 0``) — the core
+    #367 legibility fix. The pass count is honest for both session types;
+    ``CAP_REACHED`` is only ever produced for implementation sessions (the
+    classifier scopes the cap there), so its wording never leaks into a
+    review-pr-comments PR.
+    """
+    kind = status.kind
+    short_sha = status.reviewed_sha[:7] if status.reviewed_sha else "unknown"
+
+    if kind is ReviewStatusKind.REVIEWED:
+        line = f"✅ Reviewed at `{short_sha}` via `wade review implementation`."
+    elif kind is ReviewStatusKind.SKIPPED_FLAG:
+        if status.passes > 0:
+            line = (
+                f"⚠️ Review skipped (`--skip-review`); {_review_pass_phrase(status.passes)} "
+                "recorded, but the final commit was not reviewed."
+            )
+        else:
+            line = (
+                "⚠️ Review skipped (`--skip-review`); no review passes were recorded "
+                "(review never ran)."
+            )
+    elif kind is ReviewStatusKind.CAP_REACHED:
+        line = (
+            f"⚠️ Completed after {_review_pass_phrase(status.passes)} without a fresh "
+            "review of the final commit (`done.max_review_passes` cap reached)."
+        )
+    elif kind is ReviewStatusKind.REQUIRE_OFF:
+        # The leading info emoji is intentional PR-body markdown, not an identifier.
+        line = "ℹ️ Review gate disabled (`done.require_review: false`)."  # noqa: RUF001
+    elif kind is ReviewStatusKind.DISABLED:
+        line = "ℹ️ Review gate disabled (`review_implementation.enabled: false`)."  # noqa: RUF001
+    else:  # NOT_REVIEWED — rendering fallback (the gate would normally have refused).
+        if status.passes > 0:
+            line = (
+                f"⚠️ {_review_pass_phrase(status.passes)} recorded, but the final commit "
+                "was not reviewed."
+            )
+        else:
+            line = "⚠️ The final commit was not reviewed (review never ran)."
+
+    return f"## Review Status\n\n{line}"
+
 
 def _strip_summary_section(body: str) -> str:
     """Remove an existing ``## Summary`` section from a PR body.
@@ -428,34 +528,40 @@ def _build_pr_body(
     pr_summary_path: Path | None = None,
     close_issue: bool = True,
     parent_issue: str | None = None,
+    *,
+    review_status: ReviewStatus | None = None,
 ) -> str:
-    """Compose the PR body.
+    """Compose the PR body (new-PR fallback path).
 
     Order:
     1. Part of #parent (if detected)
     2. Closes #N
     3. ## Summary (from PR-SUMMARY file)
+    4. ## Review Status (from the done-time review classification, if provided)
 
     Plan summary stays on the issue only — not copied into the PR body.
+    ``review_status`` is optional so the many callers that only compose
+    refs/summary need not construct one; ``done()`` always supplies it, so a real
+    PR always carries the review-status block.
     """
     from wade.utils.body_markers import build_marked_block
 
-    lines: list[str] = []
+    parts: list[str] = []
 
+    ref_lines: list[str] = []
     if parent_issue:
-        lines.append(f"Part of #{parent_issue}")
+        ref_lines.append(f"Part of #{parent_issue}")
     if close_issue:
-        lines.append(f"Closes #{task.id}")
-
-    if lines:
-        lines.append("")
+        ref_lines.append(f"Closes #{task.id}")
+    if ref_lines:
+        parts.append("\n".join(ref_lines))
 
     # PR summary from file — wrapped in wade:summary markers so a later `done`
     # rewrites only this block and preserves any concurrent edits (A4).
     if pr_summary_path and pr_summary_path.is_file():
         summary_content = pr_summary_path.read_text(encoding="utf-8").strip()
         if summary_content:
-            lines.append(
+            parts.append(
                 build_marked_block(
                     SUMMARY_MARKER_START,
                     SUMMARY_MARKER_END,
@@ -463,4 +569,14 @@ def _build_pr_body(
                 )
             )
 
-    return "\n".join(lines)
+    # Review-status block — same marker-scoped treatment, placed after the summary.
+    if review_status is not None:
+        parts.append(
+            build_marked_block(
+                REVIEW_STATUS_MARKER_START,
+                REVIEW_STATUS_MARKER_END,
+                _render_review_status(review_status),
+            )
+        )
+
+    return "\n\n".join(parts)

--- a/src/wade/services/implementation_service/lifecycle.py
+++ b/src/wade/services/implementation_service/lifecycle.py
@@ -392,15 +392,17 @@ class ReviewStatus(BaseModel):
 
 
 def _review_pass_phrase(passes: int) -> str:
-    """``N distinct commit(s) reviewed`` — a count of unique reviewed commits, not
-    review invocations. ``markers.record_review_pass`` is per-sha and idempotent
-    (#384), so retrying review against the same HEAD (e.g. two consecutive
-    headless timeouts) reuses one marker and is never double-counted; the phrase
-    says "commits reviewed" rather than "review passes" so it can't be misread
-    as an attempt count.
+    """``review attempted on N distinct commit(s)`` — a count of unique commits a
+    review delegation ran against, not a count of confirmed-successful reviews.
+    ``review_delegation_service._record_review_pass`` writes the
+    ``review-pass@<sha>`` marker *before* checking ``result.success``, so a
+    headless timeout or other delegation failure still advances this count
+    (#384) — the phrase must not claim those commits were actually reviewed,
+    only that a review was attempted. ``markers.record_review_pass`` is per-sha
+    and idempotent, so retrying against the same HEAD is never double-counted.
     """
     noun = "commit" if passes == 1 else "commits"
-    return f"{passes} distinct {noun} reviewed"
+    return f"review attempted on {passes} distinct {noun}"
 
 
 def _render_review_status(status: ReviewStatus) -> str:
@@ -408,13 +410,17 @@ def _render_review_status(status: ReviewStatus) -> str:
 
     The line makes the review outcome legible to a human reading the PR:
     reviewed / skipped / gate-disabled / cap-reached / not-reviewed. For the
-    non-reviewed outcomes it distinguishes "N distinct commit(s) reviewed, final
-    commit not reviewed" (``passes > 0``) from "never tried" (``passes == 0``) —
-    the core #367 legibility fix; see :func:`_review_pass_phrase` for why the
-    count is phrased as distinct commits rather than review attempts. The count
-    is honest for both session types and rendered for the gate-disabled outcomes
-    too (``REQUIRE_OFF``/``DISABLED``), not just the skipped/not-reviewed ones,
-    so a disabled gate never masks an already-recorded review history.
+    non-reviewed outcomes it distinguishes "review attempted on N distinct
+    commit(s), final commit not reviewed" (``passes > 0``) from "never tried"
+    (``passes == 0``) — the core #367 legibility fix; see
+    :func:`_review_pass_phrase` for why the count is phrased as attempted
+    reviews, not confirmed-successful ones. The count is honest for both
+    session types and rendered for the gate-disabled outcomes too
+    (``REQUIRE_OFF``/``DISABLED``), not just the skipped/not-reviewed ones, so a
+    disabled gate never masks an already-recorded review history — and those
+    two branches always state the final commit was not reviewed, without
+    claiming *when* relative to the gate the passes happened: marker files
+    carry no timestamp, so that chronology can't be known (#367 follow-up).
     ``CAP_REACHED`` is only ever produced for implementation sessions (the
     classifier scopes the cap there), so its wording never leaks into a
     review-pr-comments PR.
@@ -431,23 +437,27 @@ def _render_review_status(status: ReviewStatus) -> str:
                 "but the final commit was not reviewed."
             )
         else:
-            line = (
-                "⚠️ Review skipped (`--skip-review`); no commits were reviewed (review never ran)."
-            )
+            line = "⚠️ Review skipped (`--skip-review`); no review was attempted (review never ran)."
     elif kind is ReviewStatusKind.CAP_REACHED:
         line = (
-            f"⚠️ Completed after {_review_pass_phrase(status.passes)} without a fresh "
-            "review of the final commit (`done.max_review_passes` cap reached)."
+            f"⚠️ Completed with {_review_pass_phrase(status.passes)}; the final commit "
+            "was not freshly reviewed (`done.max_review_passes` cap reached)."
         )
     elif kind is ReviewStatusKind.REQUIRE_OFF:
         # The leading info emoji is intentional PR-body markdown, not an identifier.
-        line = "ℹ️ Review gate disabled (`done.require_review: false`)."  # noqa: RUF001
+        line = (
+            "ℹ️ Review gate disabled (`done.require_review: false`); "  # noqa: RUF001
+            "the final commit was not reviewed."
+        )
         if status.passes > 0:
-            line += f" {_review_pass_phrase(status.passes)} before the gate was disabled."
+            line += f" {_review_pass_phrase(status.passes).capitalize()}."
     elif kind is ReviewStatusKind.DISABLED:
-        line = "ℹ️ Review gate disabled (`review_implementation.enabled: false`)."  # noqa: RUF001
+        line = (
+            "ℹ️ Review gate disabled (`review_implementation.enabled: false`); "  # noqa: RUF001
+            "the final commit was not reviewed."
+        )
         if status.passes > 0:
-            line += f" {_review_pass_phrase(status.passes)} before the gate was disabled."
+            line += f" {_review_pass_phrase(status.passes).capitalize()}."
     else:  # NOT_REVIEWED — rendering fallback (the gate would normally have refused).
         if status.passes > 0:
             line = f"⚠️ {_review_pass_phrase(status.passes)}, but the final commit was not reviewed."

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -26,8 +26,8 @@ notice) instead of looping — break a stuck loop with `wade implementation-sess
 done --skip-review`.
 
 **Skipping review is visible.** `done` records the outcome (reviewed / skipped /
-gate-disabled) with the pass count as a `## Review Status` line in the PR body, so
-`--skip-review` is not a silent shortcut.
+gate-disabled / cap-reached) with the pass count as a `## Review Status` line in
+the PR body, so `--skip-review` is not a silent shortcut.
 
 **This step is mandatory when `review_implementation.enabled` is not `false`.
 Do NOT proceed to Step 2 until this step is complete and any actionable

--- a/templates/skills/_partials/review-implementation-closing-step.md
+++ b/templates/skills/_partials/review-implementation-closing-step.md
@@ -25,6 +25,10 @@ marker); major findings, re-run once. Once spent, `done` completes anyway (with 
 notice) instead of looping — break a stuck loop with `wade implementation-session
 done --skip-review`.
 
+**Skipping review is visible.** `done` records the outcome (reviewed / skipped /
+gate-disabled) with the pass count as a `## Review Status` line in the PR body, so
+`--skip-review` is not a silent shortcut.
+
 **This step is mandatory when `review_implementation.enabled` is not `false`.
 Do NOT proceed to Step 2 until this step is complete and any actionable
 findings are addressed and committed.**

--- a/templates/skills/review-pr-comments-session/SKILL.md
+++ b/templates/skills/review-pr-comments-session/SKILL.md
@@ -155,6 +155,11 @@ it fails, debug and fix it — do NOT bypass.
 - `wade review implementation` has not run for the current commit → run it, or
   pass `--skip-review`. Hatch: `done.require_review: false`.
 
+`done` also records the review outcome as a `## Review Status` line in the PR body
+(reviewed at `<sha>` / skipped via `--skip-review` / gate disabled), with the
+review-pass count — so a skipped or never-run review is visible to reviewers, not
+silent.
+
 A **pre-push git hook** refuses a push of the session branch without a current
 `.wade/done@<sha>` marker (`done` writes it). `git push --no-verify` bypasses it
 in one flag — it is a quality layer, not a boundary; do not route around it.

--- a/tests/e2e/test_implement_work_done_contract.py
+++ b/tests/e2e/test_implement_work_done_contract.py
@@ -380,6 +380,13 @@ class TestWorkDoneCommand:
         assert "safety limit reached" in out2
         assert _remote_has_branch(origin_repo, branch_name)
 
+        # #367: completing at the cap without a fresh review is recorded in the PR
+        # body as a cap-reached note, not a clean "reviewed" line.
+        body = _pr_body_for_branch(mock_gh_cli["state_file"], branch_name)
+        assert "<!-- wade:review-status:start -->" in body
+        assert "cap reached" in body
+        assert "✅ Reviewed" not in body
+
     def test_review_pass_count_survives_second_implement(
         self,
         e2e_repo: Path,
@@ -464,3 +471,160 @@ class TestWorkDoneCommand:
         assert "git rm --cached .claude/skills/implementation-session/SKILL.md" in output
         assert _count_gh_calls(mock_gh_cli["log_file"], ["pr", "edit"]) == 0
         assert _count_gh_calls(mock_gh_cli["log_file"], ["pr", "ready"]) == 0
+
+
+def _pr_body_for_branch(state_file: Path, branch_name: str) -> str:
+    """Return the stored PR body for the given head branch from mock gh state."""
+    pr_number = _find_mock_pr_number_by_head(state_file, branch_name)
+    state_data = json.loads(state_file.read_text(encoding="utf-8"))
+    prs = state_data.get("prs", {})
+    assert isinstance(prs, dict)
+    pr_data = prs.get(pr_number)
+    assert isinstance(pr_data, dict)
+    return str(pr_data.get("body", ""))
+
+
+class TestReviewStatusBlockContract:
+    """#367: `done` projects the review status into the durable PR body.
+
+    Complements the unit tests (pure classifier + renderer) by exercising the
+    config wiring end to end — the ``done.require_review``/``--skip-review``/
+    reviewed-marker paths all reach the PR body a human reviewer actually sees.
+    """
+
+    _MARKER = "<!-- wade:review-status:start -->"
+
+    def _bootstrap(
+        self,
+        e2e_repo: Path,
+        mock_gh_cli: MockGhCli,
+        issue_number: int,
+        issue_title: str,
+    ) -> tuple[Path, str]:
+        """implement → worktree → PR-SUMMARY + one impl commit. Returns (wt, branch)."""
+        _seed_mock_issue(
+            mock_gh_cli["state_file"],
+            issue_number=issue_number,
+            title=issue_title,
+            body="## Tasks\n- Do the work\n",
+        )
+        _init_origin_remote(e2e_repo)
+
+        start_result = _run(["implement", str(issue_number), "--cd"], cwd=e2e_repo)
+        assert start_result.returncode == 0, start_result.stdout + start_result.stderr
+        worktree_path = Path(start_result.stdout.strip())
+        assert worktree_path.is_dir()
+
+        (worktree_path / "PR-SUMMARY.md").write_text(
+            "Implemented the change and validated behavior.\n", encoding="utf-8"
+        )
+        (worktree_path / "impl.txt").write_text("work\n", encoding="utf-8")
+        _git(["add", "-A"], cwd=worktree_path)
+        _git(["commit", "-m", f"feat: complete #{issue_number}"], cwd=worktree_path)
+
+        branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=worktree_path).stdout.strip()
+        return worktree_path, branch
+
+    def test_skip_review_records_skip_notice_in_pr_body(
+        self,
+        e2e_repo: Path,
+        mock_gh_cli: MockGhCli,
+    ) -> None:
+        """A deliberate --skip-review bypass is visible in the PR body (#367)."""
+        worktree_path, branch = self._bootstrap(
+            e2e_repo, mock_gh_cli, 361, "fix: record the review skip"
+        )
+
+        result = _run(["implementation-session", "done", "--skip-review"], cwd=worktree_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        body = _pr_body_for_branch(mock_gh_cli["state_file"], branch)
+        assert self._MARKER in body
+        assert "Review skipped" in body
+        assert "--skip-review" in body
+
+    def test_reviewed_run_records_reviewed_line_in_pr_body(
+        self,
+        e2e_repo: Path,
+        mock_gh_cli: MockGhCli,
+    ) -> None:
+        """A normal reviewed run shows a "Reviewed at <sha>" line (#367)."""
+        worktree_path, branch = self._bootstrap(
+            e2e_repo, mock_gh_cli, 362, "fix: record the reviewed status"
+        )
+
+        # A real self-review pass (default prompt mode, exit 2) writes the
+        # sha-keyed reviewed@<HEAD> marker the done gate later reads.
+        review = _run(["review", "implementation"], cwd=worktree_path)
+        assert review.returncode == 2, review.stdout + review.stderr
+        head = _git(["rev-parse", "HEAD"], cwd=worktree_path).stdout.strip()
+
+        result = _run(["implementation-session", "done"], cwd=worktree_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        body = _pr_body_for_branch(mock_gh_cli["state_file"], branch)
+        assert self._MARKER in body
+        assert f"Reviewed at `{head[:7]}`" in body
+
+    def test_require_review_disabled_records_gate_disabled_note(
+        self,
+        e2e_repo: Path,
+        mock_gh_cli: MockGhCli,
+    ) -> None:
+        """`done.require_review: false` surfaces a "review gate disabled" note (#367).
+
+        Exercises the config wiring end to end (not just the pure classifier): the
+        toggle is set in the project config the worktree inherits, and done — with
+        no review run at all — still records why the gate did not apply.
+        """
+        config_path = e2e_repo / ".wade.yml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8") + "\ndone:\n  require_review: false\n",
+            encoding="utf-8",
+        )
+
+        worktree_path, branch = self._bootstrap(
+            e2e_repo, mock_gh_cli, 363, "fix: reflect the disabled review gate"
+        )
+
+        result = _run(["implementation-session", "done"], cwd=worktree_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        body = _pr_body_for_branch(mock_gh_cli["state_file"], branch)
+        assert self._MARKER in body
+        assert "Review gate disabled" in body
+        assert "done.require_review: false" in body
+
+    def test_reviews_disabled_records_gate_disabled_note(
+        self,
+        e2e_repo: Path,
+        mock_gh_cli: MockGhCli,
+    ) -> None:
+        """`ai.review_implementation.enabled: false` surfaces the gate-disabled note (#367).
+
+        Distinct config path from `done.require_review: false`: reviews are off
+        project-wide, so the review-ran gate auto-skips — done still records *why*
+        (the `review_implementation.enabled: false` wording) in the PR body.
+        """
+        config_path = e2e_repo / ".wade.yml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8").replace(
+                "ai:\n  default_tool: claude\n",
+                "ai:\n  default_tool: claude\n  review_implementation:\n    enabled: false\n",
+            ),
+            encoding="utf-8",
+        )
+        # Guard against a silent replace-miss producing a confusing downstream fail.
+        assert "review_implementation:" in config_path.read_text(encoding="utf-8")
+
+        worktree_path, branch = self._bootstrap(
+            e2e_repo, mock_gh_cli, 364, "fix: reflect reviews disabled"
+        )
+
+        result = _run(["implementation-session", "done"], cwd=worktree_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        body = _pr_body_for_branch(mock_gh_cli["state_file"], branch)
+        assert self._MARKER in body
+        assert "Review gate disabled" in body
+        assert "review_implementation.enabled: false" in body

--- a/tests/integration/test_skill_context_budget.py
+++ b/tests/integration/test_skill_context_budget.py
@@ -25,9 +25,14 @@ from wade.skills.installer import (
 # Bumped 8000 -> 8200 for #392: the implementation-session skill gained a short,
 # load-bearing note that the issue title (and thus the derived PR title) must be
 # conventional-commit format — code now enforces this at `done`, and the note
-# tells the agent how to react. The guard still catches *silent* regressions;
-# this bump is the explicit, reviewed adjustment it is designed to force.
-BUDGET_CHARS = 8200
+# tells the agent how to react.
+# Bumped 8200 -> 8400 for #367: `done` now records the review outcome (reviewed /
+# skipped / gate-disabled, with the pass count) as a `## Review Status` block in
+# the PR body, and the closing-step partial gained a short, load-bearing note that
+# `--skip-review` is therefore visible, not a silent shortcut. The guard still
+# catches *silent* regressions; this bump is the explicit, reviewed adjustment it
+# is designed to force.
+BUDGET_CHARS = 8400
 
 # (session label, launch prompt template, phase skill dir name)
 _SESSIONS = [

--- a/tests/unit/test_services/test_review_status_block.py
+++ b/tests/unit/test_services/test_review_status_block.py
@@ -179,7 +179,7 @@ class TestRenderReviewStatus:
     def test_skipped_with_passes_is_attempted_not_never(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.SKIPPED_FLAG, passes=2))
         assert "--skip-review" in out
-        assert "2 review passes recorded" in out
+        assert "2 distinct commits reviewed" in out
         assert "not reviewed" in out
         assert "never ran" not in out
 
@@ -190,26 +190,39 @@ class TestRenderReviewStatus:
 
     def test_skipped_single_pass_is_singular(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.SKIPPED_FLAG, passes=1))
-        assert "1 review pass recorded" in out
+        assert "1 distinct commit reviewed" in out
 
     def test_cap_reached_mentions_cap_and_count(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.CAP_REACHED, passes=2))
         assert "done.max_review_passes" in out
-        assert "2 review passes" in out
+        assert "2 distinct commits reviewed" in out
 
     def test_require_off_note(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.REQUIRE_OFF))
         assert "Review gate disabled" in out
         assert "done.require_review: false" in out
 
+    def test_require_off_with_passes_shows_pass_history(self) -> None:
+        # A gate-disabled outcome must not discard a prior pass history — the
+        # distinction between "review never ran" and "ran, but not for the final
+        # commit" must survive even when the gate itself is off (#367 follow-up).
+        out = _render_review_status(_status(ReviewStatusKind.REQUIRE_OFF, passes=2))
+        assert "Review gate disabled" in out
+        assert "2 distinct commits reviewed" in out
+
     def test_disabled_note(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.DISABLED))
         assert "Review gate disabled" in out
         assert "review_implementation.enabled: false" in out
 
+    def test_disabled_with_passes_shows_pass_history(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.DISABLED, passes=3))
+        assert "Review gate disabled" in out
+        assert "3 distinct commits reviewed" in out
+
     def test_not_reviewed_with_passes(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.NOT_REVIEWED, passes=3))
-        assert "3 review passes recorded" in out
+        assert "3 distinct commits reviewed" in out
         assert "not reviewed" in out
 
     def test_not_reviewed_without_passes(self) -> None:
@@ -223,7 +236,7 @@ class TestRenderReviewStatus:
         out = _render_review_status(
             _status(ReviewStatusKind.SKIPPED_FLAG, passes=2, session_type="review-pr-comments")
         )
-        assert "2 review passes recorded" in out
+        assert "2 distinct commits reviewed" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services/test_review_status_block.py
+++ b/tests/unit/test_services/test_review_status_block.py
@@ -1,0 +1,359 @@
+"""Unit tests for the PR-body review-status block (#367).
+
+Covers the three pieces the feature adds:
+
+- ``_classify_review`` — the single classifier shared by the ``done`` review-ran
+  gate and the PR-body renderer (one source of truth, no branching drift).
+- ``_render_review_status`` — the per-kind line, including the attempted-vs-never
+  distinction and the honest pass count for both session types.
+- The marker-scoped block written into both PR-body paths (existing-PR
+  ``_transform`` and new-PR ``_build_pr_body``): idempotent on re-run and
+  preserving content outside the markers.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from wade.git.pr import PRLookup, PRRef
+from wade.models.config import (
+    AICommandConfig,
+    AIConfig,
+    DoneConfig,
+    ProjectConfig,
+    ProjectSettings,
+)
+from wade.models.task import Task
+from wade.services.implementation_service.done import _classify_review, _done_via_pr
+from wade.services.implementation_service.lifecycle import (
+    REVIEW_STATUS_MARKER_END,
+    REVIEW_STATUS_MARKER_START,
+    ReviewStatus,
+    ReviewStatusKind,
+    _build_pr_body,
+    _render_review_status,
+)
+from wade.services.implementation_service.usage_tracking import (
+    IMPL_USAGE_MARKER_END,
+    IMPL_USAGE_MARKER_START,
+)
+from wade.utils import markers
+
+_DONE = "wade.services.implementation_service.done"
+
+
+# ---------------------------------------------------------------------------
+# _classify_review — one kind per branch, mirroring the gate's short-circuit order
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyReview:
+    def test_reviewed_when_exact_sha_marker_present(self, tmp_path: Path) -> None:
+        markers.write_marker(tmp_path, "reviewed", "head")
+        status = _classify_review(ProjectConfig(), tmp_path, "head", skip_review=False)
+        assert status.kind is ReviewStatusKind.REVIEWED
+        assert status.reviewed_sha == "head"
+
+    def test_skip_flag(self, tmp_path: Path) -> None:
+        status = _classify_review(ProjectConfig(), tmp_path, "head", skip_review=True)
+        assert status.kind is ReviewStatusKind.SKIPPED_FLAG
+
+    def test_require_off(self, tmp_path: Path) -> None:
+        config = ProjectConfig(done=DoneConfig(require_review=False))
+        status = _classify_review(config, tmp_path, "head", skip_review=False)
+        assert status.kind is ReviewStatusKind.REQUIRE_OFF
+
+    def test_disabled(self, tmp_path: Path) -> None:
+        config = ProjectConfig(ai=AIConfig(review_implementation=AICommandConfig(enabled=False)))
+        status = _classify_review(config, tmp_path, "head", skip_review=False)
+        assert status.kind is ReviewStatusKind.DISABLED
+
+    def test_cap_reached_impl_only(self, tmp_path: Path) -> None:
+        markers.record_review_pass(tmp_path, "sha1")
+        markers.record_review_pass(tmp_path, "sha2")  # cap (default 2) reached
+        status = _classify_review(
+            ProjectConfig(), tmp_path, "newhead", skip_review=False, session_type="implementation"
+        )
+        assert status.kind is ReviewStatusKind.CAP_REACHED
+        assert status.passes == 2
+
+    def test_not_reviewed_before_cap(self, tmp_path: Path) -> None:
+        markers.record_review_pass(tmp_path, "sha1")  # 1 < cap 2
+        status = _classify_review(
+            ProjectConfig(), tmp_path, "newhead", skip_review=False, session_type="implementation"
+        )
+        assert status.kind is ReviewStatusKind.NOT_REVIEWED
+        assert status.passes == 1
+
+    def test_review_pr_comments_never_caps(self, tmp_path: Path) -> None:
+        # The cap is impl-only: even past the limit, review-pr-comments classifies
+        # as NOT_REVIEWED (the gate then plainly refuses), never CAP_REACHED.
+        markers.record_review_pass(tmp_path, "sha1")
+        markers.record_review_pass(tmp_path, "sha2")
+        status = _classify_review(
+            ProjectConfig(),
+            tmp_path,
+            "newhead",
+            skip_review=False,
+            session_type="review-pr-comments",
+        )
+        assert status.kind is ReviewStatusKind.NOT_REVIEWED
+        assert status.passes == 2
+
+    def test_disabled_precedes_skip_flag(self, tmp_path: Path) -> None:
+        # Short-circuit order mirrors the gate: reviews-disabled wins over the
+        # --skip-review hatch when both are true.
+        config = ProjectConfig(ai=AIConfig(review_implementation=AICommandConfig(enabled=False)))
+        status = _classify_review(config, tmp_path, "head", skip_review=True)
+        assert status.kind is ReviewStatusKind.DISABLED
+
+    def test_carries_session_type_and_passes(self, tmp_path: Path) -> None:
+        markers.record_review_pass(tmp_path, "sha1")
+        status = _classify_review(
+            ProjectConfig(), tmp_path, "abc1234def", skip_review=True, session_type="implementation"
+        )
+        assert status.session_type == "implementation"
+        assert status.passes == 1
+        assert status.reviewed_sha == "abc1234def"
+
+    def test_is_frozen(self, tmp_path: Path) -> None:
+        status = _classify_review(ProjectConfig(), tmp_path, "head", skip_review=True)
+        try:
+            status.passes = 99  # type: ignore[misc]
+        except (TypeError, ValueError, AttributeError):
+            return
+        raise AssertionError("ReviewStatus should be immutable (frozen)")
+
+
+# ---------------------------------------------------------------------------
+# _render_review_status — per-kind line
+# ---------------------------------------------------------------------------
+
+
+def _status(
+    kind: ReviewStatusKind,
+    *,
+    passes: int = 0,
+    session_type: str = "implementation",
+    sha: str = "abc1234def567",
+) -> ReviewStatus:
+    return ReviewStatus(kind=kind, passes=passes, session_type=session_type, reviewed_sha=sha)
+
+
+class TestRenderReviewStatus:
+    def test_reviewed_shows_short_sha(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.REVIEWED, sha="abc1234def567"))
+        assert "## Review Status" in out
+        assert "✅ Reviewed at `abc1234`" in out  # 7-char short sha
+        assert "wade review implementation" in out
+
+    def test_skipped_with_passes_is_attempted_not_never(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.SKIPPED_FLAG, passes=2))
+        assert "--skip-review" in out
+        assert "2 review passes recorded" in out
+        assert "not reviewed" in out
+        assert "never ran" not in out
+
+    def test_skipped_without_passes_is_never_tried(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.SKIPPED_FLAG, passes=0))
+        assert "--skip-review" in out
+        assert "never ran" in out
+
+    def test_skipped_single_pass_is_singular(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.SKIPPED_FLAG, passes=1))
+        assert "1 review pass recorded" in out
+
+    def test_cap_reached_mentions_cap_and_count(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.CAP_REACHED, passes=2))
+        assert "done.max_review_passes" in out
+        assert "2 review passes" in out
+
+    def test_require_off_note(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.REQUIRE_OFF))
+        assert "Review gate disabled" in out
+        assert "done.require_review: false" in out
+
+    def test_disabled_note(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.DISABLED))
+        assert "Review gate disabled" in out
+        assert "review_implementation.enabled: false" in out
+
+    def test_not_reviewed_with_passes(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.NOT_REVIEWED, passes=3))
+        assert "3 review passes recorded" in out
+        assert "not reviewed" in out
+
+    def test_not_reviewed_without_passes(self) -> None:
+        out = _render_review_status(_status(ReviewStatusKind.NOT_REVIEWED, passes=0))
+        assert "never ran" in out
+
+    def test_pass_count_rendered_for_review_pr_comments_session(self) -> None:
+        # The pass count is honest for BOTH session types (review-pr-comments can
+        # accrue review passes too — the earlier "always 0 there" premise was
+        # false). A skipped review-pr-comments session with passes still shows them.
+        out = _render_review_status(
+            _status(ReviewStatusKind.SKIPPED_FLAG, passes=2, session_type="review-pr-comments")
+        )
+        assert "2 review passes recorded" in out
+
+
+# ---------------------------------------------------------------------------
+# New-PR fallback path — _build_pr_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrBodyReviewStatus:
+    def test_no_block_when_review_status_absent(self) -> None:
+        # Backward compatible: callers that omit review_status get no block.
+        body = _build_pr_body(Task(id="42", title="feat: x"))
+        assert REVIEW_STATUS_MARKER_START not in body
+
+    def test_block_added_after_summary(self, tmp_path: Path) -> None:
+        pr_summary = tmp_path / "PR-SUMMARY.md"
+        pr_summary.write_text("Did the work.\n")
+        body = _build_pr_body(
+            Task(id="42", title="feat: x"),
+            pr_summary_path=pr_summary,
+            review_status=_status(ReviewStatusKind.REVIEWED, sha="deadbeefcafe"),
+        )
+        assert REVIEW_STATUS_MARKER_START in body
+        assert REVIEW_STATUS_MARKER_END in body
+        assert "✅ Reviewed at `deadbee`" in body
+        # Order: Closes → Summary → Review Status
+        assert body.find("Closes #42") < body.find("## Summary") < body.find("## Review Status")
+
+    def test_block_present_even_without_summary(self, tmp_path: Path) -> None:
+        # A skipped review with no PR-SUMMARY still records the skip in the body.
+        body = _build_pr_body(
+            Task(id="42", title="feat: x"),
+            review_status=_status(ReviewStatusKind.SKIPPED_FLAG, passes=0),
+        )
+        assert REVIEW_STATUS_MARKER_START in body
+        assert "Review skipped" in body
+
+
+# ---------------------------------------------------------------------------
+# Existing-PR path — _transform inside _done_via_pr
+# ---------------------------------------------------------------------------
+
+
+def _run_done_via_pr(
+    tmp_path: Path,
+    *,
+    starting_body: str,
+    review_status: ReviewStatus,
+) -> str:
+    """Drive _done_via_pr against an OPEN, non-draft PR; return the written body."""
+    worktree_path = tmp_path / "wt-42"
+    worktree_path.mkdir(exist_ok=True)
+    (worktree_path / "PR-SUMMARY.md").write_text("Real summary of the work.\n")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(exist_ok=True)
+
+    task = Task(id="42", title="feat: proper title", body="## Tasks\n- x\n")
+    config = ProjectConfig(project=ProjectSettings(main_branch="main"))
+    lookup = PRLookup(
+        found=True,
+        pr=PRRef(
+            number=7,
+            url="https://github.com/test/pull/7",
+            title="feat: proper title",  # matches issue → no title sync
+            state="OPEN",
+            isDraft=False,
+        ),
+    )
+    captured: dict[str, str] = {}
+
+    with ExitStack() as stack:
+        mock_get_provider = stack.enter_context(patch(f"{_DONE}.get_provider"))
+        stack.enter_context(patch(f"{_DONE}._push_branch_with_recovery", return_value=True))
+        stack.enter_context(patch(f"{_DONE}.git_pr.get_pr_for_branch", return_value=lookup))
+        stack.enter_context(patch(f"{_DONE}.git_pr.get_pr_body", return_value=starting_body))
+
+        def _capture(_repo: Path, _num: int, body: str) -> bool:
+            captured["body"] = body
+            return True
+
+        stack.enter_context(patch(f"{_DONE}.git_pr.update_pr_body", side_effect=_capture))
+        stack.enter_context(patch(f"{_DONE}.remove_in_progress_label"))
+
+        provider = MagicMock()
+        provider.read_task.return_value = task
+        provider.find_parent_issue.return_value = None
+        mock_get_provider.return_value = provider
+
+        result = _done_via_pr(
+            repo_root=repo_root,
+            branch="feat/42-x",
+            issue_number="42",
+            main_branch="main",
+            close_issue=True,
+            draft=False,
+            config=config,
+            worktree_path=worktree_path,
+            review_status=review_status,
+        )
+    assert result is True
+    return captured["body"]
+
+
+class TestReviewStatusBlockExistingPr:
+    def test_block_written_and_preserves_outside_content(self, tmp_path: Path) -> None:
+        starting = "Implements #42\n\nA reviewer's concurrent note.\n"
+        body = _run_done_via_pr(
+            tmp_path,
+            starting_body=starting,
+            review_status=_status(ReviewStatusKind.SKIPPED_FLAG, passes=0),
+        )
+        assert REVIEW_STATUS_MARKER_START in body
+        assert "Review skipped" in body
+        # Content outside wade's markers survives.
+        assert "A reviewer's concurrent note." in body
+
+    def test_block_before_impl_usage(self, tmp_path: Path) -> None:
+        starting = (
+            "Implements #42\n\n"
+            f"{IMPL_USAGE_MARKER_START}\n## Token Usage (Implementation)\n{IMPL_USAGE_MARKER_END}\n"
+        )
+        body = _run_done_via_pr(
+            tmp_path,
+            starting_body=starting,
+            review_status=_status(ReviewStatusKind.REVIEWED, sha="abc1234def"),
+        )
+        # Ordering: summary → review-status → impl-usage.
+        assert body.find("## Summary") < body.find("## Review Status")
+        assert body.find("## Review Status") < body.find(IMPL_USAGE_MARKER_START)
+
+    def test_idempotent_on_rerun(self, tmp_path: Path) -> None:
+        # Re-running done replaces its own block in place — never duplicates it.
+        first = _run_done_via_pr(
+            tmp_path,
+            starting_body="Implements #42\n\nkeep me\n",
+            review_status=_status(ReviewStatusKind.REVIEWED, sha="abc1234def"),
+        )
+        second = _run_done_via_pr(
+            tmp_path,
+            starting_body=first,
+            review_status=_status(ReviewStatusKind.REVIEWED, sha="abc1234def"),
+        )
+        assert second.count(REVIEW_STATUS_MARKER_START) == 1
+        assert second.count(REVIEW_STATUS_MARKER_END) == 1
+        assert "keep me" in second
+
+    def test_rerun_updates_status_line(self, tmp_path: Path) -> None:
+        # A second done with a different outcome replaces the line (not appends).
+        first = _run_done_via_pr(
+            tmp_path,
+            starting_body="Implements #42\n\nkeep me\n",
+            review_status=_status(ReviewStatusKind.REVIEWED, sha="abc1234def"),
+        )
+        second = _run_done_via_pr(
+            tmp_path,
+            starting_body=first,
+            review_status=_status(ReviewStatusKind.SKIPPED_FLAG, passes=1),
+        )
+        assert second.count(REVIEW_STATUS_MARKER_START) == 1
+        assert "Review skipped" in second
+        assert "✅ Reviewed" not in second

--- a/tests/unit/test_services/test_review_status_block.py
+++ b/tests/unit/test_services/test_review_status_block.py
@@ -179,7 +179,7 @@ class TestRenderReviewStatus:
     def test_skipped_with_passes_is_attempted_not_never(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.SKIPPED_FLAG, passes=2))
         assert "--skip-review" in out
-        assert "2 distinct commits reviewed" in out
+        assert "review attempted on 2 distinct commits" in out
         assert "not reviewed" in out
         assert "never ran" not in out
 
@@ -190,17 +190,18 @@ class TestRenderReviewStatus:
 
     def test_skipped_single_pass_is_singular(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.SKIPPED_FLAG, passes=1))
-        assert "1 distinct commit reviewed" in out
+        assert "review attempted on 1 distinct commit" in out
 
     def test_cap_reached_mentions_cap_and_count(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.CAP_REACHED, passes=2))
         assert "done.max_review_passes" in out
-        assert "2 distinct commits reviewed" in out
+        assert "review attempted on 2 distinct commits" in out
 
     def test_require_off_note(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.REQUIRE_OFF))
         assert "Review gate disabled" in out
         assert "done.require_review: false" in out
+        assert "final commit was not reviewed" in out
 
     def test_require_off_with_passes_shows_pass_history(self) -> None:
         # A gate-disabled outcome must not discard a prior pass history — the
@@ -208,21 +209,27 @@ class TestRenderReviewStatus:
         # commit" must survive even when the gate itself is off (#367 follow-up).
         out = _render_review_status(_status(ReviewStatusKind.REQUIRE_OFF, passes=2))
         assert "Review gate disabled" in out
-        assert "2 distinct commits reviewed" in out
+        assert "final commit was not reviewed" in out
+        assert "Review attempted on 2 distinct commits" in out
+        # No invented chronology — marker files carry no config-change timestamp.
+        assert "before the gate was disabled" not in out
 
     def test_disabled_note(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.DISABLED))
         assert "Review gate disabled" in out
         assert "review_implementation.enabled: false" in out
+        assert "final commit was not reviewed" in out
 
     def test_disabled_with_passes_shows_pass_history(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.DISABLED, passes=3))
         assert "Review gate disabled" in out
-        assert "3 distinct commits reviewed" in out
+        assert "final commit was not reviewed" in out
+        assert "Review attempted on 3 distinct commits" in out
+        assert "before the gate was disabled" not in out
 
     def test_not_reviewed_with_passes(self) -> None:
         out = _render_review_status(_status(ReviewStatusKind.NOT_REVIEWED, passes=3))
-        assert "3 distinct commits reviewed" in out
+        assert "review attempted on 3 distinct commits" in out
         assert "not reviewed" in out
 
     def test_not_reviewed_without_passes(self) -> None:
@@ -236,7 +243,7 @@ class TestRenderReviewStatus:
         out = _render_review_status(
             _status(ReviewStatusKind.SKIPPED_FLAG, passes=2, session_type="review-pr-comments")
         )
-        assert "2 distinct commits reviewed" in out
+        assert "review attempted on 2 distinct commits" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services/test_review_status_block.py
+++ b/tests/unit/test_services/test_review_status_block.py
@@ -32,6 +32,7 @@ from wade.services.implementation_service.lifecycle import (
     REVIEW_STATUS_MARKER_START,
     ReviewStatus,
     ReviewStatusKind,
+    SessionType,
     _build_pr_body,
     _render_review_status,
 )
@@ -109,6 +110,30 @@ class TestClassifyReview:
         status = _classify_review(config, tmp_path, "head", skip_review=True)
         assert status.kind is ReviewStatusKind.DISABLED
 
+    def test_reviewed_precedes_skip_flag(self, tmp_path: Path) -> None:
+        # The exact-sha marker is positive evidence and outranks the hatches: a
+        # commit that was actually reviewed must report REVIEWED even when
+        # --skip-review was also passed on this run (#367).
+        markers.write_marker(tmp_path, "reviewed", "head")
+        status = _classify_review(ProjectConfig(), tmp_path, "head", skip_review=True)
+        assert status.kind is ReviewStatusKind.REVIEWED
+
+    def test_reviewed_precedes_require_off(self, tmp_path: Path) -> None:
+        # A project that permanently sets require_review: false must still
+        # report REVIEWED for a commit that was actually reviewed.
+        markers.write_marker(tmp_path, "reviewed", "head")
+        config = ProjectConfig(done=DoneConfig(require_review=False))
+        status = _classify_review(config, tmp_path, "head", skip_review=False)
+        assert status.kind is ReviewStatusKind.REVIEWED
+
+    def test_reviewed_precedes_disabled(self, tmp_path: Path) -> None:
+        # Even with reviews disabled in config, a genuinely-present marker for
+        # this exact sha must still report REVIEWED, not DISABLED.
+        markers.write_marker(tmp_path, "reviewed", "head")
+        config = ProjectConfig(ai=AIConfig(review_implementation=AICommandConfig(enabled=False)))
+        status = _classify_review(config, tmp_path, "head", skip_review=False)
+        assert status.kind is ReviewStatusKind.REVIEWED
+
     def test_carries_session_type_and_passes(self, tmp_path: Path) -> None:
         markers.record_review_pass(tmp_path, "sha1")
         status = _classify_review(
@@ -136,10 +161,12 @@ def _status(
     kind: ReviewStatusKind,
     *,
     passes: int = 0,
-    session_type: str = "implementation",
+    session_type: SessionType | str = SessionType.IMPLEMENTATION,
     sha: str = "abc1234def567",
 ) -> ReviewStatus:
-    return ReviewStatus(kind=kind, passes=passes, session_type=session_type, reviewed_sha=sha)
+    return ReviewStatus(
+        kind=kind, passes=passes, session_type=SessionType(session_type), reviewed_sha=sha
+    )
 
 
 class TestRenderReviewStatus:


### PR DESCRIPTION
Closes #367

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem

Issue #367's core correctness hole — `done` being unable to tell a clean review
from one that never ran — is already fixed. `done` now runs a code-enforced
`_gate_review_ran` gate (`services/implementation_service/done.py:515`) keyed to a
per-SHA `reviewed@<HEAD>` marker, with a bounded review-pass cap (#384). Two
**legibility** gaps remain, and both resolve to the *same* missing mechanism:

1. **A deliberate `--skip-review` bypass is invisible to humans.** `skip_review`
   is threaded into the gate (`done.py:548`) but stops there. `_done_via_pr` — the
   only place the PR body is written — never learns review was bypassed, so a
   human reviewer cannot see that review was intentionally skipped. This is an
   **unmet acceptance criterion** of #367.

2. **Failure/attempt history is not legible.** The review artifacts
   (`reviewed@<sha>`, `review-pass@<sha>`) are zero-byte, **worktree-local**, and
   discarded at session end — no human ever sees them. So in the durable artifact
   (the PR), "attempted twice, timed out twice" is indistinguishable from "never
   tried."

The key insight: the **durable, human-legible artifact is the PR body**, not the
`.wade/` markers. Everything needed to make review status legible is already
derivable at finalize time — `markers.marker_present("reviewed", head)` (did a
review pass for the final commit?) and `markers.count_review_passes()` (how many
distinct commits were reviewed?). Both remaining items are therefore a single
change: **project review status into the PR body** as a new marker-bounded block.

Decision (confirmed with the user during planning):
- **One combined issue** — both items edit the same code path (`_done_via_pr`, its
  `_transform`, and `done()` threading) and share the same block, tests, and skill
  updates; splitting them would churn the same block twice.
- **Keep the existing zero-byte markers as storage** (no separate on-disk JSON
  receipt). Make outcomes legible by projecting them into the PR body. This
  satisfies the acceptance target with minimal change.

## Proposed Solution

Add a `wade:review-status` marker-bounded block to the PR body, written by `done`
at finalize, that records the review outcome for the pushed commit.

### 1. Resolve a single "review status" value (no logic drift)

Extract the gate's decision into one pure, side-effect-free classifier so the gate
and the PR-body writer share a single source of truth (avoid re-deriving the
branching in two places):

```
_classify_review(config, worktree_root, head_sha, skip_review, session_type)
    -> ReviewStatus            # a single frozen dataclass, see below
```

Return **one** frozen dataclass `ReviewStatus` bundling everything the gate and
the renderer need, so a single object flows through
`_gate_review_ran` → `done()` → `_done_via_pr` → renderer (no three-positional-arg
drift — per review feedback):

```
@dataclass(frozen=True)
class ReviewStatus:
    kind: ReviewStatusKind      # StrEnum, values below
    passes: int                 # count_review_passes() — see rendering note in §2
    session_type: str           # "implementation" | "review-pr-comments"
    reviewed_sha: str           # the pre-sync HEAD the agent reviewed (for display)
```

`ReviewStatusKind` (StrEnum) captures the outcome:
- `REVIEWED`         — `reviewed@head_sha` present (review passed for this commit)
- `SKIPPED_FLAG`     — `--skip-review` passed
- `REQUIRE_OFF`      — `done.require_review: false`
- `DISABLED`         — `review_implementation.enabled: false`
- `CAP_REACHED`      — impl-only; `count_review_passes() >= done.max_review_passes`
  with no `reviewed@head`
- `NOT_REVIEWED`     — gate would refuse (only reachable if `done` proceeds anyway;
  primarily a rendering fallback)

- Refactor `_gate_review_ran` to decide pass/refuse **from** `_classify_review(...).kind`
  (keeping all current console messages and behaviour identical — this is a
  no-behaviour-change refactor of the gate).
- In `done()`, after gates pass and using the **same `pre_sync_head`** the gate
  used (the SHA the agent actually reviewed — sync may advance HEAD afterward),
  call `_classify_review` again (cheap, idempotent marker reads) and pass the
  resulting `ReviewStatus` object into `_done_via_pr`.

### 2. Write the review-status block into the PR body

**Helper module locations (verified — do not look for these in the wrong file):**
- `SUMMARY_MARKER_START/END` live in `implementation_service/lifecycle.py` — add
  the new `REVIEW_STATUS_MARKER_START/END` constants there too.
- `IMPL_USAGE_MARKER_START/END` live in `implementation_service/usage_tracking.py`
  (not `lifecycle.py`).
- `build_marked_block`, `upsert_marked_block`, `update_body_preserving_markers`,
  `enforce_body_budget` live in `utils/body_markers.py`.
- `remove_marker_block`, `extract_marker_block` live in `utils/markdown.py`.

Steps:
- Add `REVIEW_STATUS_MARKER_START` / `REVIEW_STATUS_MARKER_END`
  (`<!-- wade:review-status:start -->` / `:end -->`) alongside `SUMMARY_MARKER_*`
  in `lifecycle.py`.
- Add a small renderer `_render_review_status(status: ReviewStatus) -> str` (takes
  the single dataclass) producing a one/two-line block, e.g.:
  - REVIEWED: `✅ Reviewed at \`<short-sha>\` via \`wade review implementation\`.`
  - SKIPPED_FLAG: `⚠️ Review skipped (\`--skip-review\`). <N> review pass(es)
    recorded; the final commit was not reviewed.`  ← makes attempted-vs-never legible
  - CAP_REACHED: `⚠️ Completed after <N> review pass(es) without a fresh review of
    the final commit (\`done.max_review_passes\` cap reached).`
  - REQUIRE_OFF / DISABLED: `ℹ️ Review gate disabled (\`done.require_review: false\`
    / \`review_implementation.enabled: false\`).`
- **Pass-count rendering (corrected):** `review-pass@*` markers are written by
  `_record_review_pass()` inside `wade review implementation` **regardless of
  session type**, and the review-pr-comments skill tells the agent to run that
  command when its review-ran gate fails — so a review-pr-comments session *can*
  have a nonzero pass count (the earlier "always 0 there" premise was false).
  Therefore: **render `<N> review pass(es) recorded` whenever `passes > 0` for
  both session types.** Only the `CAP_REACHED` *status* is implementation-only
  (only implementation sessions apply the `done.max_review_passes` cap); the raw
  attempt count is meaningful and honest to show in either session.
- Insert the block in **both** PR-body paths, marker-scoped so a concurrent edit
  outside the markers survives (reuse the `build_marked_block` /
  `remove_marker_block` / `update_body_preserving_markers` flow already used for
  the summary block):
  - existing-PR path: extend `_transform` in `_done_via_pr` to upsert the
    review-status block, placed adjacent to the summary block and **before** the
    impl-usage table (`IMPL_USAGE_MARKER_START`). ⚠️ **Verify against `_transform`'s
    actual body first** — confirm inserting a block between the summary and
    impl-usage markers composes with the existing content → summary → usage
    ordering logic rather than assuming it (see Risks).
  - new-PR fallback path: add the block in `_build_pr_body`.
- Idempotent: re-running `done` replaces its own block in place, never
  duplicates it.

### 3. Threading

- Bundle everything into the single `ReviewStatus` object (§1) so only **one** new
  argument crosses the boundary: `done()` → `_done_via_pr(..., review_status=...)`,
  and `_done_via_pr` → `_build_pr_body(..., review_status=...)`. Because
  `ReviewStatus` already carries `session_type`, `passes`, and `reviewed_sha`,
  neither `_done_via_pr` nor `_build_pr_body` needs a separate `session_type`
  parameter — this closes the gap that `_done_via_pr`/`_build_pr_body` currently
  receive no `session_type` while the renderer needs it.
- `_build_pr_body` has exactly **one** caller (`done.py`), verified — adding a
  required `review_status` param is safe (no other call site to break).
- No change to gate exit semantics; the block is purely additive to the PR body.

### Non-goals (explicit)

- **Granular failure reason** ("timed out" vs "errored" vs "found unaddressed
  findings") is NOT recorded — distinguishing those would require the review
  command to persist each attempt's `DelegationResult` outcome, a heavier change.
  The acceptance target is only *attempted-N-times* vs *never-tried*, which the
  pass count + reviewed-status already deliver. Captured as a possible future
  enhancement in Notes.
- No new `.wade/` receipt file or marker format change — markers stay zero-byte;
  the PR body is the receipt.
- No config toggle for the block (it is small and informational, always written).
  Revisit only if it proves noisy.

## Tasks

- [ ] Add the `ReviewStatusKind` StrEnum and the frozen `ReviewStatus` dataclass
      (`kind`, `passes`, `session_type`, `reviewed_sha`), plus a pure
      `_classify_review(...)` helper returning it.
- [ ] Refactor `_gate_review_ran` to decide pass/refuse from `_classify_review(...).kind`
      with **no behaviour change** (identical console output for every branch); the
      existing gate tests must still pass unchanged.
- [ ] In `done()`, compute the `ReviewStatus` after gates pass — using the same
      `pre_sync_head` the gate used — and thread the single object into `_done_via_pr`.
- [ ] Thread `review_status` into `_done_via_pr` and (as a required param) into
      `_build_pr_body`; confirm `_build_pr_body`'s single caller is the only one.
      (No separate `session_type` param — it rides inside `ReviewStatus`.)
- [ ] Add `REVIEW_STATUS_MARKER_START` / `_END` constants in `lifecycle.py`
      (alongside `SUMMARY_MARKER_*`).
- [ ] Add `_render_review_status(status: ReviewStatus) -> str`; render the
      pass-count line whenever `passes > 0` for **both** session types, and gate
      the `CAP_REACHED` wording to implementation sessions only.
- [ ] **Verify `_transform`'s actual body** handles a block inserted between the
      summary and impl-usage markers, then write the marker-scoped block in both
      `_done_via_pr` paths (existing-PR `_transform` + new-PR `_build_pr_body`),
      idempotent on re-run.
- [ ] Unit tests: `_classify_review` returns the right `kind` for each branch
      (reviewed / skip-flag / require-off / disabled / cap-reached / not-reviewed);
      renderer output per kind (incl. `passes > 0` in a review-pr-comments session);
      block upsert is idempotent and preserves content outside the markers in both
      PR-body paths.
- [ ] E2E contract tests (`./scripts/test-e2e.sh`): (a) `done --skip-review` leaves
      a skip notice in the PR body; (b) a normal reviewed run shows the "Reviewed at
      <sha>" line; (c) a config-disabled path (`done.require_review: false`) shows
      the "review gate disabled" note — this exercises the config wiring end-to-end,
      not just the pure classifier.
- [ ] Update skill text — `templates/skills/implementation-session/SKILL.md`,
      `templates/skills/review-pr-comments-session/SKILL.md`, and any shared
      `_partials` — to note that skip/attempt status is now recorded in the PR body.
- [ ] Docs: update the PR-body marker inventory in `docs/dev/` (and `AGENTS.md`
      only if the marker set / workflow doc there changes).
- [ ] Run `./scripts/check-all.sh` and `./scripts/test-e2e.sh` — both must pass.

## Acceptance Criteria

- [ ] A deliberate `--skip-review` bypass is recorded and **visible in the PR
      body** (closes the outstanding #367 criterion).
- [ ] The PR body distinguishes "attempted N times, final commit not reviewed"
      (pass count > 0) from "never tried" (pass count 0).
- [ ] A normal, reviewed `done` shows a "Reviewed at <sha>" line in the PR body.
- [ ] `done.require_review: false` and `review_implementation.enabled: false` are
      reflected as a "review gate disabled" note; the cap-reached path is reflected
      as a "completed without fresh review" note.
- [ ] The block is idempotent — re-running `done` replaces its own block and leaves
      all other PR-body content (summary, usage tables, concurrent edits) intact.
- [ ] Gate refusal/approval behaviour is unchanged (pure refactor); existing
      `_gate_review_ran` tests still pass.
- [ ] Skill text matches the new behaviour.
- [ ] `./scripts/check-all.sh` and `./scripts/test-e2e.sh` pass.

## Notes

- Discovered on wade PR #363 (#356): two consecutive review timeouts let the
  session reach `done` and mark the PR ready with no review performed. The gate
  (PR #375 / PR #385) closed the correctness hole; this issue closes the
  **legibility** gap that remained.
- Deliberately does **not** block on review *findings* — only makes the review
  *status* (ran / skipped / attempted-but-not-passed) visible.
- **Knowledge to capture during implementation** (not addable from a planning
  session): the durable, human-legible record of session state is the **PR body**
  (marker-bounded blocks), not the `.wade/` markers, which are worktree-local and
  discarded at session end. When something needs to be visible to a human
  reviewer, project it into the PR body — do not rely on `.wade/` artifacts. This
  is why #367's remaining legibility items were solved by a PR-body block rather
  than a richer on-disk receipt.
- **Possible future enhancement** (out of scope): if granular failure reasons are
  later wanted, have the review command persist each attempt's outcome
  (passed / timed-out / errored) and surface a "last review outcome" line in the
  same block.
- **Related:** #366 (headless review timeouts) reduces how often a review fails;
  this issue ensures a failed/skipped review cannot be mistaken for a clean one in
  the PR.
- **Risks / verify-don't-assume:**
  - `_transform`'s current marker-ordering (summary → impl-usage) must be read and
    confirmed to accept a new block between the two before wiring placement — do
    not bake the "before `IMPL_USAGE_MARKER_START`" placement in as done.
  - The `REQUIRE_OFF` / `DISABLED` / `CAP_REACHED` paths touch config wiring
    end-to-end, so they get dedicated E2E coverage (see Tasks), not just unit tests
    on the pure classifier.

<!-- wade:plan:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completed PRs now include a durable review-status summary with the outcome and review-pass count.
  * Review results clearly indicate reviewed, skipped, disabled, not-required, or cap-reached states.
  * Existing PR summaries are updated consistently without duplicating status information.

* **Documentation**
  * Updated user and developer guidance for review-status reporting.
  * Documented the configurable session context budget, now capped at 8,400 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:review-status:start -->

## Review Status

✅ Reviewed at `0ef45c9` via `wade review implementation`.

<!-- wade:review-status:end -->

<!-- wade:summary:start -->

## Summary

## What was done

`done` now projects the review outcome into the **PR body** as a marker-scoped
`wade:review-status` block, so a human reviewer can tell a clean review from one
that was skipped, gate-disabled, or never actually passed. This closes the two
legibility gaps that remained on #367: a deliberate `--skip-review` bypass is now
visible, and "attempted N times, final commit not reviewed" reads differently
from "never tried". The review markers themselves stay unchanged (zero-byte,
worktree-local) — the PR body is the durable, human-legible receipt.

## Changes

- **Single source of truth for review status.** Added `_classify_review` (a pure,
  side-effect-free classifier) returning a frozen `ReviewStatus` model (`kind`,
  `passes`, `session_type`, `reviewed_sha`). `_gate_review_ran` was refactored to
  decide pass/refuse from `_classify_review(...).kind` with **no behaviour
  change** — identical console output for every branch — so the gate and the
  PR-body renderer can never drift.
- **Renderer + markers.** Added `_render_review_status` and the
  `wade:review-status:start/end` markers in `lifecycle.py`. It renders reviewed /
  skipped / gate-disabled (`done.require_review: false` /
  `ai.review_implementation.enabled: false`) / cap-reached, and shows the
  review-pass count for **both** session types so an attempted-but-not-passed run
  is distinguishable from a never-run one.
- **Threading.** `done()` classifies once (against the same pre-sync HEAD the gate
  used, since an impl-only sync can advance HEAD) and threads the single
  `ReviewStatus` object into both PR-body paths — the existing-PR `_transform` and
  the new-PR `_build_pr_body`. The block is marker-scoped and idempotent on
  re-run (replaced in place, never duplicated), placed after the summary and
  before the impl-usage table; content outside the markers is preserved.

## Key technical decisions

- **Frozen Pydantic model, not a dataclass.** The plan specified a frozen
  dataclass, but the codebase is Pydantic-everywhere (zero dataclasses) with a
  precedent for co-locating small models outside `models/` (`git/pr.py::PRLookup`).
  A frozen `BaseModel` gives the same immutability with no functional difference,
  and lives in `lifecycle.py` to avoid a `done.py ↔ lifecycle.py` circular import.
- **`review_status` is an optional keyword arg** (default `None`) on `_done_via_pr`
  and `_build_pr_body`, rather than required as the plan sketched. `done()` always
  supplies a real object, so a real PR always carries the block; keeping it
  optional avoids churning the many existing body-composition tests that don't
  care about review status.
- The `CAP_REACHED` wording is implementation-only because the classifier only
  produces that kind for implementation sessions — the review-pr-comments path
  keeps its unbounded fast-path-or-refuse behaviour (the cap is #384-scoped).

## Testing

- Added `tests/unit/test_services/test_review_status_block.py` (27 tests):
  classifier per branch (reviewed / skip-flag / require-off / disabled /
  cap-reached / not-reviewed, plus precedence and review-pr-comments never-caps),
  renderer per kind (incl. pass count in a review-pr-comments session, and the
  attempted-vs-never distinction), and block idempotency + outside-marker
  preservation in both PR-body paths.
- Added 3 E2E contract tests in `test_implement_work_done_contract.py`: a
  `--skip-review` run leaves a skip notice, a real reviewed run shows the
  "Reviewed at `<sha>`" line, and `done.require_review: false` shows the
  gate-disabled note — exercising the config wiring end to end.
- All existing `_gate_review_ran` / `_done_via_pr` / `_build_pr_body` tests pass
  unchanged (the gate refactor is behaviour-preserving).
- `./scripts/check.sh` (ruff + ruff format + mypy --strict) passes; the full
  non-live suite and `./scripts/test-e2e.sh` pass. Bumped the session-start skill
  budget 8200 → 8400 for the load-bearing closing-step note (documented in the
  budget test and `docs/dev/skills-system.md`).

## Notes for reviewers

- No config toggle for the block — it is small, always-written, and informational.
- Granular failure reasons ("timed out" vs "errored") are intentionally out of
  scope (would require the review command to persist each attempt's outcome); the
  acceptance target is only attempted-N vs never-tried, which the pass count +
  reviewed status deliver.
- Docs updated: `README.md` (Completion gates), `docs/dev/architecture.md`
  (review-status block under Completion Gates), `docs/dev/skills-system.md`
  (budget), and the implementation- / review-pr-comments-session skills.

## Review round — addressed 2026-08-10

Fixed 4 review comments (chatgpt-codex-connector + coderabbitai), all confirmed
against current code:

- **`_classify_review` marker precedence (real bug, both graders flagged it).**
  The exact-sha `reviewed@<head_sha>` marker was checked *after* the
  `--skip-review` / `require_review: false` / `enabled: false` hatches, so a
  commit that genuinely passed review could still render as "skipped" or
  "gate-disabled" — the opposite of what #367 exists to fix (e.g. any project
  that keeps `done.require_review: false` permanently would never show
  `REVIEWED`, even right after a real review ran). Moved the marker check to
  the front of `_classify_review` so positive evidence always wins; the gate
  (`_gate_review_ran`) is unaffected since it already treated all four kinds as
  pass-silently regardless of order. Added 3 tests
  (`test_reviewed_precedes_skip_flag`, `test_reviewed_precedes_require_off`,
  `test_reviewed_precedes_disabled`) pinning the new precedence.
- **`session_type` typed as `SessionType` (StrEnum) instead of bare `str`.**
  Added `SessionType` in `lifecycle.py` (`IMPLEMENTATION` /
  `REVIEW_PR_COMMENTS`), exported via `__all__`, and made
  `ReviewStatus.session_type` use it so a typo'd session type is now a
  validation error instead of silently falling through the impl-only branches.
  `done()` and `_classify_review()` keep accepting `SessionType | str` at their
  boundaries (real CLI/test call sites still pass plain string literals) and
  normalize via `SessionType(session_type)` before constructing `ReviewStatus`.
  Existing string-equality comparisons in `_classify_review` /
  `_gate_review_ran` are untouched, per reviewer request.
- **Documented `cap-reached` outcome** in
  `review-implementation-closing-step.md` — the "Skipping review is visible"
  paragraph listed reviewed/skipped/gate-disabled but omitted the
  `max_review_passes` cap outcome that `done` can also render.

No threads left unresolved. `./scripts/test.sh` (3044 passed) and
`./scripts/check.sh` (ruff + mypy --strict) both clean.

## Review round 2 — addressed 2026-08-10

Fixed 2 more review comments (chatgpt-codex-connector), both confirmed against
current code:

- **Pass count could read as an attempt count.** `markers.record_review_pass` is
  per-sha and idempotent (#384: retrying review against the same HEAD, e.g. two
  consecutive headless timeouts, reuses one marker rather than inflating the
  count) — correct for the `done.max_review_passes` cap, but the new PR-body
  text ("N review pass(es) recorded") could be misread as "review ran N times."
  Reworded `_review_pass_phrase` to say "N distinct commit(s) reviewed" instead,
  making the distinct-commit semantics explicit rather than implying a raw
  attempt count (the lighter of the two fixes the reviewer offered — no new
  persisted state, cap semantics unchanged).
- **Gate-disabled outcomes discarded the pass count.** When the final commit
  lacked a `reviewed` marker but earlier commits had recorded passes,
  `REQUIRE_OFF`/`DISABLED` rendered only "Review gate disabled" — losing the
  attempted-vs-never distinction #367 exists to preserve. Both branches now
  append the pass count ("N distinct commit(s) reviewed before the gate was
  disabled") when `passes > 0`.
- Updated `tests/unit/test_services/test_review_status_block.py` for the new
  wording and added `test_require_off_with_passes_shows_pass_history` /
  `test_disabled_with_passes_shows_pass_history`.

No threads left unresolved. `./scripts/test.sh` (3046 passed) and
`./scripts/check.sh` (ruff + mypy --strict) both clean.

## Review round 3 — addressed 2026-08-10

Fixed 2 more review comments (chatgpt-codex-connector), both confirmed against
current code — round 2's "N distinct commit(s) reviewed" wording still
overstated what the pass count means:

- **Pass markers record attempts, not confirmed reviews.**
  `review_delegation_service._record_review_pass` writes the
  `review-pass@<sha>` marker *before* checking `result.success` (so a headless
  timeout or other delegation failure still advances the count, by design, for
  the `done.max_review_passes` cap). Round 2's "N distinct commit(s) reviewed"
  phrase therefore claimed completed reviews that may never have happened.
  Reworded `_review_pass_phrase` to "review attempted on N distinct commit(s)"
  so the count can't be misread as confirmed-successful reviews.
- **`REQUIRE_OFF`/`DISABLED` invented a chronology.** Round 2 appended "N
  distinct commit(s) reviewed before the gate was disabled" — but marker files
  carry no config-change timestamp, so "before the gate was disabled" is
  unsupported (false for a project where the gate was always off). Both
  branches now always state plainly that the final commit was not reviewed,
  and append the (reworded) pass count separately without claiming timing
  relative to the gate.
- Updated `tests/unit/test_services/test_review_status_block.py` for the new
  wording; added assertions that "before the gate was disabled" no longer
  appears and that the final-commit-not-reviewed statement is always present
  for these two kinds.

No threads left unresolved.

<!-- wade:summary:end -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | **344,981** |
| Input tokens | **344,100** |
| Output tokens | **881** |
| Cached tokens | **0** |

<!-- wade:impl-usage:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | **115,829** |
| Input tokens | **115,300** |
| Output tokens | **529** |

### Session 2

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | **114,059** |
| Input tokens | **113,500** |
| Output tokens | **559** |

### Session 3

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | **96,370** |
| Input tokens | **95,700** |
| Output tokens | **670** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `771c0618-76f5-4bc9-bb68-23bc89768e6e` |
| Review | `claude` | `d8f77ada-86a8-4b4e-be26-c0d81ddc489b` |
| Review | `claude` | `6b3fb5d6-0057-4bcb-866a-1d6eef7d1353` |
| Review | `claude` | `31bb1330-1a1f-47a8-bfe4-94dfbf61f50b` |

<!-- wade:sessions:end -->
