### PR TITLE
chore(config): default implementation sessions to yolo, matching plan/review_batch

### DIFF
--- a/.wade.yml
+++ b/.wade.yml
@@ -12,6 +12,8 @@ ai:
   plan:
     effort: xhigh
     yolo: true
+  implement:
+    yolo: true
   deps:
     tool: claude
     model: claude-sonnet-5


### PR DESCRIPTION
## What

Adds an `ai.implement` scope to `.wade.yml` with `yolo: true`.

```yaml
ai:
  implement:
    yolo: true
```

## Why

Interactive **plan** (`ai.plan.yolo: true`) and **review_batch** (`ai.review_batch.yolo: true`) sessions already opt into yolo, but the **implementation** session had no `ai.implement` scope, so it fell through to the global `ai.yolo: false`.

The resolver keys the impl session's permission mode on command `"implement"` (`implementation_service/core.py:561`), and the loader recognizes the `ai.implement` scope (`config/loader.py:195`). With no scope + `ai.yolo: false`, the session launched the tool **bare** at the default permission tier.

For `agy` (Antigravity CLI) that default tier is exactly what gates `run_command` behind interactive approval — and **hard-denies it for subagents** (which can't surface a prompt), producing `run_command was denied by system security policy for subagents`. This surfaced as an apparent "hook blocking shell", but it was neither a wade nor crossby bug — the write guards and Stop/PreToolUse hooks behaved correctly. It was purely the autonomy asymmetry in this project's own config.

## Effect

Impl sessions now launch with the same autonomy as plan/review_batch. For agy that means `--dangerously-skip-permissions --sandbox` — approval prompts skipped (subagents included) while agy's write-sandbox stays on and wade's worktree Stop/write guards still contain writes.

Verified resolution:

```
implement     -> yolo   (was: default)
plan          -> yolo
review_batch  -> yolo
deps (headless) -> default   # unchanged; headless forces default regardless
```

No code changes.