### PR TITLE
fix(resume): apply resolved autonomy mode to resumed implementation sessions

### DIFF
--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -26,7 +26,7 @@ from wade.git import worktree as git_worktree
 from wade.git.repo import GitError
 from wade.models.config import ProjectConfig
 from wade.models.hooks import SessionPhase
-from wade.models.permission import permission_mode_launch_kwargs
+from wade.models.permission import PermissionMode, permission_mode_launch_kwargs
 from wade.models.session import ImplementResult, MergeStatus, SyncEventType, SyncResult
 from wade.models.task import Task
 from wade.providers.base import AbstractTaskProvider
@@ -90,11 +90,37 @@ __all__ = [
     "_detect_ai_cli_env",
     "_resolve_task_target",
     "_resolve_worktree_from_plan",
+    "_resume_autonomy_args",
     "start",
 ]
 
 
 # ---------------------------------------------------------------------------
+
+
+def _resume_autonomy_args(adapter: AbstractAITool, permission_mode: PermissionMode) -> list[str]:
+    """Autonomy CLI flags to append to a resumed session, matching a fresh launch.
+
+    crossby's ``build_resume_command()`` takes only a session id, so — unlike
+    ``build_launch_command(**permission_mode_launch_kwargs(...))`` — it never applies
+    the resolved permission mode. Without this, a resumed session runs at the tool's
+    default tier regardless of config/UI (e.g. agy subagents get shell denied even
+    though the confirmation shows ``yolo``). Recompute the exact autonomy args a
+    fresh launch would emit — including crossby's capability-aware downgrades — and
+    append them to the resume command.
+
+    Reuses crossby's internal ``_autonomy_launch_args`` for parity with
+    ``build_launch_command``; calling ``yolo_args()`` etc. directly would skip the
+    downgrade ladder. The proper long-term home is a crossby-side
+    ``build_resume_command`` that accepts autonomy — a follow-up there; this MUST be
+    re-verified on a crossby bump. ``plan_mode=False`` mirrors this path's fresh
+    launch, which never requests plan mode.
+    """
+    return adapter._autonomy_launch_args(
+        adapter.capabilities(),
+        plan_mode=False,
+        **permission_mode_launch_kwargs(permission_mode),
+    )
 
 
 def _detect_ai_cli_env() -> str | None:
@@ -856,6 +882,12 @@ def start(
                             f"{resolved_tool} does not support resume — starting new session"
                         )
                         resume_session_id = None  # fall back to new session
+                    else:
+                        # build_resume_command() omits the autonomy flags a fresh
+                        # launch applies, so append them — otherwise a resumed session
+                        # ignores the resolved permission mode and runs at the tool's
+                        # default tier (see _resume_autonomy_args).
+                        cmd += _resume_autonomy_args(detach_adapter, resolved_permission_mode)
                 if not resume_session_id:
                     if prompt:
                         deliver_prompt_if_needed(detach_adapter, prompt)
@@ -903,6 +935,11 @@ def start(
                             f"{resolved_tool} does not support resume — starting new session"
                         )
                         resume_session_id = None  # fall back below
+                    else:
+                        # Match fresh launch: build_resume_command() drops the autonomy
+                        # flags, so without this a resumed session would ignore the
+                        # resolved permission mode and run at the default tier.
+                        resume_cmd += _resume_autonomy_args(adapter, resolved_permission_mode)
 
                 if resume_session_id and resume_cmd is not None:
                     logger.info(

--- a/tests/unit/test_services/test_resume_autonomy.py
+++ b/tests/unit/test_services/test_resume_autonomy.py
@@ -1,0 +1,38 @@
+"""Tests for ``_resume_autonomy_args`` — autonomy flags appended to resumed sessions.
+
+crossby's ``build_resume_command()`` takes only a session id, so a resumed session
+would otherwise ignore the resolved permission mode and run at the tool's default
+tier (the bug: agy subagents get shell denied despite the UI showing ``yolo``).
+The helper recomputes the same autonomy args a fresh launch emits.
+"""
+
+from __future__ import annotations
+
+from crossby.ai_tools.antigravity_cli import AntigravityCLIAdapter
+from crossby.ai_tools.claude import ClaudeAdapter
+
+from wade.models.permission import PermissionMode
+from wade.services.implementation_service.core import _resume_autonomy_args
+
+
+class TestResumeAutonomyArgs:
+    def test_agy_yolo_appends_sandbox_flags(self) -> None:
+        # The exact flags a fresh yolo launch of agy emits — what actually unblocks
+        # subagent shell on resume.
+        args = _resume_autonomy_args(AntigravityCLIAdapter(), PermissionMode.YOLO)
+        assert args == ["--dangerously-skip-permissions", "--sandbox"]
+
+    def test_agy_default_appends_nothing(self) -> None:
+        # Default tier adds no flags (parity with fresh launch), so a plain resume
+        # command is unchanged.
+        assert _resume_autonomy_args(AntigravityCLIAdapter(), PermissionMode.DEFAULT) == []
+
+    def test_agy_accept_edits(self) -> None:
+        assert _resume_autonomy_args(AntigravityCLIAdapter(), PermissionMode.ACCEPT_EDITS) == [
+            "--mode",
+            "accept-edits",
+        ]
+
+    def test_claude_yolo_nonempty_default_empty(self) -> None:
+        assert _resume_autonomy_args(ClaudeAdapter(), PermissionMode.YOLO)
+        assert _resume_autonomy_args(ClaudeAdapter(), PermissionMode.DEFAULT) == []


### PR DESCRIPTION
## The bug

Both resume branches in `implementation_service/core.py` (detach `:853`, inline `:900`) call `adapter.build_resume_command(session_id)`, which — unlike their fresh-launch siblings that pass `**permission_mode_launch_kwargs(resolved_permission_mode)` into `build_launch_command` — takes **only** a session id and never applies the resolved permission mode.

So a **resumed** implementation session runs at the tool's default tier regardless of config/UI: an agy session resumed with `ai.implement.yolo: true` still gets its subagent shell commands denied, even though `start()` displays and confirms `yolo`. This is the same subagent-denial this thread started from, on the resume path.

Surfaced by the Codex review on #424 — the config change (yolo becomes the impl default) made this pre-existing gap visible.

## The fix

`_resume_autonomy_args(adapter, permission_mode)` recomputes the exact autonomy flags a fresh launch would emit — reusing crossby's `_autonomy_launch_args` so capability-aware **downgrades** match `build_launch_command` — and both branches append them to the resume command.

Examples (agy): `yolo → --dangerously-skip-permissions --sandbox`, `default → (none)`, `accept-edits → --mode accept-edits`.

## Tests

New `test_resume_autonomy.py` covers the helper against real adapters: agy yolo/default/accept-edits exact flags, and claude yolo-nonempty / default-empty. Full `test_implementation_service.py` (137) + new (4) pass; mypy + ruff clean.

## Follow-up

The cleaner long-term home is a crossby-side `build_resume_command` that accepts autonomy directly (this wade-side append reuses crossby's internal `_autonomy_launch_args`, flagged to re-verify on a crossby bump). Noted, not on this path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resumed AI sessions now consistently preserve the selected permission mode.
  * Detached and inline sessions now use the same autonomy settings as newly launched sessions.

* **Tests**
  * Added coverage for supported permission modes across Antigravity and Claude sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->