### PR TITLE
fix(review): resolve worktree/branch by issue number + project-scope UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Requires [gh CLI](https://cli.github.com/) (authenticated) and at least one supp
 gh auth login    # if not already authenticated
 ```
 
+To let WADE move issues across a GitHub Projects (v2) board (e.g. to *In Progress*),
+also grant the `project` scope. This is optional — everything else works without it:
+
+```bash
+gh auth refresh -s project
+```
+
 ## Quick Start
 
 Initialize WADE in your project (once):

--- a/src/wade/providers/github.py
+++ b/src/wade/providers/github.py
@@ -977,12 +977,14 @@ query($owner: String!, $repo: String!, $number: Int!) {
                 .get("nodes", [])
             )
         except CommandError as e:
-            # Board move is best-effort. Surface the actionable scope hint here:
-            # this read query fails before the mutation path that also checks it,
-            # so this is the only place the user would otherwise see just a raw
-            # gh scope error. Don't retry a non-transient permission failure.
+            # Board move is best-effort, but surface the actionable scope hint at a
+            # VISIBLE level: the CLI logs at ERROR by default (logging/setup.py), so a
+            # logger.warning would be swallowed. This read query fails before the
+            # mutation path that also checks scope, so it's the only place the user
+            # would otherwise see just a raw gh error. Don't retry (a permission
+            # failure is not transient; providers must not import the UI console).
             if self._project_scope_missing(e.stderr):
-                logger.warning(
+                logger.error(
                     "github.project_scope_missing",
                     hint="Run: gh auth refresh -s project",
                 )
@@ -1049,10 +1051,11 @@ mutation($project_id: ID!, $item_id: ID!, $field_id: ID!, $option_id: String!) {
                 )
                 return True
             except CommandError as e:
-                # A read-capable token may still lack *write* project scope, so
-                # the mutation can fail on scope even when the query succeeded.
+                # A read-capable token may still lack *write* project scope, so the
+                # mutation can fail on scope even when the query succeeded. Emit at
+                # ERROR so the hint is visible at the default log level.
                 if self._project_scope_missing(e.stderr):
-                    logger.warning(
+                    logger.error(
                         "github.project_scope_missing",
                         hint="Run: gh auth refresh -s project",
                     )

--- a/src/wade/providers/github.py
+++ b/src/wade/providers/github.py
@@ -898,6 +898,22 @@ query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
 
     # --- Project board operations ---
 
+    @staticmethod
+    def _project_scope_missing(stderr: str) -> bool:
+        """Whether a gh Projects v2 error in *stderr* signals a missing OAuth scope.
+
+        Board moves need the ``project`` scope. gh surfaces its absence two ways
+        depending on the call: the GraphQL API's ``INSUFFICIENT_SCOPES`` error
+        type, and the CLI's human-readable "required scopes ... 'read:project'"
+        message on the read query. Match either so the actionable hint fires on
+        whichever call fails first.
+        """
+        return (
+            "INSUFFICIENT_SCOPES" in stderr
+            or "read:project" in stderr
+            or "required scopes" in stderr
+        )
+
     def move_to_in_progress(self, task_id: str) -> bool:
         """Move an issue to 'In Progress' on GitHub Projects v2.
 
@@ -950,7 +966,6 @@ query($owner: String!, $repo: String!, $number: Int!) {
                     f"query={query}",
                 ],
                 check=True,
-                retries=3,
             )
 
             data = json.loads(result.stdout)
@@ -961,7 +976,18 @@ query($owner: String!, $repo: String!, $number: Int!) {
                 .get("projectItems", {})
                 .get("nodes", [])
             )
-        except (CommandError, json.JSONDecodeError):
+        except CommandError as e:
+            # Board move is best-effort. Surface the actionable scope hint here:
+            # this read query fails before the mutation path that also checks it,
+            # so this is the only place the user would otherwise see just a raw
+            # gh scope error. Don't retry a non-transient permission failure.
+            if self._project_scope_missing(e.stderr):
+                logger.warning(
+                    "github.project_scope_missing",
+                    hint="Run: gh auth refresh -s project",
+                )
+            return False
+        except json.JSONDecodeError:
             return False
 
         # Find "In Progress" option across all linked projects
@@ -1016,7 +1042,6 @@ mutation($project_id: ID!, $item_id: ID!, $field_id: ID!, $option_id: String!) {
                         f"query={mutation}",
                     ],
                     check=True,
-                    retries=3,
                 )
                 logger.info(
                     "github.moved_to_in_progress",
@@ -1024,7 +1049,9 @@ mutation($project_id: ID!, $item_id: ID!, $field_id: ID!, $option_id: String!) {
                 )
                 return True
             except CommandError as e:
-                if "INSUFFICIENT_SCOPES" in e.stderr:
+                # A read-capable token may still lack *write* project scope, so
+                # the mutation can fail on scope even when the query succeeded.
+                if self._project_scope_missing(e.stderr):
                     logger.warning(
                         "github.project_scope_missing",
                         hint="Run: gh auth refresh -s project",

--- a/src/wade/services/review_service.py
+++ b/src/wade/services/review_service.py
@@ -75,7 +75,9 @@ logger = structlog.get_logger()
 # ---------------------------------------------------------------------------
 
 
-def _find_existing_branch_for_issue(repo_root: Path, issue: str) -> str | None:
+def _find_existing_branch_for_issue(
+    repo_root: Path, issue: str, preferred: str | None = None
+) -> str | None:
     """Return the name of an existing branch that belongs to *issue*, or ``None``.
 
     Matches by the stable issue *number* — first the worktrees, then local and
@@ -84,6 +86,13 @@ def _find_existing_branch_for_issue(repo_root: Path, issue: str) -> str | None:
     the issue renamed to conventional-commit form when its PR opens) would make a
     reconstructed name drift from the real branch. A worktree's branch is
     preferred because it is the exact ref checked out for the issue.
+
+    When more than one branch carries the issue number (e.g. a closed PR was
+    retitled and implementation restarted), selection is deterministic:
+    ``list_branch_names`` returns an unordered set, so prefer *preferred* — the
+    name reconstructed from the issue's *current* title, i.e. the freshest
+    branch — and otherwise fall back to sorted order rather than returning a
+    hash-ordered (across-run nondeterministic) element.
     """
     with contextlib.suppress(GitError):
         for wt in git_worktree.list_worktrees(repo_root):
@@ -94,10 +103,15 @@ def _find_existing_branch_for_issue(repo_root: Path, issue: str) -> str | None:
     # back to any local or remote branch carrying the issue number so the
     # remote-recovery path fetches the *real* branch rather than a drifted name.
     with contextlib.suppress(GitError):
+        matches: set[str] = set()
         for name in git_branch.list_branch_names(repo_root):
             short = name[len("origin/") :] if name.startswith("origin/") else name
             if extract_issue_from_branch(short) == issue:
-                return short
+                matches.add(short)
+        if preferred is not None and preferred in matches:
+            return preferred
+        if matches:
+            return sorted(matches)[0]
 
     return None
 
@@ -129,15 +143,16 @@ def _resolve_task_branch(config: ProjectConfig, task: Task, repo_root: Path) -> 
     except GitError:
         pass
 
-    existing = _find_existing_branch_for_issue(repo_root, issue)
-    if existing is not None:
-        return existing
-
-    return git_branch.make_branch_name(
+    # Reconstruct the current-title name once: it is both the tiebreaker preference
+    # for _find_existing_branch_for_issue (prefer the freshest branch when an issue
+    # has several) and the fallback when no branch for the issue exists yet.
+    reconstructed = git_branch.make_branch_name(
         config.project.branch_prefix,
         int(task.id),
         task.title,
     )
+    existing = _find_existing_branch_for_issue(repo_root, issue, preferred=reconstructed)
+    return existing if existing is not None else reconstructed
 
 
 def fetch_reviews(

--- a/src/wade/services/review_service.py
+++ b/src/wade/services/review_service.py
@@ -75,19 +75,64 @@ logger = structlog.get_logger()
 # ---------------------------------------------------------------------------
 
 
-def _resolve_task_branch(config: ProjectConfig, task: Task, repo_root: Path) -> str:
-    """Resolve the branch name for a task.
+def _find_existing_branch_for_issue(repo_root: Path, issue: str) -> str | None:
+    """Return the name of an existing branch that belongs to *issue*, or ``None``.
 
-    Prefers the currently checked-out branch when its issue number matches the
-    task; falls back to make_branch_name for out-of-worktree or detached-HEAD
-    callers.
+    Matches by the stable issue *number* — first the worktrees, then local and
+    remote branches — never by a freshly slugified title. The slug is frozen into
+    the branch at ``wade implement`` time, so a title edited afterward (commonly:
+    the issue renamed to conventional-commit form when its PR opens) would make a
+    reconstructed name drift from the real branch. A worktree's branch is
+    preferred because it is the exact ref checked out for the issue.
     """
+    with contextlib.suppress(GitError):
+        for wt in git_worktree.list_worktrees(repo_root):
+            if wt.branch and extract_issue_from_branch(wt.branch) == issue:
+                return wt.branch
+
+    # No live worktree (e.g. it was cleaned up while the PR stayed open) — fall
+    # back to any local or remote branch carrying the issue number so the
+    # remote-recovery path fetches the *real* branch rather than a drifted name.
+    with contextlib.suppress(GitError):
+        for name in git_branch.list_branch_names(repo_root):
+            short = name[len("origin/") :] if name.startswith("origin/") else name
+            if extract_issue_from_branch(short) == issue:
+                return short
+
+    return None
+
+
+def _resolve_task_branch(config: ProjectConfig, task: Task, repo_root: Path) -> str:
+    """Resolve the branch name for a task by its stable issue *number*.
+
+    Resolution order:
+
+    1. the currently checked-out branch, when it already carries this issue
+       (an in-worktree caller — authoritative);
+    2. an existing worktree / local / remote branch carrying this issue number
+       (see :func:`_find_existing_branch_for_issue`);
+    3. a name reconstructed from the current title — only when nothing for this
+       issue exists yet (first-time creation).
+
+    Resolving by number rather than by re-slugifying ``task.title`` is
+    deliberate: the branch slug is frozen at ``wade implement`` time, so a title
+    edited afterward regenerates a *different* name and orphans the real
+    worktree/PR — the "No worktree or remote branch found for issue #N" failure
+    this guards against.
+    """
+    issue = str(int(task.id))
+
     try:
         current_branch = git_repo.get_current_branch(repo_root)
-        if extract_issue_from_branch(current_branch) == str(int(task.id)):
+        if extract_issue_from_branch(current_branch) == issue:
             return current_branch
     except GitError:
         pass
+
+    existing = _find_existing_branch_for_issue(repo_root, issue)
+    if existing is not None:
+        return existing
+
     return git_branch.make_branch_name(
         config.project.branch_prefix,
         int(task.id),
@@ -125,8 +170,8 @@ def fetch_reviews(
         console.error(f"Could not read issue #{issue_number}: {e}")
         return False
 
-    # Find branch and PR — prefer actual checked-out branch (authoritative);
-    # fall back to reconstructed name for out-of-worktree or detached-HEAD callers.
+    # Resolve the branch by issue number (worktree / local / remote), not by
+    # re-slugifying the title — the title may have drifted since implement.
     branch_name = _resolve_task_branch(config, task, repo_root)
 
     lookup = git_pr.get_pr_for_branch(repo_root, branch_name)

--- a/tests/unit/test_providers/test_github.py
+++ b/tests/unit/test_providers/test_github.py
@@ -678,9 +678,60 @@ class TestMoveToInProgress:
         )
         mock_run.side_effect = [nwo_response, scope_err]
 
-        result = provider.move_to_in_progress("191")
+        with patch("wade.providers.github.logger") as mock_logger:
+            result = provider.move_to_in_progress("191")
 
         assert result is False
+        # Hint must be emitted at a VISIBLE level (logger.error), since the CLI
+        # logs at ERROR by default — a logger.warning would be swallowed.
+        mock_logger.error.assert_any_call(
+            "github.project_scope_missing", hint="Run: gh auth refresh -s project"
+        )
+
+    @patch("wade.providers.github.run")
+    def test_mutation_scope_error_hints_and_is_nonfatal(
+        self, mock_run: MagicMock, provider: GitHubProvider
+    ) -> None:
+        """A write-scope failure on the mutation (read succeeded) also surfaces the hint."""
+        nwo_response = _make_completed("owner/repo\n")
+        query_response = _make_completed(
+            json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "projectItems": {
+                                    "nodes": [
+                                        {
+                                            "id": "item-id",
+                                            "project": {
+                                                "id": "project-id",
+                                                "field": {
+                                                    "id": "field-id",
+                                                    "options": [
+                                                        {"id": "opt-id", "name": "In Progress"}
+                                                    ],
+                                                },
+                                            },
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        )
+        scope_err = CommandError(["gh"], 1, "errors: [{ type: INSUFFICIENT_SCOPES }]")
+        mock_run.side_effect = [nwo_response, query_response, scope_err]
+
+        with patch("wade.providers.github.logger") as mock_logger:
+            result = provider.move_to_in_progress("191")
+
+        assert result is False
+        mock_logger.error.assert_any_call(
+            "github.project_scope_missing", hint="Run: gh auth refresh -s project"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_providers/test_github.py
+++ b/tests/unit/test_providers/test_github.py
@@ -646,6 +646,42 @@ class TestMoveToInProgress:
 
         assert result is False
 
+    def test_project_scope_missing_classifier(self) -> None:
+        """The scope classifier matches both gh error wordings, and nothing else."""
+        cls = GitHubProvider._project_scope_missing
+        # GraphQL API error type (surfaced on the mutation path).
+        assert cls("errors: [{ type: INSUFFICIENT_SCOPES }]") is True
+        # gh CLI human-readable message (surfaced on the read query).
+        assert cls("requires one of the following scopes: ['read:project']") is True
+        assert cls("Your token has not been granted the required scopes") is True
+        # Unrelated failures must not masquerade as a scope problem.
+        assert cls("some unrelated GraphQL error") is False
+        assert cls("") is False
+
+    @patch("wade.providers.github.run")
+    def test_read_scope_error_is_nonfatal(
+        self, mock_run: MagicMock, provider: GitHubProvider
+    ) -> None:
+        """A missing project scope on the read query returns False (non-fatal).
+
+        This path previously swallowed the error silently; it must still return
+        False rather than raise — now while also surfacing the scope hint — even
+        though the failing read never reaches the mutation path's scope check.
+        """
+        nwo_response = _make_completed("owner/repo\n")
+        scope_err = CommandError(
+            ["gh"],
+            1,
+            "Your token has not been granted the required scopes to execute this "
+            "query. The 'id' field requires one of the following scopes: "
+            "['read:project'], but your token has only been granted: ['gist']",
+        )
+        mock_run.side_effect = [nwo_response, scope_err]
+
+        result = provider.move_to_in_progress("191")
+
+        assert result is False
+
 
 # ---------------------------------------------------------------------------
 # Registry tests

--- a/tests/unit/test_services/test_review_service.py
+++ b/tests/unit/test_services/test_review_service.py
@@ -22,6 +22,7 @@ from wade.services.implementation_service import (
 )
 from wade.services.review_service import (
     _capture_review_session_usage,
+    _find_existing_branch_for_issue,
     _post_review_lifecycle,
     _quiet_next_steps_prompt,
     _recover_worktree,
@@ -519,10 +520,11 @@ class TestReviewServiceStart:
             result = start(target="42")
 
         assert result is True
-        # Resolution came from the worktree's real branch, not the drifted slug.
-        mock_setup["make_branch_name"].assert_not_called()
+        # Resolution used the worktree's real (frozen) branch, never the drifted
+        # slug reconstructed from the current title.
         called_branch = mock_setup["get_pr_for_branch"].call_args[0][1]
         assert called_branch == "feat/42-fix-the-widget"
+        assert called_branch != "feat/42-totally-renamed"
 
     def test_recovers_by_issue_when_title_drifted(self, mock_setup: dict[str, MagicMock]) -> None:
         """With no live worktree, recovery fetches the real remote branch.
@@ -550,9 +552,11 @@ class TestReviewServiceStart:
             result = start(target="42")
 
         assert result is True
-        mock_setup["make_branch_name"].assert_not_called()
+        # Recovery used the real remote branch resolved by issue number, never the
+        # drifted slug reconstructed from the current title.
         recover_branch = mock_recover.call_args[0][1]
         assert recover_branch == "feat/42-fix-the-widget"
+        assert recover_branch != "feat/42-totally-renamed"
 
     def test_merged_pr_returns_false(
         self, tmp_path: Path, mock_setup: dict[str, MagicMock]
@@ -953,6 +957,50 @@ class TestCaptureReviewSessionUsage:
             )
 
         assert result == "claude-opus-4-6"
+
+
+# ---------------------------------------------------------------------------
+# _find_existing_branch_for_issue — resolve / disambiguate by issue number
+# ---------------------------------------------------------------------------
+
+
+class TestFindExistingBranchForIssue:
+    """Branch resolution by issue number, including same-issue ambiguity (#417 review)."""
+
+    def test_prefers_reconstructed_name_on_ambiguity(self, tmp_path: Path) -> None:
+        """>1 same-issue branch, no worktree → prefer the freshest (reconstructed) name."""
+        with (
+            patch("wade.services.review_service.git_worktree.list_worktrees", return_value=[]),
+            patch(
+                "wade.services.review_service.git_branch.list_branch_names",
+                return_value={"main", "feat/42-old-slug", "feat/42-new-slug"},
+            ),
+        ):
+            got = _find_existing_branch_for_issue(tmp_path, "42", preferred="feat/42-new-slug")
+        assert got == "feat/42-new-slug"
+
+    def test_ambiguity_without_preference_is_deterministic(self, tmp_path: Path) -> None:
+        """Ambiguous match without a preference is sorted (stable), not hash-ordered."""
+        branches = {"main", "feat/42-old-slug", "feat/42-new-slug"}
+        with (
+            patch("wade.services.review_service.git_worktree.list_worktrees", return_value=[]),
+            patch(
+                "wade.services.review_service.git_branch.list_branch_names",
+                return_value=branches,
+            ),
+        ):
+            first = _find_existing_branch_for_issue(tmp_path, "42")
+            second = _find_existing_branch_for_issue(tmp_path, "42")
+        assert first == second == "feat/42-new-slug"  # sorted(): "new" < "old"
+
+    def test_worktree_branch_wins_over_reconstructed(self, tmp_path: Path) -> None:
+        """A live worktree's branch is authoritative even when a preferred name is given."""
+        with patch(
+            "wade.services.review_service.git_worktree.list_worktrees",
+            return_value=[Worktree(path=str(tmp_path / "wt"), branch="feat/42-frozen-slug")],
+        ):
+            got = _find_existing_branch_for_issue(tmp_path, "42", preferred="feat/42-renamed")
+        assert got == "feat/42-frozen-slug"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services/test_review_service.py
+++ b/tests/unit/test_services/test_review_service.py
@@ -500,6 +500,60 @@ class TestReviewServiceStart:
         result = start(target="42")
         assert result is False
 
+    def test_resolves_worktree_by_issue_when_title_drifted(
+        self, mock_setup: dict[str, MagicMock]
+    ) -> None:
+        """A title edited after `wade implement` must not orphan the worktree.
+
+        The reconstructed name (make_branch_name) drifts from the real, frozen
+        branch; start() must still find the worktree by issue number and use the
+        real branch for PR lookup — never the drifted reconstruction.
+        """
+        # Simulate the issue having been retitled since implement: the
+        # regenerated slug no longer matches the branch frozen into the worktree.
+        mock_setup["make_branch_name"].return_value = "feat/42-totally-renamed"
+        with patch(
+            "wade.services.review_service.git_repo.get_current_branch",
+            side_effect=GitError("on main"),
+        ):
+            result = start(target="42")
+
+        assert result is True
+        # Resolution came from the worktree's real branch, not the drifted slug.
+        mock_setup["make_branch_name"].assert_not_called()
+        called_branch = mock_setup["get_pr_for_branch"].call_args[0][1]
+        assert called_branch == "feat/42-fix-the-widget"
+
+    def test_recovers_by_issue_when_title_drifted(self, mock_setup: dict[str, MagicMock]) -> None:
+        """With no live worktree, recovery fetches the real remote branch.
+
+        When the worktree was cleaned up but the PR branch still exists on the
+        remote, resolution falls back to the remote branch *by issue number* so
+        _recover_worktree fetches the real branch rather than a drifted slug.
+        """
+        mock_setup["make_branch_name"].return_value = "feat/42-totally-renamed"
+        mock_setup["list_worktrees"].return_value = []  # worktree already cleaned up
+        with (
+            patch(
+                "wade.services.review_service.git_repo.get_current_branch",
+                side_effect=GitError("on main"),
+            ),
+            patch(
+                "wade.services.review_service.git_branch.list_branch_names",
+                return_value={"main", "origin/feat/42-fix-the-widget"},
+            ),
+            patch(
+                "wade.services.review_service._recover_worktree",
+                return_value=Path("/tmp/recovered"),
+            ) as mock_recover,
+        ):
+            result = start(target="42")
+
+        assert result is True
+        mock_setup["make_branch_name"].assert_not_called()
+        recover_branch = mock_recover.call_args[0][1]
+        assert recover_branch == "feat/42-fix-the-widget"
+
     def test_merged_pr_returns_false(
         self, tmp_path: Path, mock_setup: dict[str, MagicMock]
     ) -> None:


### PR DESCRIPTION
## Why

Two independent defects surfaced from a single session (implement #191 → PR opened → `exit` → `review pr-comments` auto-ran):

1. **`review pr-comments` failed with "No worktree or remote branch found for issue #191"** even though the worktree, local + remote branch, and open PR all existed. Root cause confirmed empirically: the review flow **regenerated** the branch name by re-slugifying the issue's *current* title and required an exact match. The branch slug is frozen at `wade implement` time, but issue #191 was retitled afterward (`[firma/correctness] …` → `fix(firma): …`, the conventional-commit form its PR uses), so the regenerated name (`feat/191-fix-firma-settlement-under-reports-prize-on-mixed`) no longer matched the real branch (`feat/191-firma-correctness-settlement-under-reports-prize`). Both the local worktree match and the remote-recovery `git fetch` used that drifted name and missed together.

2. **A missing `project` OAuth scope produced a scary `subprocess.failed` ERROR (retried 3×) with no actionable guidance.** `move_to_in_progress()`'s board move is best-effort, but the read query swallowed the scope error silently — the `gh auth refresh -s project` hint only lived on the mutation path, which the failing read never reaches — and the narrow `INSUFFICIENT_SCOPES` check didn't even match gh's CLI wording (`required scopes ... 'read:project'`).

## What changed

**Fix #1 — `src/wade/services/review_service.py`**
- Resolve the task branch by the **stable issue number**: checked-out branch → an existing worktree/local/remote branch carrying that number (new `_find_existing_branch_for_issue` helper) → title reconstruction only when nothing for the issue exists yet.
- Fixes every caller at once: `start()` (the post-`exit` handoff), `fetch_reviews()`, and the remote-recovery path (now fetches the *real* branch, not a drifted slug). No title edit can orphan the worktree/PR again.

**Fix #2 — `src/wade/providers/github.py`, `README.md`**
- New `_project_scope_missing()` classifier matches **both** gh wordings (`INSUFFICIENT_SCOPES` and the CLI's `required scopes … read:project`).
- Surface the `gh auth refresh -s project` hint on the read path (previously unreachable).
- Drop `retries=3` on both best-effort project calls — no pointless retry of a non-transient permission error.
- Document the optional `project` scope in the README.

## Tests
- `test_resolves_worktree_by_issue_when_title_drifted`, `test_recovers_by_issue_when_title_drifted` — resolution/recovery by issue number when the reconstructed name diverges.
- `test_project_scope_missing_classifier`, `test_read_scope_error_is_nonfatal` — both error wordings + read-path handling.
- Full unit suite green (3224 passed); ruff + mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing GitHub Projects permissions with clear guidance and no unnecessary retries.
  * Review workflows now find existing branches and worktrees reliably even when issue titles change.
  * Pull request lookup and worktree recovery use the correct existing branch.

* **Documentation**
  * Added instructions for granting the optional GitHub Projects permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->