### PR TITLE
fix(init): preserve user-set ai.implement keys on re-init

### DIFF
--- a/src/wade/services/init_service/config_io.py
+++ b/src/wade/services/init_service/config_io.py
@@ -370,13 +370,24 @@ def _patch_config(
         raw["ai"] = ai
         changed = True
 
-    # Patch implement tool override
+    # Patch implement tool override. Manage ONLY the ``tool`` key: any other
+    # implement-scoped keys a user set by hand (model / effort / mode /
+    # permission_mode / yolo / enabled / timeout — all valid under ``ai.implement``
+    # and honored by the loader) must survive a re-init. Replacing the section
+    # wholesale or ``del``-ing it silently dropped them, so mutate a copy and keep
+    # the section iff anything is left.
     if force:
+        existing = ai.get("implement")
+        section: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
         if implement_tool and implement_tool != ai_tool:
-            ai["implement"] = {"tool": implement_tool}
-            changed = True
+            section["tool"] = implement_tool
+        else:
+            section.pop("tool", None)
+        if section:
+            ai["implement"] = section
         elif "implement" in ai:
             del ai["implement"]
+        if ai.get("implement") != existing:
             changed = True
         raw["ai"] = ai
     elif implement_tool and implement_tool != ai_tool and not ai.get("implement"):

--- a/src/wade/services/init_service/config_io.py
+++ b/src/wade/services/init_service/config_io.py
@@ -347,6 +347,9 @@ def _patch_config(
 
     # Patch AI tool and default model
     ai = raw.get("ai", {}) or {}
+    # Captured before the overwrite below: the implement-section patch further down
+    # needs the *previous* default to tell whether the effective implement tool changed.
+    old_default_tool = ai.get("default_tool")
     if ai_tool and (force or not ai.get("default_tool")):
         ai["default_tool"] = str(ai_tool)
         raw["ai"] = ai
@@ -383,6 +386,17 @@ def _patch_config(
             section["tool"] = implement_tool
         else:
             section.pop("tool", None)
+        # ``model`` is the one tool-specific key here: resolve_model prefers this
+        # command-scoped value over the freshly-written ``models.<tool>`` mapping and
+        # drops it as incompatible for a different tool, so a stale pin would shadow
+        # the re-init's model choice. Drop it only on a *confirmed* effective-tool
+        # change; portable keys (permission_mode / yolo / effort / mode / enabled /
+        # timeout) always survive.
+        existing_tool = existing.get("tool") if isinstance(existing, dict) else None
+        old_effective_tool = existing_tool or old_default_tool
+        new_effective_tool = implement_tool or ai_tool
+        if old_effective_tool and new_effective_tool and old_effective_tool != new_effective_tool:
+            section.pop("model", None)
         if section:
             ai["implement"] = section
         elif "implement" in ai:

--- a/src/wade/services/init_service/config_io.py
+++ b/src/wade/services/init_service/config_io.py
@@ -386,17 +386,19 @@ def _patch_config(
             section["tool"] = implement_tool
         else:
             section.pop("tool", None)
-        # ``model`` is the one tool-specific key here: resolve_model prefers this
-        # command-scoped value over the freshly-written ``models.<tool>`` mapping and
-        # drops it as incompatible for a different tool, so a stale pin would shadow
-        # the re-init's model choice. Drop it only on a *confirmed* effective-tool
-        # change; portable keys (permission_mode / yolo / effort / mode / enabled /
-        # timeout) always survive.
+        # ``model`` and ``effort`` are the tool-specific keys here: resolve_model /
+        # resolve_effort both give the command-scoped value precedence over the
+        # freshly-written ``models.<tool>`` mapping, then reject it for a different
+        # tool — an incompatible model or an unsupported effort (e.g. agy rejects
+        # ``xhigh``) resolves to ``None`` — so a stale pin silently shadows the
+        # re-init's choice. Drop both only on a *confirmed* effective-tool change;
+        # portable keys (permission_mode / yolo / mode / enabled / timeout) survive.
         existing_tool = existing.get("tool") if isinstance(existing, dict) else None
         old_effective_tool = existing_tool or old_default_tool
         new_effective_tool = implement_tool or ai_tool
         if old_effective_tool and new_effective_tool and old_effective_tool != new_effective_tool:
             section.pop("model", None)
+            section.pop("effort", None)
         if section:
             ai["implement"] = section
         elif "implement" in ai:

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -1029,6 +1029,43 @@ class TestPatchConfig:
         config = yaml.safe_load(config_path.read_text())
         assert config["ai"]["implement"] == {"yolo": True, "tool": "antigravity-cli"}
 
+    def test_force_drops_stale_implement_model_on_tool_change(self, tmp_path: Path) -> None:
+        """A tool-specific ``ai.implement.model`` is cleared when the impl tool changes.
+
+        Otherwise the stale pin outranks the freshly-written ``models.<new-tool>``
+        mapping (resolve_model precedence) and gets dropped as incompatible, so the
+        re-init's model choice is silently ignored. Portable keys still survive.
+        """
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text(
+            "version: 2\nai:\n  default_tool: claude\n"
+            "  implement:\n    model: claude-opus-4.8\n    yolo: true\n"
+        )
+        _patch_config(
+            config_path,
+            "claude",
+            ComplexityModelMapping(),
+            implement_tool="antigravity-cli",
+            force=True,
+        )
+        config = yaml.safe_load(config_path.read_text())
+        # model (pinned for claude) is dropped; yolo (portable) survives; tool set.
+        assert config["ai"]["implement"] == {"yolo": True, "tool": "antigravity-cli"}
+
+    def test_force_keeps_implement_model_when_tool_unchanged(self, tmp_path: Path) -> None:
+        """An ``ai.implement.model`` survives re-init when the effective tool is unchanged."""
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text(
+            "version: 2\nai:\n  default_tool: claude\n"
+            "  implement:\n    model: claude-opus-4.8\n    yolo: true\n"
+        )
+        # implement_tool == default tool → effective tool stays claude → model kept.
+        _patch_config(
+            config_path, "claude", ComplexityModelMapping(), implement_tool="claude", force=True
+        )
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["implement"] == {"model": "claude-opus-4.8", "yolo": True}
+
     def test_force_sets_command_overrides(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
         config_path.write_text("version: 2\nai:\n  default_tool: claude\n")

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -983,6 +983,52 @@ class TestPatchConfig:
         config = yaml.safe_load(config_path.read_text())
         assert "implement" not in config["ai"]
 
+    def test_force_preserves_other_implement_keys_when_tool_removed(self, tmp_path: Path) -> None:
+        """Re-init must strip only the redundant ``tool`` key, not user-set siblings.
+
+        ``ai.implement`` legitimately carries yolo/effort/permission_mode/etc.
+        (all honored by the loader); a force re-init where the implement tool
+        matches the default previously deleted the whole section, silently
+        dropping those keys.
+        """
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text(
+            "version: 2\nai:\n  default_tool: claude\n"
+            "  implement:\n    tool: antigravity-cli\n    yolo: true\n    effort: xhigh\n"
+        )
+        _patch_config(
+            config_path, "claude", ComplexityModelMapping(), implement_tool="claude", force=True
+        )
+        config = yaml.safe_load(config_path.read_text())
+        # tool (now redundant, == default) is removed; the rest survives.
+        assert config["ai"]["implement"] == {"yolo": True, "effort": "xhigh"}
+
+    def test_force_preserves_toolless_implement_section(self, tmp_path: Path) -> None:
+        """A hand-authored ``ai.implement`` with no ``tool`` key survives re-init untouched."""
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text(
+            "version: 2\nai:\n  default_tool: claude\n  implement:\n    yolo: true\n"
+        )
+        _patch_config(config_path, "claude", ComplexityModelMapping(), force=True)
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["implement"] == {"yolo": True}
+
+    def test_force_sets_implement_tool_preserves_siblings(self, tmp_path: Path) -> None:
+        """Setting a differing implement tool keeps other implement-scoped keys."""
+        config_path = tmp_path / ".wade.yml"
+        config_path.write_text(
+            "version: 2\nai:\n  default_tool: claude\n  implement:\n    yolo: true\n"
+        )
+        _patch_config(
+            config_path,
+            "claude",
+            ComplexityModelMapping(),
+            implement_tool="antigravity-cli",
+            force=True,
+        )
+        config = yaml.safe_load(config_path.read_text())
+        assert config["ai"]["implement"] == {"yolo": True, "tool": "antigravity-cli"}
+
     def test_force_sets_command_overrides(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"
         config_path.write_text("version: 2\nai:\n  default_tool: claude\n")

--- a/tests/unit/test_services/test_init.py
+++ b/tests/unit/test_services/test_init.py
@@ -994,13 +994,14 @@ class TestPatchConfig:
         config_path = tmp_path / ".wade.yml"
         config_path.write_text(
             "version: 2\nai:\n  default_tool: claude\n"
-            "  implement:\n    tool: antigravity-cli\n    yolo: true\n    effort: xhigh\n"
+            "  implement:\n    tool: claude\n    yolo: true\n    effort: xhigh\n"
         )
         _patch_config(
             config_path, "claude", ComplexityModelMapping(), implement_tool="claude", force=True
         )
         config = yaml.safe_load(config_path.read_text())
-        # tool (now redundant, == default) is removed; the rest survives.
+        # tool (redundant, == default) is removed; effective tool is unchanged
+        # (claude → claude), so the tool-specific effort survives alongside yolo.
         assert config["ai"]["implement"] == {"yolo": True, "effort": "xhigh"}
 
     def test_force_preserves_toolless_implement_section(self, tmp_path: Path) -> None:
@@ -1029,17 +1030,18 @@ class TestPatchConfig:
         config = yaml.safe_load(config_path.read_text())
         assert config["ai"]["implement"] == {"yolo": True, "tool": "antigravity-cli"}
 
-    def test_force_drops_stale_implement_model_on_tool_change(self, tmp_path: Path) -> None:
-        """A tool-specific ``ai.implement.model`` is cleared when the impl tool changes.
+    def test_force_drops_stale_tool_specific_keys_on_tool_change(self, tmp_path: Path) -> None:
+        """Tool-specific ``model``/``effort`` are cleared when the impl tool changes.
 
-        Otherwise the stale pin outranks the freshly-written ``models.<new-tool>``
-        mapping (resolve_model precedence) and gets dropped as incompatible, so the
-        re-init's model choice is silently ignored. Portable keys still survive.
+        Both outrank the freshly-written per-tool mapping (resolve_model /
+        resolve_effort precedence) and get rejected as incompatible for the new
+        tool (e.g. agy rejects ``xhigh``), so a stale pin silently voids the
+        re-init's choice. Portable keys still survive.
         """
         config_path = tmp_path / ".wade.yml"
         config_path.write_text(
             "version: 2\nai:\n  default_tool: claude\n"
-            "  implement:\n    model: claude-opus-4.8\n    yolo: true\n"
+            "  implement:\n    model: claude-opus-4.8\n    effort: xhigh\n    yolo: true\n"
         )
         _patch_config(
             config_path,
@@ -1049,22 +1051,26 @@ class TestPatchConfig:
             force=True,
         )
         config = yaml.safe_load(config_path.read_text())
-        # model (pinned for claude) is dropped; yolo (portable) survives; tool set.
+        # model + effort (pinned for claude) dropped; yolo (portable) survives; tool set.
         assert config["ai"]["implement"] == {"yolo": True, "tool": "antigravity-cli"}
 
-    def test_force_keeps_implement_model_when_tool_unchanged(self, tmp_path: Path) -> None:
-        """An ``ai.implement.model`` survives re-init when the effective tool is unchanged."""
+    def test_force_keeps_tool_specific_keys_when_tool_unchanged(self, tmp_path: Path) -> None:
+        """``ai.implement`` model/effort survive re-init when the effective tool is unchanged."""
         config_path = tmp_path / ".wade.yml"
         config_path.write_text(
             "version: 2\nai:\n  default_tool: claude\n"
-            "  implement:\n    model: claude-opus-4.8\n    yolo: true\n"
+            "  implement:\n    model: claude-opus-4.8\n    effort: xhigh\n    yolo: true\n"
         )
-        # implement_tool == default tool → effective tool stays claude → model kept.
+        # implement_tool == default tool → effective tool stays claude → keys kept.
         _patch_config(
             config_path, "claude", ComplexityModelMapping(), implement_tool="claude", force=True
         )
         config = yaml.safe_load(config_path.read_text())
-        assert config["ai"]["implement"] == {"model": "claude-opus-4.8", "yolo": True}
+        assert config["ai"]["implement"] == {
+            "model": "claude-opus-4.8",
+            "effort": "xhigh",
+            "yolo": True,
+        }
 
     def test_force_sets_command_overrides(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".wade.yml"


### PR DESCRIPTION
## The bug

`_patch_config` (`init_service/config_io.py`) treated the `ai.implement` section as if it only ever held a `tool` override. On the **force** path — which runs on an interactive `wade init` re-run (`commands.py`: `force=not non_interactive`) — it either:

- replaced the whole section with `{"tool": implement_tool}`, or
- **`del`-eted the entire section** when the implement tool matched the default (the common single-tool case).

But `ai.implement` legitimately carries `model` / `effort` / `mode` / `permission_mode` / `yolo` / `enabled` / `timeout` — all parsed by the loader (`loader.py`: `command_configs["implement"] = _parse_command_config(...)`) and honored at resolution (e.g. `resolve_permission_mode(..., "implement")`). So any of those a user hand-set were **silently destroyed** the next time they ran `wade init`.

Concretely: a user who adds `ai.implement.yolo: true` (or `effort`, `permission_mode`, …) loses it on the next interactive re-init whenever their implement tool equals the default tool.

## The fix

Manage **only** the `tool` key: mutate a copy of the existing section, set or drop `tool`, and keep the section iff anything remains (deleting it only when it becomes empty). A tool-only section still collapses to deletion, so behavior for init-authored configs is unchanged.

## Tests

- `test_force_removes_implement_section_when_same_as_default` — unchanged, still green (tool-only section → empty → deleted).
- `test_force_preserves_other_implement_keys_when_tool_removed` — new: `{tool, yolo, effort}` with implement==default → `{yolo, effort}` (tool stripped, siblings kept).
- `test_force_preserves_toolless_implement_section` — new: a hand-authored toolless section survives untouched.
- `test_force_sets_implement_tool_preserves_siblings` — new: setting a differing implement tool keeps siblings.

Full `test_init.py` (201 tests) passes; mypy + ruff clean.

## Context

Found while investigating why an agy implementation session couldn't run shell (that turned out to be agy's own permission policy + a config gap — see #424, which adds `ai.implement.yolo: true`). This is the code-level bug that would otherwise silently revert that kind of hand-added `ai.implement` setting on re-init.