### PR TITLE
refactor: shared typed worktree model for list_worktrees() consumers

### DIFF
--- a/src/wade/git/hooks.py
+++ b/src/wade/git/hooks.py
@@ -328,7 +328,7 @@ def _maybe_disable_worktree_config_extension(worktree_path: Path) -> None:
         # A worktree-scoped read needs the extension still enabled — it is, since
         # we only unset it below. Any lingering hooksPath override (wade's or the
         # user's) means a sibling still depends on worktree config.
-        if git_repo.get_config_value(Path(wt["path"]), "core.hooksPath", worktree=True):
+        if git_repo.get_config_value(Path(wt.path), "core.hooksPath", worktree=True):
             return
     git_repo.unset_config_value(worktree_path, "extensions.worktreeConfig")
     logger.debug("skills.worktree_config_extension_disabled", path=str(worktree_path))

--- a/src/wade/git/worktree.py
+++ b/src/wade/git/worktree.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import structlog
 
 from wade.git.repo import _run_git, _run_git_with_retry
+from wade.models import Worktree
 
 log = structlog.get_logger(__name__)
 
@@ -142,25 +143,25 @@ def remove_worktree(repo_root: Path, worktree_path: Path, force: bool = True) ->
     _run_git_with_retry(*args, cwd=repo_root)
 
 
-def list_worktrees(repo_root: Path) -> list[dict[str, str]]:
+def list_worktrees(repo_root: Path) -> list[Worktree]:
     """List all worktrees for a repository.
 
     Args:
         repo_root: Root of the main repository checkout.
 
     Returns:
-        List of dicts, each with keys: "path", "head", "branch".
-        The branch value is the short ref name (e.g., "main") or
-        "(detached)" for detached HEAD worktrees.
+        List of :class:`~wade.models.Worktree` entries with typed ``path``,
+        ``head``, and ``branch`` attributes. The branch value is the short ref
+        name (e.g., "main") or "(detached)" for detached HEAD worktrees.
     """
     result = _run_git("worktree", "list", "--porcelain", cwd=repo_root)
-    worktrees: list[dict[str, str]] = []
+    worktrees: list[Worktree] = []
     current: dict[str, str] = {}
 
     for line in result.stdout.splitlines():
         if line.startswith("worktree "):
             if current:
-                worktrees.append(current)
+                worktrees.append(Worktree(**current))
             current = {"path": line[len("worktree ") :]}
         elif line.startswith("HEAD "):
             current["head"] = line[len("HEAD ") :]
@@ -171,11 +172,11 @@ def list_worktrees(repo_root: Path) -> list[dict[str, str]]:
         elif line.strip() == "detached":
             current["branch"] = "(detached)"
         elif line.strip() == "" and current:
-            worktrees.append(current)
+            worktrees.append(Worktree(**current))
             current = {}
 
     if current:
-        worktrees.append(current)
+        worktrees.append(Worktree(**current))
 
     return worktrees
 

--- a/src/wade/git/worktree.py
+++ b/src/wade/git/worktree.py
@@ -156,27 +156,30 @@ def list_worktrees(repo_root: Path) -> list[Worktree]:
     """
     result = _run_git("worktree", "list", "--porcelain", cwd=repo_root)
     worktrees: list[Worktree] = []
-    current: dict[str, str] = {}
+    current: Worktree | None = None
 
     for line in result.stdout.splitlines():
         if line.startswith("worktree "):
-            if current:
-                worktrees.append(Worktree(**current))
-            current = {"path": line[len("worktree ") :]}
+            if current is not None:
+                worktrees.append(current)
+            current = Worktree(path=line[len("worktree ") :])
+        elif current is None:
+            # Porcelain output always opens an entry with a "worktree " line;
+            # ignore anything before the first one.
+            continue
         elif line.startswith("HEAD "):
-            current["head"] = line[len("HEAD ") :]
+            current.head = line[len("HEAD ") :]
         elif line.startswith("branch "):
             # Refs come as "refs/heads/branch-name"
-            ref = line[len("branch ") :]
-            current["branch"] = ref.removeprefix("refs/heads/")
+            current.branch = line[len("branch ") :].removeprefix("refs/heads/")
         elif line.strip() == "detached":
-            current["branch"] = "(detached)"
-        elif line.strip() == "" and current:
-            worktrees.append(Worktree(**current))
-            current = {}
+            current.branch = "(detached)"
+        elif line.strip() == "":
+            worktrees.append(current)
+            current = None
 
-    if current:
-        worktrees.append(Worktree(**current))
+    if current is not None:
+        worktrees.append(current)
 
     return worktrees
 

--- a/src/wade/models/__init__.py
+++ b/src/wade/models/__init__.py
@@ -32,6 +32,7 @@ from wade.models.session import (
     WorktreeState,
 )
 from wade.models.task import Complexity, Label, LabelType, PlanFile, Task, TaskState
+from wade.models.worktree import Worktree
 
 __all__ = [
     "AICommandConfig",
@@ -67,5 +68,6 @@ __all__ = [
     "TaskState",
     "TokenUsage",
     "WorkflowEvent",
+    "Worktree",
     "WorktreeState",
 ]

--- a/src/wade/models/worktree.py
+++ b/src/wade/models/worktree.py
@@ -1,0 +1,23 @@
+"""Worktree domain model — a single ``git worktree list`` entry."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Worktree(BaseModel):
+    """A single git worktree entry parsed from ``git worktree list --porcelain``.
+
+    Attributes:
+        path: Absolute path to the worktree. Always present — it is the first
+            porcelain line for every entry.
+        head: The checked-out commit SHA, or ``None`` for a bare/mid-operation
+            entry that omits ``HEAD``.
+        branch: The short ref name (e.g. ``main``) or the literal
+            ``"(detached)"`` for detached-HEAD worktrees. ``None`` when the
+            entry carries neither a branch nor a detached marker.
+    """
+
+    path: str
+    head: str | None = None
+    branch: str | None = None

--- a/src/wade/services/implementation_service/_shared.py
+++ b/src/wade/services/implementation_service/_shared.py
@@ -34,8 +34,8 @@ def find_worktree_path(
     worktrees = git_worktree.list_worktrees(repo_root)
 
     for wt in worktrees:
-        wt_branch = wt.get("branch", "")
-        wt_path = wt.get("path", "")
+        wt_branch = wt.branch or ""
+        wt_path = wt.path
 
         # Match by issue number in branch name
         if f"/{target}-" in wt_branch or wt_branch.endswith(f"/{target}"):

--- a/src/wade/services/implementation_service/cleanup.py
+++ b/src/wade/services/implementation_service/cleanup.py
@@ -73,8 +73,8 @@ def list_sessions(
 
     # The first worktree is the main checkout — skip unless --all
     for i, wt in enumerate(worktrees):
-        wt_branch = wt.get("branch", "")
-        wt_path = wt.get("path", "")
+        wt_branch = wt.branch or ""
+        wt_path = wt.path
 
         # Skip main checkout unless --all
         if i == 0 and not show_all:
@@ -241,8 +241,8 @@ def _remove_stale(
         if i == 0:
             continue  # Skip main
 
-        wt_branch = wt.get("branch", "")
-        wt_path = wt.get("path", "")
+        wt_branch = wt.branch or ""
+        wt_path = wt.path
         issue_number = extract_issue_from_branch(wt_branch)
 
         # Look up the issue exactly as list_sessions() does so classify_staleness
@@ -291,22 +291,24 @@ def _remove_stale(
         return True
 
     console.rule(f"Stale worktrees ({len(stale_wts)})")
-    for wt in stale_wts:
-        console.step(f"[{wt['staleness'].upper()}] {wt['branch']}")
-        console.detail(f"Path: {wt['path']}")
+    for stale in stale_wts:
+        console.step(f"[{stale['staleness'].upper()}] {stale['branch']}")
+        console.detail(f"Path: {stale['path']}")
 
     if not force:
         console.info("Use --force to remove these worktrees.")
         return True
 
     removed = 0
-    for wt in stale_wts:
+    for stale in stale_wts:
         # A2: even with --force (skip confirmation), _cleanup_worktree still
         # refuses a worktree carrying uncommitted changes or unmerged local
         # commits unless --discard-dirty was passed. STALE_REMOTE_GONE says
         # nothing about local commits, so a remote-gone branch with unpushed
         # work is preserved here, not silently nuked.
-        if _cleanup_worktree(repo_root, Path(wt["path"]), main_branch, discard_dirty=discard_dirty):
+        if _cleanup_worktree(
+            repo_root, Path(stale["path"]), main_branch, discard_dirty=discard_dirty
+        ):
             removed += 1
 
     console.panel(f"  Removed {removed} stale worktree(s)", title="Stale cleanup")
@@ -436,8 +438,8 @@ def _cleanup_worktree(
     worktrees = git_worktree.list_worktrees(main_root)
     branch_name: str | None = None
     for wt in worktrees:
-        if wt.get("path") == str(wt_path):
-            branch_name = wt.get("branch")
+        if wt.path == str(wt_path):
+            branch_name = wt.branch
             break
 
     # A2 loss guard — never silently discard a dirty worktree or force-delete a

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -695,9 +695,9 @@ def start(
         # Reuse the worktree if the branch already exists (idempotent re-run)
         existing_wt = next(
             (
-                Path(wt["path"])
+                Path(wt.path)
                 for wt in git_worktree.list_worktrees(repo_root)
-                if wt.get("branch") == branch_name
+                if wt.branch == branch_name
             ),
             None,
         )

--- a/src/wade/services/implementation_service/draft_pr.py
+++ b/src/wade/services/implementation_service/draft_pr.py
@@ -171,8 +171,8 @@ def _find_checked_out_worktree(repo_root: Path, branch_name: str) -> tuple[bool,
 
     try:
         for wt in git_worktree.list_worktrees(repo_root):
-            if wt.get("branch") == branch_name:
-                return True, Path(wt["path"])
+            if wt.branch == branch_name:
+                return True, Path(wt.path)
         return False, None
     except Exception:
         logger.debug("draft_pr.worktree_check_failed", exc_info=True)

--- a/src/wade/services/plan_service.py
+++ b/src/wade/services/plan_service.py
@@ -856,7 +856,7 @@ def _branch_work_in_flight(repo_root: Path, branch_name: str, base: str) -> bool
 
     try:
         for wt in git_worktree.list_worktrees(repo_root):
-            if wt.get("branch") == branch_name:
+            if wt.branch == branch_name:
                 return True
     except Exception:
         logger.debug("plan.in_flight_worktree_check_failed", exc_info=True)
@@ -984,9 +984,9 @@ def _reconcile_inflight_worktree_base(
     try:
         wt_path = next(
             (
-                Path(wt["path"])
+                Path(wt.path)
                 for wt in git_worktree.list_worktrees(repo_root)
-                if wt.get("branch") == branch_name
+                if wt.branch == branch_name
             ),
             None,
         )

--- a/src/wade/services/review_service.py
+++ b/src/wade/services/review_service.py
@@ -569,9 +569,9 @@ def start(
 
     existing_wt = next(
         (
-            Path(wt["path"])
+            Path(wt.path)
             for wt in git_worktree.list_worktrees(repo_root)
-            if wt.get("branch") == branch_name
+            if wt.branch == branch_name
         ),
         None,
     )

--- a/src/wade/services/smart_start.py
+++ b/src/wade/services/smart_start.py
@@ -12,7 +12,6 @@ import webbrowser
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
-from typing import Any
 
 import structlog
 from crossby.ai_tools import AbstractAITool
@@ -26,6 +25,7 @@ from wade.git import repo as git_repo
 from wade.git.repo import GitError
 from wade.models.permission import PermissionMode
 from wade.models.session import MergeStatus, SessionRecord
+from wade.models.worktree import Worktree
 from wade.providers.base import AbstractTaskProvider
 from wade.providers.registry import get_provider
 from wade.services.implementation_service import _merge_pr, check_tracking_issue_and_batch
@@ -209,7 +209,7 @@ def smart_start(
     # Extract draft state and worktree presence
     is_draft = lookup.pr.is_draft
     worktrees = git_worktree.list_worktrees(repo_root)
-    has_worktree = any(wt.get("branch") == branch_name for wt in worktrees)
+    has_worktree = any(wt.branch == branch_name for wt in worktrees)
 
     # Build dynamic menu based on PR state and worktree
     menu_options: list[tuple[str, Callable[[], bool]]] = []
@@ -237,7 +237,7 @@ def smart_start(
             )
         )
         review_worktree_path = next(
-            (Path(wt["path"]) for wt in worktrees if wt.get("branch") == branch_name),
+            (Path(wt.path) for wt in worktrees if wt.branch == branch_name),
             None,
         )
         menu_options.append(
@@ -355,11 +355,11 @@ def _run_merge_pr(
     pr_number: int,
     task_id: str,
     provider: AbstractTaskProvider,
-    worktrees: list[Any],
+    worktrees: list[Worktree],
 ) -> bool:
     """Execute the merge PR action from the menu."""
     worktree_path = next(
-        (Path(wt["path"]) for wt in worktrees if wt.get("branch") == branch_name),
+        (Path(wt.path) for wt in worktrees if wt.branch == branch_name),
         None,
     )
     if worktree_path is None:

--- a/tests/integration/test_git.py
+++ b/tests/integration/test_git.py
@@ -317,7 +317,7 @@ class TestListWorktrees:
         worktrees = list_worktrees(tmp_git_repo)
         assert len(worktrees) >= 1
         # The main checkout should be listed
-        paths = [wt["path"] for wt in worktrees]
+        paths = [wt.path for wt in worktrees]
         assert str(tmp_git_repo.resolve()) in [str(Path(p).resolve()) for p in paths]
 
     def test_lists_created_worktrees(self, tmp_git_repo: Path, tmp_path: Path) -> None:
@@ -328,7 +328,7 @@ class TestListWorktrees:
         create_worktree(tmp_git_repo, "branch-b", wt2, base_branch=main)
 
         worktrees = list_worktrees(tmp_git_repo)
-        branches = [wt.get("branch", "") for wt in worktrees]
+        branches = [wt.branch or "" for wt in worktrees]
         assert "branch-a" in branches
         assert "branch-b" in branches
 
@@ -345,16 +345,16 @@ class TestRemoveWorktree:
 
         # Should no longer appear in worktree list
         worktrees = list_worktrees(tmp_git_repo)
-        branches = [wt.get("branch", "") for wt in worktrees]
+        branches = [wt.branch or "" for wt in worktrees]
         assert "temp-branch" not in branches
 
 
 class TestPruneWorktrees:
     def test_prune_does_not_error_on_clean_repo(self, tmp_git_repo: Path) -> None:
         # Pruning a clean repo should preserve the existing worktree set.
-        before = sorted(list_worktrees(tmp_git_repo), key=lambda wt: wt["path"])
+        before = sorted(list_worktrees(tmp_git_repo), key=lambda wt: wt.path)
         prune_worktrees(tmp_git_repo)
-        after = sorted(list_worktrees(tmp_git_repo), key=lambda wt: wt["path"])
+        after = sorted(list_worktrees(tmp_git_repo), key=lambda wt: wt.path)
         assert after == before
         assert len(after) >= 1
 

--- a/tests/unit/test_git/test_detached_worktree.py
+++ b/tests/unit/test_git/test_detached_worktree.py
@@ -20,7 +20,7 @@ class TestCreateDetachedWorktree:
 
         # Verify it shows as detached in worktree list
         worktrees = list_worktrees(tmp_git_repo)
-        detached = [wt for wt in worktrees if wt.get("branch") == "(detached)"]
+        detached = [wt for wt in worktrees if wt.branch == "(detached)"]
         assert len(detached) >= 1
 
     def test_detached_worktree_at_head(self, tmp_git_repo: Path, tmp_path: Path) -> None:
@@ -63,7 +63,7 @@ class TestCreateDetachedWorktree:
         remove_worktree(tmp_git_repo, wt_path)
 
         worktrees = list_worktrees(tmp_git_repo)
-        wt_paths = [wt["path"] for wt in worktrees]
+        wt_paths = [wt.path for wt in worktrees]
         assert str(wt_path) not in wt_paths
 
     def test_multiple_detached_worktrees(self, tmp_git_repo: Path, tmp_path: Path) -> None:
@@ -77,7 +77,7 @@ class TestCreateDetachedWorktree:
         assert wt2.is_dir()
 
         worktrees = list_worktrees(tmp_git_repo)
-        detached = [wt for wt in worktrees if wt.get("branch") == "(detached)"]
+        detached = [wt for wt in worktrees if wt.branch == "(detached)"]
         assert len(detached) >= 2
 
     def test_detached_worktree_creates_nested_parent_dirs(

--- a/tests/unit/test_services/test_cleanup_loss_guard.py
+++ b/tests/unit/test_services/test_cleanup_loss_guard.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from wade.git.repo import GitError
+from wade.models.worktree import Worktree
 from wade.services.implementation_service.cleanup import (
     _cleanup_worktree,
     _worktree_loss_risk,
@@ -207,7 +208,7 @@ class TestCleanupWorktreeGuard:
         stack.enter_context(
             patch(
                 f"{_CLEANUP}.git_worktree.list_worktrees",
-                return_value=[{"path": "/repo/wt", "branch": "feat/42-x"}],
+                return_value=[Worktree(path="/repo/wt", branch="feat/42-x")],
             )
         )
         stack.enter_context(patch(f"{_CLEANUP}._worktree_loss_risk", return_value=losses))

--- a/tests/unit/test_services/test_draft_pr_retarget.py
+++ b/tests/unit/test_services/test_draft_pr_retarget.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 from wade.git.pr import PRLookup, PRRef
 from wade.git.repo import GitError
+from wade.models.worktree import Worktree
 from wade.services.implementation_service.draft_pr import (
     _branch_has_real_work,
     _find_checked_out_worktree,
@@ -96,7 +97,7 @@ class TestRerootScaffoldBranch:
     @patch(f"{_D}.git_branch.resolve_start_point", side_effect=_resolver())
     @patch(
         "wade.git.worktree.list_worktrees",
-        return_value=[{"path": "/wt", "branch": "feat/42-x"}],
+        return_value=[Worktree(path="/wt", branch="feat/42-x")],
     )
     def test_checked_out_scaffold_branch_rerooted_in_place(
         self,
@@ -131,7 +132,7 @@ class TestRerootScaffoldBranch:
     @patch(f"{_D}.git_branch.resolve_start_point", side_effect=_resolver())
     @patch(
         "wade.git.worktree.list_worktrees",
-        return_value=[{"path": "/wt", "branch": "feat/42-x"}],
+        return_value=[Worktree(path="/wt", branch="feat/42-x")],
     )
     def test_checked_out_dirty_worktree_aborts(
         self,
@@ -328,7 +329,7 @@ class TestBranchWorkSignals:
 
     @patch(
         "wade.git.worktree.list_worktrees",
-        return_value=[{"path": "/wt", "branch": "feat/42-x"}],
+        return_value=[Worktree(path="/wt", branch="feat/42-x")],
     )
     def test_checked_out(self, _wt: MagicMock) -> None:
         assert _find_checked_out_worktree(Path("/repo"), "feat/42-x") == (True, Path("/wt"))

--- a/tests/unit/test_services/test_implementation_service.py
+++ b/tests/unit/test_services/test_implementation_service.py
@@ -26,6 +26,7 @@ from wade.models.config import (
 )
 from wade.models.session import MergeStatus
 from wade.models.task import Task
+from wade.models.worktree import Worktree
 from wade.services.implementation_service import (
     _BATCH_STATUS_DONE,
     _BATCH_STATUS_IN_PROGRESS,
@@ -767,7 +768,7 @@ class TestImplementationStart:
             patch("wade.git.repo.get_repo_root", return_value=tmp_path),
             patch(
                 "wade.git.worktree.list_worktrees",
-                return_value=[{"path": str(existing_wt), "branch": branch_name}],
+                return_value=[Worktree(path=str(existing_wt), branch=branch_name)],
             ),
             patch("wade.git.worktree.create_worktree") as mock_create,
             patch("wade.services.implementation_service.core.write_plan_md"),

--- a/tests/unit/test_services/test_plan_service.py
+++ b/tests/unit/test_services/test_plan_service.py
@@ -13,6 +13,7 @@ from crossby.models.ai import TokenUsage
 from wade.git.pr import PRLookup, PRRef
 from wade.models.config import AIConfig, ProjectConfig, ProjectSettings
 from wade.models.task import CloseReason, Complexity, PlanFile, Task
+from wade.models.worktree import Worktree
 from wade.services.ai_resolution import resolve_ai_tool, resolve_model
 from wade.services.plan_service import (
     PlanDiagnostic,
@@ -1180,7 +1181,7 @@ class TestBranchWorkInFlight:
     def test_active_worktree_is_in_flight(self, tmp_path: Path) -> None:
         with patch(
             "wade.git.worktree.list_worktrees",
-            return_value=[{"path": "/wt", "branch": "feat/1-x"}],
+            return_value=[Worktree(path="/wt", branch="feat/1-x")],
         ):
             assert _branch_work_in_flight(tmp_path, "feat/1-x", "main") is True
 
@@ -1320,8 +1321,8 @@ class TestReconcileInflightWorktreeBase:
     def _issue(self) -> Task:
         return Task(id="42", title="feat: thing")
 
-    def _wt_entry(self, wt: Path) -> list[dict[str, str]]:
-        return [{"path": str(wt), "branch": "feat/42-thing"}]
+    def _wt_entry(self, wt: Path) -> list[Worktree]:
+        return [Worktree(path=str(wt), branch="feat/42-thing")]
 
     def test_writes_pin_for_inflight_worktree(self, tmp_path: Path) -> None:
         wt = tmp_path / "wt"

--- a/tests/unit/test_services/test_review_service.py
+++ b/tests/unit/test_services/test_review_service.py
@@ -13,6 +13,7 @@ from wade.git.pr import PRLookup, PRRef
 from wade.git.repo import GitError
 from wade.models.review import ReviewComment, ReviewThread
 from wade.models.task import Task, TaskState
+from wade.models.worktree import Worktree
 from wade.services.implementation_service import (
     REVIEW_USAGE_MARKER_END,
     REVIEW_USAGE_MARKER_START,
@@ -416,7 +417,7 @@ class TestReviewServiceStart:
             ),
             "list_worktrees": patch(
                 "wade.services.review_service.git_worktree.list_worktrees",
-                return_value=[{"path": str(worktree_path), "branch": "feat/42-fix-the-widget"}],
+                return_value=[Worktree(path=str(worktree_path), branch="feat/42-fix-the-widget")],
             ),
             "get_pr_for_branch": patch(
                 "wade.services.review_service.git_pr.get_pr_for_branch",
@@ -2270,7 +2271,7 @@ class TestReviewSessionAutonomyE2E:
             ),
             patch(
                 "wade.services.review_service.git_worktree.list_worktrees",
-                return_value=[{"path": str(worktree_path), "branch": "feat/42-fix-the-widget"}],
+                return_value=[Worktree(path=str(worktree_path), branch="feat/42-fix-the-widget")],
             ),
             patch(
                 "wade.services.review_service.git_pr.get_pr_for_branch",

--- a/tests/unit/test_services/test_smart_start.py
+++ b/tests/unit/test_services/test_smart_start.py
@@ -9,6 +9,7 @@ from wade.git.pr import PRLookup, PRRef
 from wade.git.repo import GitError
 from wade.models.review import PollOutcome
 from wade.models.task import Task, TaskState
+from wade.models.worktree import Worktree
 from wade.services.smart_start import SmartStartContext, _run_review_pr_comments, smart_start
 
 
@@ -271,7 +272,7 @@ class TestSmartStartDraftPR:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch(
         "wade.git.worktree.list_worktrees",
-        return_value=[{"branch": "feat/42-fix", "path": "/tmp/wt"}],
+        return_value=[Worktree(branch="feat/42-fix", path="/tmp/wt")],
     )
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
     @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")

--- a/tests/unit/test_services/test_smart_start_resume.py
+++ b/tests/unit/test_services/test_smart_start_resume.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from wade.git.pr import PRLookup, PRRef
 from wade.models.session import SessionRecord
 from wade.models.task import Task, TaskState
+from wade.models.worktree import Worktree
 from wade.services.smart_start import (
     SmartStartContext,
     _get_latest_resumable_session,
@@ -252,7 +253,7 @@ class TestSmartStartResumeIntegration:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch(
         "wade.git.worktree.list_worktrees",
-        return_value=[{"branch": "feat/42-fix", "path": "/tmp/wt"}],
+        return_value=[Worktree(branch="feat/42-fix", path="/tmp/wt")],
     )
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
     @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
@@ -298,7 +299,7 @@ class TestSmartStartResumeIntegration:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch(
         "wade.git.worktree.list_worktrees",
-        return_value=[{"branch": "feat/42-fix", "path": "/tmp/wt"}],
+        return_value=[Worktree(branch="feat/42-fix", path="/tmp/wt")],
     )
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
     @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
@@ -342,7 +343,7 @@ class TestSmartStartResumeIntegration:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch(
         "wade.git.worktree.list_worktrees",
-        return_value=[{"branch": "feat/42-fix", "path": "/tmp/wt"}],
+        return_value=[Worktree(branch="feat/42-fix", path="/tmp/wt")],
     )
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
     @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")


### PR DESCRIPTION
Closes #413

<!-- wade:plan:start -->

## Complexity
complex

## Context / Problem

`git.worktree.list_worktrees()` returns `list[dict[str, str]]`. Consumers across
the git, service, and hook layers reach into string keys — `wt["path"]`,
`wt.get("branch")`, `wt.get("path", "")` — with no type safety: a typo'd key or a
wrong assumption about which keys are present is invisible to mypy and only
surfaces at runtime.

CodeRabbit (PR #376 review) suggested replacing the raw dicts with a shared
Pydantic model exposing typed attributes (`worktree.path`, `worktree.branch`).
This was deferred from PR #377 as out-of-scope for the base-branch feature.

This is a **pure maintainability refactor — no behavior change.** The JSON
(porcelain) parsing in `list_worktrees()` stays exactly as-is; we only map the
accumulated fields into a model at the point each entry is appended.

## Proposed Solution

1. **Add a `Worktree` Pydantic model** in a new leaf module
   `src/wade/models/worktree.py`:

   ```python
   class Worktree(BaseModel):
       """A single git worktree entry parsed from `git worktree list --porcelain`."""
       path: str
       head: str | None = None
       branch: str | None = None
   ```

   - `path` is always present (it is the first porcelain line for every entry).
   - `head` and `branch` are optional: a worktree mid-operation or a bare entry
     may omit `HEAD`/`branch`. `branch` is the short ref (e.g. `main`) or the
     literal `"(detached)"` for detached-HEAD worktrees — this string mapping
     stays in `list_worktrees()`.
   - Plain `BaseModel` (not `frozen`) to match the repo's existing model style
     (`ImplementationSession`, `SessionRecord`).
   - Export `Worktree` from `src/wade/models/__init__.py` (add to imports and
     `__all__`).
   - **`path` stays `str`, deliberately** (not `Path`, despite
     `ImplementationSession.worktree_path` being `Path`). The porcelain output is
     a raw string and the current dict is `dict[str, str]`; keeping `str` is the
     closest zero-behavior-change mapping. Notably `cleanup.py` (~439) compares
     `path == str(wt_path)` — a `Path`-typed field would silently break that
     (`Path(...) == str(...)` is `False`), so `str` avoids a subtle regression.
     The `Path(wt.path)` wrappers at call sites are kept as-is.

2. **Change `list_worktrees()` to return `list[Worktree]`**
   (`src/wade/git/worktree.py`). Keep the porcelain line-by-line parse into a
   temporary `dict[str, str]`; at each append site construct a `Worktree` from
   the accumulated dict. Update the return type annotation and the docstring
   `Returns:` block.

   > Layering: `models/` is a leaf; the git layer is allowed to import models,
   > so `from wade.models import Worktree` in `git/worktree.py` is legal. Every
   > other consumer (services, `git/hooks.py`, cli) may import models too. No
   > layering rule is violated.

3. **Migrate the 9 source consumers** to attribute access. Exhaustive list:

   | File | Current | New |
   |------|---------|-----|
   | `services/review_service.py` (~572) | `Path(wt["path"])`, `wt.get("branch") == branch_name` | `Path(wt.path)`, `wt.branch == branch_name` |
   | `services/plan_service.py` (~858) | `wt.get("branch") == branch_name` | `wt.branch == branch_name` |
   | `services/plan_service.py` (~987) | `Path(wt["path"])`, `wt.get("branch")` | `Path(wt.path)`, `wt.branch` |
   | `services/implementation_service/core.py` (~698) | `Path(wt["path"])`, `wt.get("branch")` | `Path(wt.path)`, `wt.branch` |
   | `services/implementation_service/_shared.py` (~37) | `wt.get("branch", "")`, `wt.get("path", "")` | `wt.branch or ""`, `wt.path` |
   | `services/implementation_service/cleanup.py` (~76, ~244) | `wt.get("branch", "")`, `wt.get("path", "")` | `wt.branch or ""`, `wt.path` |
   | `services/implementation_service/cleanup.py` (~439) | `wt.get("path") == str(wt_path)`, `wt.get("branch")` | `wt.path == str(wt_path)`, `wt.branch` |
   | `services/implementation_service/draft_pr.py` (~173) | `wt.get("branch")`, `Path(wt["path"])` | `wt.branch`, `Path(wt.path)` |
   | `services/smart_start.py` (~212, ~240, ~362) | `wt.get("branch")`, `Path(wt["path"])` | `wt.branch`, `Path(wt.path)` |
   | `services/smart_start.py` (~358) | param `worktrees: list[Any]` | `worktrees: list[Worktree]` |
   | `git/hooks.py` (~331) | `Path(wt["path"])` | `Path(wt.path)` |

   **Semantic preservation — do not deviate:**
   - `.get("branch")` → `.branch` is exact: both yield `None` when absent, so
     `== branch_name` comparisons behave identically.
   - `.get("branch", "")` → `.branch or ""` — **must keep the empty-string
     default**, since `_shared.py` / `cleanup.py` build branch-name substrings
     from it and would otherwise `TypeError` on `None`.
   - `.get("path", "")` → `.path` — `path` is guaranteed by the parser, so the
     defensive `""` default is dead and can be dropped.
   - `draft_pr.py` / `plan_service.py` wrap the loop in `try/except` and
     **fail closed** on any exception; the model swap must not widen or narrow
     that (attribute access on a valid `Worktree` never raises).

4. **`cli/worktree.py` needs no change** — verify and document. Despite being
   named in the issue scope, `cli/worktree.py` does **not** call
   `git.worktree.list_worktrees()`. Its `sessions[idx]["issue"]` / `s["staleness"]`
   / `s["branch"]` accesses read `list_sessions()` output (a richer dict with
   `issue`, `issue_state`, `staleness`, `commits_ahead`), which is a **separate,
   out-of-scope** structure. Leave it untouched.

5. **Update tests** — two categories:

   - **Fixtures that build non-empty worktree lists** → replace the dict
     literals with `Worktree(...)` instances:
     - `tests/unit/test_services/test_plan_service.py` (`_wt_entry` helper ~1324; inline ~1183)
     - `tests/unit/test_services/test_draft_pr_retarget.py` (~99, ~134, ~331)
     - `tests/unit/test_services/test_smart_start_resume.py` (~255, ~301, ~345)
     - `tests/unit/test_services/test_smart_start.py` (~274)
     - `tests/unit/test_services/test_review_service.py` (~419, ~2273)
     - `tests/unit/test_services/test_cleanup_loss_guard.py` (~210)
     - `tests/unit/test_services/test_implementation_service.py` (~770)
   - **Assertions over real `list_worktrees()` output** → swap key access for
     attributes:
     - `tests/integration/test_git.py` (~320 `wt["path"]`, ~331 `wt.get("branch", "")`)
     - `tests/unit/test_git/test_detached_worktree.py` (~23, ~66, ~80: `wt.get("branch")`, `wt["path"]`)
   - **`return_value=[]` mocks need no change** — an empty list satisfies
     `list[Worktree]` (e.g. most of `test_implementation_service.py`,
     `test_preserve_session_data.py`, `test_post_implementation_lifecycle.py`,
     the empty-return cases in the files above).

## Tasks

- [ ] Add `src/wade/models/worktree.py` with the `Worktree` model
- [ ] Export `Worktree` from `src/wade/models/__init__.py` (import + `__all__`)
- [ ] Change `list_worktrees()` return type to `list[Worktree]`; keep porcelain
      parsing, map accumulated dict → model at both append sites; update docstring
- [ ] Migrate `review_service.py` to attribute access
- [ ] Migrate `plan_service.py` (both call sites) to attribute access
- [ ] Migrate `implementation_service/core.py` to attribute access
- [ ] Migrate `implementation_service/_shared.py` (`.branch or ""`, `.path`)
- [ ] Migrate `implementation_service/cleanup.py` (all three call sites)
- [ ] Migrate `implementation_service/draft_pr.py` (preserve fail-closed)
- [ ] Migrate `smart_start.py` call sites + retype the `worktrees` param to `list[Worktree]`,
      and remove the now-unused `from typing import Any` import (else ruff `F401` fails)
- [ ] Migrate `git/hooks.py` to attribute access
- [ ] Confirm `cli/worktree.py` needs no change (reads `list_sessions()`, not `list_worktrees()`)
- [ ] Update non-empty worktree fixtures across the listed test files to `Worktree(...)`
- [ ] Update integration/detached assertions to attribute access
- [ ] `./scripts/check.sh` (strict mypy will flag any missed consumer) and `./scripts/test.sh` pass
- [ ] Doc-update pass: adjust `list_worktrees()` docstring; no `AGENTS.md`/`README.md`
      change expected (internal refactor, no user-facing behavior change) — confirm

## Acceptance Criteria

- [ ] `git.worktree.list_worktrees()` returns `list[Worktree]`; the model lives
      under `src/wade/models/` and is exported from `wade.models`
- [ ] No source module outside `git/worktree.py` indexes a worktree entry by
      string key — `grep -rn 'wt\["\|wt\.get("branch\|wt\.get("path' src/wade`
      returns nothing for worktree-list consumers
- [ ] `list_worktrees()` still parses via the existing porcelain logic (JSON/line
      parse unchanged) — only the mapping into the model is added
- [ ] Behavior is identical: detached worktrees still report `branch == "(detached)"`,
      absent branch/head still yield `None`, empty-string defaults preserved where
      substrings are built
- [ ] `./scripts/check.sh` (lint + strict types) and `./scripts/test.sh` pass
- [ ] No changes to `cli/worktree.py`, to the `list_sessions()` session dict, or
      to the `stale_wts` display dict (all explicitly out of scope)

## Notes

- **Single atomic PR.** The model and every consumer/test must land together:
  changing the return type breaks strict mypy on any un-migrated consumer, so
  this cannot be split without leaving the tree un-typecheckable mid-way.
- **Out of scope (leave as raw dicts):** the `list_sessions()` return dict and
  the local `stale_wts` display dict in `implementation_service/cleanup.py`
  (both carry extra fields like `staleness`/`issue`/`commits_ahead` and one is
  JSON-serialized via `json.dumps`). Typing those is a separate, larger effort.
- **Knowledge to carry forward** (planning sessions can't run `wade knowledge add`):
  strict mypy is the safety net for this refactor — once `list_worktrees()` is
  retyped, `./scripts/check.sh` pinpoints every remaining `dict`-style access, so
  run it early and let it drive the migration checklist.

<!-- wade:plan:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured worktree information with path, commit, and branch details.
  * Made the worktree model available through the package’s public API.

* **Bug Fixes**
  * Improved worktree discovery and handling across cleanup, planning, reviews, implementation, and smart-start workflows.
  * Ensured detached and final worktree entries are processed consistently.

* **Tests**
  * Updated integration and unit tests to validate structured worktree handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:summary:start -->

## Summary

## What was done

Replaced the untyped `list[dict[str, str]]` returned by
`git.worktree.list_worktrees()` with a shared, typed `Worktree` Pydantic model
and migrated every consumer across the git, service, and hook layers from
string-key access to typed attribute access. This is a pure maintainability
refactor with **no behavior change** — it closes #413 (deferred from PR #377,
originally suggested in the PR #376 CodeRabbit review).

## Changes

- **New model** `src/wade/models/worktree.py`: `Worktree(BaseModel)` with
  `path: str` (always present) and optional `head: str | None` / `branch: str | None`.
  Exported from `wade.models` (import + `__all__`).
- **`git/worktree.py`**: `list_worktrees()` now returns `list[Worktree]`. The
  parser holds its state as a typed `Worktree | None` — a `Worktree` is built
  when a `worktree ` line opens an entry and its optional `head`/`branch` fields
  are mutated as later lines are parsed, then the typed object is appended
  directly (no intermediate dict). Docstring `Returns:` updated.
- **Consumer migration** (string key → attribute): `review_service.py`,
  `plan_service.py` (both sites), `implementation_service/core.py`,
  `_shared.py`, `cleanup.py` (all `list_worktrees()` sites), `draft_pr.py`,
  `smart_start.py` (retyped the `worktrees` param to `list[Worktree]`, dropped
  the now-unused `from typing import Any`), and `git/hooks.py`.
- Semantics preserved exactly: `.get("branch")` → `.branch` (both `None` when
  absent), `.get("branch", "")` → `.branch or ""` where branch substrings are
  built, and the dead `.get("path", "")` default dropped (`path` is guaranteed).
  Fail-closed `try/except` loops in `draft_pr.py`/`plan_service.py` are unchanged.
- In `cleanup.py`, the `stale_wts` display-dict loops were renamed `wt` →
  `stale` so the typed `Worktree` loop and the out-of-scope display dict no
  longer share a variable name (also clears the last string-key access in the
  file). The `stale_wts` dict itself is out of scope and left as a raw dict.
- **Tests**: non-empty `list_worktrees` fixtures updated from dict literals to
  `Worktree(...)` instances; assertions over real output switched to attribute
  access (`test_git.py`, `test_detached_worktree.py`). `return_value=[]` mocks
  needed no change.

## Testing

- `./scripts/check.sh` — ruff lint, ruff format check, and `mypy --strict` all
  pass. Strict mypy is the safety net here: retyping the return value forces a
  type error on any missed consumer, and it reports clean.
- `./scripts/test.sh` — full suite: **3461 passed**.
- `wade review implementation` — headless review pass recorded, no actionable
  findings.

## Review round (PR #416 comments)

- **CodeRabbit 🟠 Major** (`worktree.py:164`, thread `PRRT_kwDORW_uUM6ZCv2k`):
  keep the parser state in a Pydantic model instead of `dict[str, str]`.
  Addressed — the parser now uses `current: Worktree | None`, builds the typed
  object up-front, and mutates its optional fields (see `git/worktree.py` above).
  A single `elif current is None: continue` guard narrows the type for mypy,
  avoiding a per-branch `if current is not None:`. Behavior unchanged; verified
  by the existing git integration + detached-worktree tests. Thread resolved.

## Notes for reviewers

- Out of scope (intentionally left as raw dicts): the `list_sessions()` return
  dict and the local `stale_wts` display dict in `cleanup.py` (both carry extra
  fields like `staleness`/`issue`/`commits_ahead`, one is `json.dumps`-serialized).
- `cli/worktree.py` was verified to need no change — its `sessions[idx][...]`
  accesses read `list_sessions()` output, not `list_worktrees()`.
- `path` stays `str` (not `Path`) deliberately: the porcelain output is a raw
  string, and `cleanup.py` compares `wt.path == str(wt_path)` — a `Path`-typed
  field would silently break that comparison.

<!-- wade:summary:end -->

<!-- wade:review-status:start -->

## Review Status

✅ Reviewed at `62859d9` via `wade review implementation`.

<!-- wade:review-status:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | *unavailable* |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `7d9947d7-2603-40d0-a608-67e88818d073` |
| Review | `claude` | `cb702ef8-de7f-43b2-8f4f-3fd844b1a152` |

<!-- wade:sessions:end -->
