### PR TITLE
fix(batch): forward resolved permission mode to child sessions when explicit

### DIFF
--- a/src/wade/services/implementation_service/batch.py
+++ b/src/wade/services/implementation_service/batch.py
@@ -71,16 +71,27 @@ def _build_implement_cmd(
     model_explicit: bool,
     effort: EffortLevel | None,
     permission_mode: PermissionMode,
+    permission_mode_explicit: bool,
     chain_ids: list[str] | None = None,
 ) -> list[str]:
     """Build the ``wade implement`` child command for one batch issue.
 
-    The resolved permission mode is forwarded **unconditionally**. Each child
-    process reloads the project config and re-resolves its own permission mode, so
-    a parent that resolved ``default`` — e.g. the user explicitly downgraded from a
-    yolo-configured ``ai.implement`` — but sent no flag would have every child
-    silently resolve back to ``yolo``, launching with more autonomy than the user
-    confirmed. Forwarding it every time pins children to the parent's decision.
+    The permission mode is forwarded **only when it was explicit** — the user
+    passed ``--permission-mode``/``--yolo`` or changed it in the confirmation UI.
+    Two failure modes bound this:
+
+    - *Forward an explicit mode.* A child reloads the project config and
+      re-resolves its own permission mode, so an explicit ``default`` (e.g. the
+      user downgrading from a yolo-configured ``ai.implement``) that was *not*
+      forwarded would have every child resolve back to ``yolo`` — more autonomy
+      than the user confirmed. Forwarding it pins children to that decision.
+    - *Don't forward an implicit one.* ``wade implement`` derives
+      ``permission_mode_explicit`` from ``--permission-mode`` being present, and
+      that explicitness propagates into the post-implementation review flow. So
+      forwarding an *implicit* ``default`` would make it look chosen and suppress a
+      child's own config-driven autonomy downstream (e.g. a non-default
+      ``ai.review_pr_comments.permission_mode``). An implicit mode is left for each
+      child to re-resolve from the same config, reaching the same result.
     """
     cmd = ["wade", "implement", issue_id]
     if tool:
@@ -89,7 +100,8 @@ def _build_implement_cmd(
         cmd.extend(["--model", model])
     if effort:
         cmd.extend(["--effort", effort.value])
-    cmd.extend(["--permission-mode", permission_mode.value])
+    if permission_mode_explicit:
+        cmd.extend(["--permission-mode", permission_mode.value])
     if chain_ids:
         cmd.extend(["--chain", ",".join(chain_ids)])
     return cmd
@@ -187,6 +199,7 @@ def batch(
     resolved_effort = resolve_effort(effort, config, "implement", tool=resolved_tool)
     resolved_permission_mode = resolve_permission_mode(permission_mode, yolo, config, "implement")
     _pre_model = resolved_model
+    _pre_permission_mode = resolved_permission_mode
     (
         resolved_tool,
         resolved_model,
@@ -205,6 +218,16 @@ def batch(
     # If the user changed the model interactively, propagate it explicitly to child sessions
     if not model_explicit and resolved_model != _pre_model:
         model_explicit = True
+    # Forward the permission mode to children only when the user actually chose it —
+    # a CLI flag, or a change in the confirmation UI. An implicit default/yolo
+    # (resolved purely from config) is left for each child to re-resolve, so we do
+    # not make an implicit mode look explicit and suppress a child's own
+    # config-driven autonomy downstream (see _build_implement_cmd).
+    permission_mode_explicit = (
+        permission_mode is not None
+        or yolo is not None
+        or resolved_permission_mode != _pre_permission_mode
+    )
 
     if not model_explicit:
         console.info("Model: auto (per-issue complexity)")
@@ -231,7 +254,7 @@ def batch(
         """Build the ``wade implement`` command for a single issue.
 
         Thin closure over the resolved selection; see :func:`_build_implement_cmd`
-        for the command shape and why the permission mode is always forwarded.
+        for the command shape and when the permission mode is forwarded.
         """
         return _build_implement_cmd(
             issue_id,
@@ -240,6 +263,7 @@ def batch(
             model_explicit=model_explicit,
             effort=resolved_effort,
             permission_mode=resolved_permission_mode,
+            permission_mode_explicit=permission_mode_explicit,
             chain_ids=chain_ids,
         )
 

--- a/src/wade/services/implementation_service/batch.py
+++ b/src/wade/services/implementation_service/batch.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 
 import structlog
+from crossby.models.ai import EffortLevel
 
 from wade.config.loader import load_config
 from wade.git import branch as git_branch
@@ -49,6 +50,7 @@ __all__ = [
     "_POLL_INTERVAL_SECONDS",
     "_POLL_TIMEOUT_SECONDS",
     "_build_graph_from_issues",
+    "_build_implement_cmd",
     "_build_pr_index",
     "_classify_issue_status",
     "_find_tracking_issue",
@@ -59,6 +61,38 @@ __all__ = [
     "check_tracking_issue_and_batch",
     "poll_batch_completion",
 ]
+
+
+def _build_implement_cmd(
+    issue_id: str,
+    *,
+    tool: str | None,
+    model: str | None,
+    model_explicit: bool,
+    effort: EffortLevel | None,
+    permission_mode: PermissionMode,
+    chain_ids: list[str] | None = None,
+) -> list[str]:
+    """Build the ``wade implement`` child command for one batch issue.
+
+    The resolved permission mode is forwarded **unconditionally**. Each child
+    process reloads the project config and re-resolves its own permission mode, so
+    a parent that resolved ``default`` — e.g. the user explicitly downgraded from a
+    yolo-configured ``ai.implement`` — but sent no flag would have every child
+    silently resolve back to ``yolo``, launching with more autonomy than the user
+    confirmed. Forwarding it every time pins children to the parent's decision.
+    """
+    cmd = ["wade", "implement", issue_id]
+    if tool:
+        cmd.extend(["--ai", tool])
+    if model and model_explicit:
+        cmd.extend(["--model", model])
+    if effort:
+        cmd.extend(["--effort", effort.value])
+    cmd.extend(["--permission-mode", permission_mode.value])
+    if chain_ids:
+        cmd.extend(["--chain", ",".join(chain_ids)])
+    return cmd
 
 
 def check_tracking_issue_and_batch(
@@ -194,24 +228,20 @@ def batch(
         chains = []
 
     def _build_cmd(issue_id: str, chain_ids: list[str] | None = None) -> list[str]:
-        """Build the wade implement command for a single issue.
+        """Build the ``wade implement`` command for a single issue.
 
-        Args:
-            issue_id: The issue number to implement.
-            chain_ids: Optional remaining issue IDs for --chain continuation.
+        Thin closure over the resolved selection; see :func:`_build_implement_cmd`
+        for the command shape and why the permission mode is always forwarded.
         """
-        cmd = ["wade", "implement", issue_id]
-        if resolved_tool:
-            cmd.extend(["--ai", resolved_tool])
-        if resolved_model and model_explicit:
-            cmd.extend(["--model", resolved_model])
-        if resolved_effort:
-            cmd.extend(["--effort", resolved_effort.value])
-        if resolved_permission_mode is not PermissionMode.DEFAULT:
-            cmd.extend(["--permission-mode", resolved_permission_mode.value])
-        if chain_ids:
-            cmd.extend(["--chain", ",".join(chain_ids)])
-        return cmd
+        return _build_implement_cmd(
+            issue_id,
+            tool=resolved_tool,
+            model=resolved_model,
+            model_explicit=model_explicit,
+            effort=resolved_effort,
+            permission_mode=resolved_permission_mode,
+            chain_ids=chain_ids,
+        )
 
     # Collect all items to launch in one batch
     batch_items: list[tuple[list[str], str | None, str | None]] = []

--- a/tests/unit/test_services/test_batch_build_cmd.py
+++ b/tests/unit/test_services/test_batch_build_cmd.py
@@ -1,10 +1,14 @@
 """Unit tests for ``_build_implement_cmd`` — the batch ``wade implement`` child command.
 
-Regression coverage for the permission-mode propagation bug: batch children reload
-the project config and re-resolve their own permission mode, so an explicitly
-resolved ``default`` that is *not* forwarded lets each child resolve back to a
-``yolo``-configured ``ai.implement`` — launching with more autonomy than confirmed.
-The resolved mode must therefore be forwarded unconditionally.
+The permission mode is forwarded to children **only when it was explicit**. Two
+bugs bound this and both are covered here:
+
+- An explicit ``default`` (e.g. the user downgrading from a yolo-configured
+  ``ai.implement``) must be forwarded, else each child reloads the config and
+  re-resolves back to ``yolo`` — more autonomy than confirmed.
+- An implicit ``default`` must NOT be forwarded, else ``wade implement`` treats it
+  as explicit and suppresses a child's own config-driven autonomy downstream
+  (e.g. a non-default ``ai.review_pr_comments.permission_mode``).
 """
 
 from __future__ import annotations
@@ -15,13 +19,9 @@ from wade.models.permission import PermissionMode
 from wade.services.implementation_service.batch import _build_implement_cmd
 
 
-def _mode_value(cmd: list[str]) -> str:
-    return cmd[cmd.index("--permission-mode") + 1]
-
-
 class TestBuildImplementCmd:
-    def test_forwards_default_permission_mode(self) -> None:
-        """An explicitly resolved ``default`` is forwarded so children can't
+    def test_forwards_explicit_default_permission_mode(self) -> None:
+        """An explicitly chosen ``default`` is forwarded so children can't
         re-resolve a yolo config back to yolo."""
         cmd = _build_implement_cmd(
             "42",
@@ -30,10 +30,39 @@ class TestBuildImplementCmd:
             model_explicit=False,
             effort=None,
             permission_mode=PermissionMode.DEFAULT,
+            permission_mode_explicit=True,
         )
         assert cmd == ["wade", "implement", "42", "--ai", "claude", "--permission-mode", "default"]
 
-    def test_forwards_yolo_permission_mode(self) -> None:
+    def test_omits_implicit_default_permission_mode(self) -> None:
+        """An implicit ``default`` is NOT forwarded — left for the child to
+        re-resolve, so it doesn't look explicit downstream."""
+        cmd = _build_implement_cmd(
+            "42",
+            tool="claude",
+            model=None,
+            model_explicit=False,
+            effort=None,
+            permission_mode=PermissionMode.DEFAULT,
+            permission_mode_explicit=False,
+        )
+        assert "--permission-mode" not in cmd
+
+    def test_omits_implicit_yolo_permission_mode(self) -> None:
+        """Even a non-default mode stays unforwarded when implicit — the child
+        re-resolves the same yolo from the shared config."""
+        cmd = _build_implement_cmd(
+            "9",
+            tool="claude",
+            model=None,
+            model_explicit=False,
+            effort=None,
+            permission_mode=PermissionMode.YOLO,
+            permission_mode_explicit=False,
+        )
+        assert "--permission-mode" not in cmd
+
+    def test_forwards_explicit_yolo_permission_mode(self) -> None:
         cmd = _build_implement_cmd(
             "7",
             tool="claude",
@@ -41,8 +70,9 @@ class TestBuildImplementCmd:
             model_explicit=False,
             effort=None,
             permission_mode=PermissionMode.YOLO,
+            permission_mode_explicit=True,
         )
-        assert _mode_value(cmd) == "yolo"
+        assert cmd[cmd.index("--permission-mode") + 1] == "yolo"
 
     def test_model_only_forwarded_when_explicit(self) -> None:
         implicit = _build_implement_cmd(
@@ -52,6 +82,7 @@ class TestBuildImplementCmd:
             model_explicit=False,
             effort=None,
             permission_mode=PermissionMode.DEFAULT,
+            permission_mode_explicit=False,
         )
         assert "--model" not in implicit
         explicit = _build_implement_cmd(
@@ -61,6 +92,7 @@ class TestBuildImplementCmd:
             model_explicit=True,
             effort=None,
             permission_mode=PermissionMode.DEFAULT,
+            permission_mode_explicit=False,
         )
         assert "--model" in explicit
         assert explicit[explicit.index("--model") + 1] == "claude-opus-4.8"
@@ -73,8 +105,9 @@ class TestBuildImplementCmd:
             model_explicit=False,
             effort=EffortLevel.HIGH,
             permission_mode=PermissionMode.ACCEPT_EDITS,
+            permission_mode_explicit=True,
             chain_ids=["4", "5"],
         )
         assert cmd[cmd.index("--effort") + 1] == "high"
         assert cmd[cmd.index("--chain") + 1] == "4,5"
-        assert _mode_value(cmd) == "accept-edits"
+        assert cmd[cmd.index("--permission-mode") + 1] == "accept-edits"

--- a/tests/unit/test_services/test_batch_build_cmd.py
+++ b/tests/unit/test_services/test_batch_build_cmd.py
@@ -1,0 +1,80 @@
+"""Unit tests for ``_build_implement_cmd`` — the batch ``wade implement`` child command.
+
+Regression coverage for the permission-mode propagation bug: batch children reload
+the project config and re-resolve their own permission mode, so an explicitly
+resolved ``default`` that is *not* forwarded lets each child resolve back to a
+``yolo``-configured ``ai.implement`` — launching with more autonomy than confirmed.
+The resolved mode must therefore be forwarded unconditionally.
+"""
+
+from __future__ import annotations
+
+from crossby.models.ai import EffortLevel
+
+from wade.models.permission import PermissionMode
+from wade.services.implementation_service.batch import _build_implement_cmd
+
+
+def _mode_value(cmd: list[str]) -> str:
+    return cmd[cmd.index("--permission-mode") + 1]
+
+
+class TestBuildImplementCmd:
+    def test_forwards_default_permission_mode(self) -> None:
+        """An explicitly resolved ``default`` is forwarded so children can't
+        re-resolve a yolo config back to yolo."""
+        cmd = _build_implement_cmd(
+            "42",
+            tool="claude",
+            model=None,
+            model_explicit=False,
+            effort=None,
+            permission_mode=PermissionMode.DEFAULT,
+        )
+        assert cmd == ["wade", "implement", "42", "--ai", "claude", "--permission-mode", "default"]
+
+    def test_forwards_yolo_permission_mode(self) -> None:
+        cmd = _build_implement_cmd(
+            "7",
+            tool="claude",
+            model=None,
+            model_explicit=False,
+            effort=None,
+            permission_mode=PermissionMode.YOLO,
+        )
+        assert _mode_value(cmd) == "yolo"
+
+    def test_model_only_forwarded_when_explicit(self) -> None:
+        implicit = _build_implement_cmd(
+            "1",
+            tool="claude",
+            model="claude-opus-4.8",
+            model_explicit=False,
+            effort=None,
+            permission_mode=PermissionMode.DEFAULT,
+        )
+        assert "--model" not in implicit
+        explicit = _build_implement_cmd(
+            "1",
+            tool="claude",
+            model="claude-opus-4.8",
+            model_explicit=True,
+            effort=None,
+            permission_mode=PermissionMode.DEFAULT,
+        )
+        assert "--model" in explicit
+        assert explicit[explicit.index("--model") + 1] == "claude-opus-4.8"
+
+    def test_effort_and_chain_forwarded(self) -> None:
+        cmd = _build_implement_cmd(
+            "3",
+            tool="claude",
+            model=None,
+            model_explicit=False,
+            effort=EffortLevel.HIGH,
+            permission_mode=PermissionMode.ACCEPT_EDITS,
+            chain_ids=["4", "5"],
+        )
+        assert cmd[cmd.index("--effort") + 1] == "high"
+        assert cmd[cmd.index("--chain") + 1] == "4,5"
+        assert _mode_value(cmd) == "accept-edits"


### PR DESCRIPTION
## The bug

`batch._build_cmd` forwarded `--permission-mode` to child `wade implement` processes **only when the resolved mode wasn't default**:

```python
if resolved_permission_mode is not PermissionMode.DEFAULT:
    cmd.extend(["--permission-mode", resolved_permission_mode.value])
```

Each child reloads the project config and re-resolves its own permission mode. So when a batch parent resolves `default` — because the user explicitly downgraded (`wade implement-batch --permission-mode default`, or picked `default` in the confirmation UI) over a config whose `ai.implement` resolves to `yolo` — the parent sends **no flag**, and every child silently re-resolves back to `yolo`, launching with more autonomy than the user confirmed.

It's a latent bug in the "skip the flag when default" shortcut (which assumes children re-resolve to the same value); a non-default `ai.implement` default is what exposes it. Note effort is already forwarded unconditionally — only permission mode had this hole.

Found via the Codex review on #424 (which makes `ai.implement` resolve to `yolo`, exactly the config that triggers this).

## The fix

Forward the resolved permission mode **unconditionally**. Extracted the nested `_build_cmd` closure into a module-level, unit-testable `_build_implement_cmd()`.

## Tests

New `test_batch_build_cmd.py`:
- `default` is forwarded (`--permission-mode default` present) — the core regression.
- `yolo` forwarded.
- `--model` only when explicit; `--effort` / `--chain` preserved.

`test_implementation_service.py` (137) + the new tests all pass; mypy + ruff clean.