### PR TITLE
fix: restore nested-session guard for Antigravity CLI in wade implement

### DIFF
--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -112,6 +112,9 @@ def _detect_ai_cli_env() -> str | None:
     # Cursor CLI
     if os.environ.get("CURSOR_CLI"):
         return "CURSOR_CLI"
+    # Antigravity CLI (agy) sets ANTIGRAVITY_AGENT=1 in its session env
+    if os.environ.get("ANTIGRAVITY_AGENT"):
+        return "ANTIGRAVITY_AGENT"
     return None
 
 

--- a/tests/unit/test_services/test_implementation_service.py
+++ b/tests/unit/test_services/test_implementation_service.py
@@ -53,6 +53,7 @@ from wade.services.implementation_service import (
     poll_batch_completion,
     start,
 )
+from wade.services.implementation_service.core import _detect_ai_cli_env
 
 # ---------------------------------------------------------------------------
 # Bootstrap helper tests
@@ -653,6 +654,45 @@ class TestImplementationLaunchCommandAssembly:
                 tool = adapter.TOOL_ID
                 assert "--permission-mode" not in cmd, f"{tool}: leaked --permission-mode"
                 assert "--approval-mode" not in cmd, f"{tool}: leaked --approval-mode"
+
+
+# ---------------------------------------------------------------------------
+# Nested AI CLI session detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectAiCliEnv:
+    """Tests for _detect_ai_cli_env() — the nested-session guard.
+
+    Each test clears every marker var first so leftover env state from other
+    tests (or the host running the suite) can't leak a false positive.
+    """
+
+    _MARKER_VARS = (
+        "CLAUDE_CODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "COPILOT_CLI",
+        "CODEX_CLI",
+        "CURSOR_CLI",
+        "ANTIGRAVITY_AGENT",
+    )
+
+    def _clear_markers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in self._MARKER_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_antigravity_agent_marker_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ANTIGRAVITY_AGENT (agy's in-session marker) is recognized as a nested session."""
+        self._clear_markers(monkeypatch)
+        monkeypatch.setenv("ANTIGRAVITY_AGENT", "1")
+
+        assert _detect_ai_cli_env() == "ANTIGRAVITY_AGENT"
+
+    def test_no_markers_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no known marker vars set, detection returns None."""
+        self._clear_markers(monkeypatch)
+
+        assert _detect_ai_cli_env() is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services/test_review_service.py
+++ b/tests/unit/test_services/test_review_service.py
@@ -582,6 +582,34 @@ class TestReviewServiceStart:
         review_file = wt_paths[0] / "REVIEW-COMMENTS.md"
         assert not review_file.exists()
 
+    def test_antigravity_agent_nested_session_skips_ai_launch(
+        self, tmp_path: Path, mock_setup: dict[str, MagicMock], mock_provider: MagicMock
+    ) -> None:
+        """ANTIGRAVITY_AGENT (agy's in-session marker) triggers the nested-session guard.
+
+        Regression test for #341 — _detect_ai_cli_env is one function shared by
+        both wade implement and wade review; this exercises the review call site.
+        """
+        from wade.models.review import PRReviewStatus
+
+        thread = ReviewThread(
+            comments=[ReviewComment(author="alice", body="Fix this", path="main.py", line=10)]
+        )
+        mock_setup["get_comprehensive_review_status"].return_value = PRReviewStatus(
+            actionable_threads=[thread],
+            all_unresolved_threads=[thread],
+        )
+        mock_setup["_detect_ai_cli_env"].return_value = "ANTIGRAVITY_AGENT"
+
+        with patch("wade.services.review_service.console") as mock_console:
+            result = start(target="42")
+
+        assert result is True
+        info_calls = [call.args[0] for call in mock_console.info.call_args_list]
+        assert any("ANTIGRAVITY_AGENT" in msg for msg in info_calls), (
+            f"Expected nested-session guard message in console.info calls, got: {info_calls}"
+        )
+
     def test_outdated_threads_proceed_to_session(
         self, tmp_path: Path, mock_setup: dict[str, MagicMock], mock_provider: MagicMock
     ) -> None:

--- a/tests/unit/test_services/test_review_service.py
+++ b/tests/unit/test_services/test_review_service.py
@@ -600,8 +600,16 @@ class TestReviewServiceStart:
             all_unresolved_threads=[thread],
         )
         mock_setup["_detect_ai_cli_env"].return_value = "ANTIGRAVITY_AGENT"
+        # A resolved tool (not the fixture's default None) so the guard is the
+        # only thing standing between start() and the inline launch below.
+        mock_setup["resolve_ai_tool"].return_value = "claude"
 
-        with patch("wade.services.review_service.console") as mock_console:
+        from crossby.ai_tools import AbstractAITool
+
+        with (
+            patch("wade.services.review_service.console") as mock_console,
+            patch.object(AbstractAITool, "get") as mock_get,
+        ):
             result = start(target="42")
 
         assert result is True
@@ -609,6 +617,8 @@ class TestReviewServiceStart:
         assert any("ANTIGRAVITY_AGENT" in msg for msg in info_calls), (
             f"Expected nested-session guard message in console.info calls, got: {info_calls}"
         )
+        # The guard must short-circuit before the adapter is ever resolved/launched.
+        mock_get.assert_not_called()
 
     def test_outdated_threads_proceed_to_session(
         self, tmp_path: Path, mock_setup: dict[str, MagicMock], mock_provider: MagicMock


### PR DESCRIPTION
Closes #341

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem

PR #336 (issue #335) replaced the Gemini CLI tool with the Antigravity CLI
(`agy`) and, in doing so, deleted the `GEMINI_CLI` branch from
`_detect_ai_cli_env()` (`src/wade/services/implementation_service/core.py:94`)
without a replacement. That guard is what stops `wade implement` from launching a
**second** AI instance when it's already running *inside* an AI CLI session — it
creates the worktree and prints its path instead of nesting infinitely. Today it
recognizes `CLAUDE_CODE` / `CLAUDE_CODE_ENTRYPOINT`, `COPILOT_CLI`, `CODEX_CLI`,
and `CURSOR_CLI` — nothing for `agy`, so an `agy` session gets no guard.

`agy` (Antigravity CLI) is a rebrand of the Gemini CLI and still exports
**`GEMINI_CLI`** as its in-session marker — the same variable the pre-#336 guard
already checked. Verified against the installed binary: `GEMINI_CLI` is the only
session-marker env token present; `ANTIGRAVITY_CLI` / `AGY_CLI` do not exist in
it. So the fix is simply to restore the `GEMINI_CLI` branch. (This is `agy`'s own
env var, not wade re-adding Gemini as a supported tool.)

The function is defined once in `core.py` and re-imported by `review_service.py`,
so restoring this one branch fixes the guard for both `wade implement` **and**
`wade review pr-comments` — no second edit.

## Proposed Solution

Add one branch to `_detect_ai_cli_env()`, after the `CURSOR_CLI` check:

```python
# Antigravity CLI (agy) — its in-session marker (agy is a rebranded Gemini CLI)
if os.environ.get("GEMINI_CLI"):
    return "GEMINI_CLI"
```

Return the literal var name to match every other branch (it feeds only the
informational `Skipping AI launch … detected via GEMINI_CLI` log line).

## Tasks

- [ ] Add the `GEMINI_CLI` branch to `_detect_ai_cli_env()` in
      `src/wade/services/implementation_service/core.py`, commented as the
      Antigravity CLI (`agy`) session marker.
- [ ] **Best-effort, non-blocking:** on a host with `agy` installed, confirm a
      live `agy` session exports `GEMINI_CLI` (`env | grep GEMINI_CLI` inside the
      session) and note the result in the PR description. Binary inspection
      already indicates `GEMINI_CLI` is the only candidate, so do **not** block
      the merge if no `agy`-enabled host is available.
- [ ] Add a unit test in
      `tests/unit/test_services/test_implementation_service.py` (no existing test
      exercises the detection branches directly — they all patch the function, so
      a new direct test is warranted). Import `_detect_ai_cli_env` from
      `wade.services.implementation_service.core`, clear the other markers
      (`CLAUDE_CODE`, `CLAUDE_CODE_ENTRYPOINT`, `COPILOT_CLI`, `CODEX_CLI`,
      `CURSOR_CLI`) with `monkeypatch.delenv(..., raising=False)`, set
      `GEMINI_CLI`, and assert the function returns `"GEMINI_CLI"`; plus a
      negative case (all cleared → `None`).
- [ ] Since the guard is shared, add/verify a `GEMINI_CLI` regression case on the
      review side too — `tests/unit/test_services/test_review_service.py` already
      has a `_detect_ai_cli_env` patch fixture (around line 452); cheap insurance
      that the fix covers both `implement` and `review` call sites.
- [ ] Run `./scripts/test.sh` and `./scripts/check.sh`.

## Acceptance Criteria

- [ ] `_detect_ai_cli_env()` returns a non-`None` value when `GEMINI_CLI` is set
      (i.e. inside an `agy` session), preventing a nested AI launch from
      `wade implement` (and, via the shared function, `wade review`).
- [ ] Best-effort: if an `agy`-enabled host is available, confirmed in a live
      session that it exports `GEMINI_CLI` and documented in the PR (non-blocking
      — binary inspection already establishes `GEMINI_CLI` as the only marker).
- [ ] A unit test covers the Antigravity CLI detection branch (positive +
      negative case).
- [ ] `./scripts/test.sh` and `./scripts/check.sh` pass.

<!-- wade:plan:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of existing Antigravity CLI sessions.
  * Prevented nested AI sessions from launching when an agent session is already active.
  * Review startup now completes successfully while clearly indicating when an AI launch is skipped.
* **Tests**
  * Added coverage for active and inactive session detection.
  * Added regression coverage for review behavior during nested sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:summary:start -->

## Summary

## What was done

Restored the nested-session guard in `_detect_ai_cli_env()` for the Antigravity CLI (`agy`), so `wade implement` (and `wade review pr-comments`, which shares the same function) no longer launches a second AI instance when already running inside an `agy` session.

## Changes

- Added an `ANTIGRAVITY_AGENT` branch to `_detect_ai_cli_env()` in `src/wade/services/implementation_service/core.py`, restoring the guard PR #336 dropped when it replaced Gemini CLI with `agy` and deleted the old `GEMINI_CLI` branch without a replacement.
- Added direct unit tests for `_detect_ai_cli_env()` (positive/negative) in `tests/unit/test_services/test_implementation_service.py` — no prior test exercised the detection branches directly (they all mock the function).
- Added a regression test in `tests/unit/test_services/test_review_service.py` confirming the shared guard also fires on the `wade review` call site.

## Key technical decision — deviation from the original issue plan

The issue (#341) proposed restoring a `GEMINI_CLI` branch, reasoning that `agy` is a rebranded Gemini CLI and would still export `GEMINI_CLI` as its session marker, based on binary inspection.

I verified this live against the actually-installed `agy` v1.1.11 (`~/.local/bin/agy`) by running `agy --print` non-interactively with `--dangerously-skip-permissions` and dumping its session environment. **`GEMINI_CLI` is not set at all** (confirmed twice — an initial `grep -c GEMINI_CLI` false-positive turned out to be the search command text self-matching inside the `ANTIGRAVITY_SOURCE_METADATA` env var, not a real hit). The actual, reproducible marker is **`ANTIGRAVITY_AGENT=1`**, alongside `ANTIGRAVITY_AGENTAPI_EXE` pointing at the `agy` binary path.

Implementing the plan as originally written would have left the guard silently broken for the real, currently-installed CLI. I flagged this to the user mid-implementation and, per their direction, implemented the guard against the verified `ANTIGRAVITY_AGENT` marker instead of `GEMINI_CLI`.

## Testing

- `./scripts/test.sh` — 3074 passed
- `./scripts/check.sh` — ruff lint, ruff format check, and mypy --strict all clean
- Live-verified `ANTIGRAVITY_AGENT=1` is set inside a real `agy --print` session on this host (see "Key technical decision" above)
- `wade review implementation` — completed, no actionable findings

## Notes for reviewers

This changes the marker env var from the plan's `GEMINI_CLI` to the live-verified `ANTIGRAVITY_AGENT`. If `agy` behaves differently across versions/install paths, it may be worth adding both branches defensively in a follow-up — happy to do that here instead if preferred.

## Review comments addressed

- **CodeRabbit** (`tests/unit/test_services/test_review_service.py:611`, thread `PRRT_kwDORW_uUM6YEYQV`): the `test_antigravity_agent_nested_session_skips_ai_launch` regression test relied on the `mock_setup` fixture's default `resolve_ai_tool` return value of `None`, so `start()`'s "if resolved_tool:" inline-launch block was never reachable regardless of the guard — a negative assertion there would have been vacuous. Fixed by setting `resolve_ai_tool` to a valid tool (`"claude"`) and asserting `AbstractAITool.get` is never called, which genuinely proves the nested-session guard short-circuits before the inline launch path. Verified with `./scripts/test.sh` (3074 passed) and `./scripts/check.sh` (clean). Thread resolved.

<!-- wade:summary:end -->

<!-- wade:review-status:start -->

## Review Status

✅ Reviewed at `a959fac` via `wade review implementation`.

<!-- wade:review-status:end -->

<!-- wade:impl-usage:start -->

## Token Usage (Implementation)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | **129,363** |
| Input tokens | **128,700** |
| Output tokens | **663** |

<!-- wade:impl-usage:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | **73,867** |
| Input tokens | **72,900** |
| Output tokens | **967** |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `8a1a4fa0-3867-4e17-91c9-3784fa4ac036` |
| Review | `claude` | `749b920b-1d8f-46d5-8fb0-e05876dff02c` |

<!-- wade:sessions:end -->
