### PR TITLE
fix(implement): resolve branch by issue number so retitled issues resume their PR/plan

### DIFF
--- a/src/wade/git/pr.py
+++ b/src/wade/git/pr.py
@@ -625,13 +625,19 @@ def list_prs(
     *,
     state: str = "all",
     limit: int = 100,
+    raise_on_error: bool = False,
 ) -> list[PRSummary]:
     """List PRs for the repository.
 
     Returns a list of PRSummary objects with number, url, headRefName, state,
     isDraft, mergedAt fields.  Uses a single ``gh pr list`` call to avoid
-    per-branch API requests.  Returns an empty list on any failure (missing
-    ``gh`` binary, non-zero exit, or bad JSON).
+    per-branch API requests.
+
+    On any failure (missing ``gh`` binary, non-zero exit, or bad JSON) returns an
+    empty list — unless ``raise_on_error`` is set, in which case the failure is
+    re-raised as :class:`GhCliError`. Pass ``raise_on_error=True`` when the caller
+    must distinguish a genuine "no PRs" result from a listing that could not be
+    performed (which must NOT be read as absence).
     """
     try:
         result = _run_gh(
@@ -647,20 +653,28 @@ def list_prs(
             check=False,
         )
     except GhCliError:
+        if raise_on_error:
+            raise
         return []
     if result.returncode != 0:
+        if raise_on_error:
+            raise GhCliError(
+                f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}"
+            )
         return []
     try:
         rows = json.loads(result.stdout)
         if not isinstance(rows, list):
-            return []
+            raise ValueError("expected a JSON array")
         prs: list[PRSummary] = []
         for row in rows:
             if not isinstance(row, dict):
-                return []
+                raise ValueError("expected JSON objects")
             prs.append(PRSummary(**row))
         return prs
-    except (json.JSONDecodeError, TypeError, KeyError, ValueError):
+    except (json.JSONDecodeError, TypeError, KeyError, ValueError) as e:
+        if raise_on_error:
+            raise GhCliError(f"gh pr list returned unparseable output: {e}") from e
         return []
 
 

--- a/src/wade/services/implementation_service/_shared.py
+++ b/src/wade/services/implementation_service/_shared.py
@@ -151,14 +151,15 @@ def find_open_pr_branch_for_issue(repo_root: Path, issue_id: int | str) -> str |
     (which a branch-name-ordering tiebreak could otherwise pick). One
     ``gh pr list`` call.
 
-    Returns ``None`` when no open PR matches (nothing to resume — start fresh) or
-    when the listing fails (``list_prs`` returns ``[]`` on error); callers then
-    fall back to git-based resolution.
+    Returns ``None`` only when no open PR genuinely matches (nothing to resume —
+    start fresh). Raises :class:`~wade.git.pr.GhCliError` when the listing itself
+    fails: callers MUST NOT treat that as absence (an open PR may exist on another
+    same-issue branch), and should abort/report rather than bootstrap a duplicate.
     """
     issue = str(int(issue_id))
     matches = [
         pr
-        for pr in git_pr.list_prs(repo_root, state="open")
+        for pr in git_pr.list_prs(repo_root, state="open", raise_on_error=True)
         if extract_issue_from_branch(pr.head_ref_name) == issue
     ]
     if not matches:

--- a/src/wade/services/implementation_service/_shared.py
+++ b/src/wade/services/implementation_service/_shared.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 
 from wade.git import branch as git_branch
+from wade.git import pr as git_pr
 from wade.git import repo as git_repo
 from wade.git import worktree as git_worktree
 from wade.git.repo import GitError
@@ -19,6 +20,7 @@ from wade.git.repo import GitError
 __all__ = [
     "extract_issue_from_branch",
     "find_existing_branch_for_issue",
+    "find_open_pr_branch_for_issue",
     "find_worktree_path",
     "resolve_task_branch",
 ]
@@ -137,3 +139,32 @@ def resolve_task_branch(
     reconstructed = git_branch.make_branch_name(branch_prefix, int(issue_id), title)
     existing = find_existing_branch_for_issue(repo_root, issue, preferred=reconstructed)
     return existing if existing is not None else reconstructed
+
+
+def find_open_pr_branch_for_issue(repo_root: Path, issue_id: int | str) -> str | None:
+    """Head branch of the OPEN PR that belongs to *issue_id*, or ``None``.
+
+    Where :func:`find_existing_branch_for_issue` matches branches by name, this
+    settles resume ambiguity by PR *state*: among any branches carrying the issue
+    number, the live open PR is the one to resume — regardless of how the title
+    has drifted or how many stale same-issue branches a closed PR left behind
+    (which a branch-name-ordering tiebreak could otherwise pick). One
+    ``gh pr list`` call.
+
+    Returns ``None`` when no open PR matches (nothing to resume — start fresh) or
+    when the listing fails (``list_prs`` returns ``[]`` on error); callers then
+    fall back to git-based resolution.
+    """
+    issue = str(int(issue_id))
+    matches = [
+        pr
+        for pr in git_pr.list_prs(repo_root, state="open")
+        if extract_issue_from_branch(pr.head_ref_name) == issue
+    ]
+    if not matches:
+        return None
+    # Deterministic when several open PRs carry the issue number (rare): the most
+    # recently updated wins. ``updated_at`` is an ISO-8601 string, so a reverse
+    # lexical sort is chronological; the PR number breaks exact ties.
+    matches.sort(key=lambda pr: (pr.updated_at or "", pr.number), reverse=True)
+    return matches[0].head_ref_name

--- a/src/wade/services/implementation_service/_shared.py
+++ b/src/wade/services/implementation_service/_shared.py
@@ -56,8 +56,16 @@ def find_worktree_path(
 
 
 def extract_issue_from_branch(branch: str) -> str | None:
-    """Extract the issue number from a branch name like ``feat/42-slug``."""
-    m = re.search(r"/(\d+)", branch)
+    """Extract the issue number from a branch name like ``feat/42-slug``.
+
+    wade names branches ``{prefix}/{issue}-{slug}``, so the issue number is the
+    ``/{digits}-`` segment — the digits immediately before the slug. Preferring
+    that boundary keeps a *numeric* multi-segment prefix honest: e.g.
+    ``release/2026`` yields ``release/2026/42-title``, which must resolve to
+    ``42``, not the prefix's ``2026`` (#428 review). Fall back to a bare
+    ``/{digits}`` for hyphenless branches (``feat/42``).
+    """
+    m = re.search(r"/(\d+)-", branch) or re.search(r"/(\d+)", branch)
     return m.group(1) if m else None
 
 
@@ -141,6 +149,13 @@ def resolve_task_branch(
     return existing if existing is not None else reconstructed
 
 
+# ``gh pr list`` fetches at most this many PRs per call. It comfortably exceeds
+# any realistic open-PR count; a *full* page back means we cannot prove a missing
+# issue PR is truly absent (it could lie beyond the page), so that case is treated
+# as indeterminate rather than "no open PR" (#428 review).
+_OPEN_PR_SCAN_LIMIT = 1000
+
+
 def find_open_pr_branch_for_issue(repo_root: Path, issue_id: int | str) -> str | None:
     """Head branch of the OPEN PR that belongs to *issue_id*, or ``None``.
 
@@ -152,20 +167,27 @@ def find_open_pr_branch_for_issue(repo_root: Path, issue_id: int | str) -> str |
     ``gh pr list`` call.
 
     Returns ``None`` only when no open PR genuinely matches (nothing to resume —
-    start fresh). Raises :class:`~wade.git.pr.GhCliError` when the listing itself
-    fails: callers MUST NOT treat that as absence (an open PR may exist on another
-    same-issue branch), and should abort/report rather than bootstrap a duplicate.
+    start fresh). Raises :class:`~wade.git.pr.GhCliError` when the result cannot be
+    trusted as complete — either the listing failed, or a full page came back so an
+    open PR could exist beyond it. Callers MUST NOT treat those as absence (a live
+    PR may exist on another same-issue branch) and should abort/report rather than
+    bootstrap a duplicate.
     """
     issue = str(int(issue_id))
-    matches = [
-        pr
-        for pr in git_pr.list_prs(repo_root, state="open", raise_on_error=True)
-        if extract_issue_from_branch(pr.head_ref_name) == issue
-    ]
-    if not matches:
-        return None
-    # Deterministic when several open PRs carry the issue number (rare): the most
-    # recently updated wins. ``updated_at`` is an ISO-8601 string, so a reverse
-    # lexical sort is chronological; the PR number breaks exact ties.
-    matches.sort(key=lambda pr: (pr.updated_at or "", pr.number), reverse=True)
-    return matches[0].head_ref_name
+    open_prs = git_pr.list_prs(
+        repo_root, state="open", limit=_OPEN_PR_SCAN_LIMIT, raise_on_error=True
+    )
+    matches = [pr for pr in open_prs if extract_issue_from_branch(pr.head_ref_name) == issue]
+    if matches:
+        # Deterministic when several open PRs carry the issue number (rare): the
+        # most recently updated wins. ``updated_at`` is an ISO-8601 string, so a
+        # reverse lexical sort is chronological; the PR number breaks exact ties.
+        matches.sort(key=lambda pr: (pr.updated_at or "", pr.number), reverse=True)
+        return matches[0].head_ref_name
+    if len(open_prs) >= _OPEN_PR_SCAN_LIMIT:
+        # A full page with no match — an open PR for this issue could be beyond it,
+        # so absence is unproven. Fail loud rather than risk a duplicate PR.
+        raise git_pr.GhCliError(
+            f"more than {_OPEN_PR_SCAN_LIMIT} open PRs — cannot rule out an open PR for #{issue}"
+        )
+    return None

--- a/src/wade/services/implementation_service/_shared.py
+++ b/src/wade/services/implementation_service/_shared.py
@@ -7,16 +7,20 @@ import cycles between those modules.
 
 from __future__ import annotations
 
+import contextlib
 import re
 from pathlib import Path
 
+from wade.git import branch as git_branch
 from wade.git import repo as git_repo
 from wade.git import worktree as git_worktree
 from wade.git.repo import GitError
 
 __all__ = [
     "extract_issue_from_branch",
+    "find_existing_branch_for_issue",
     "find_worktree_path",
+    "resolve_task_branch",
 ]
 
 
@@ -53,3 +57,83 @@ def extract_issue_from_branch(branch: str) -> str | None:
     """Extract the issue number from a branch name like ``feat/42-slug``."""
     m = re.search(r"/(\d+)", branch)
     return m.group(1) if m else None
+
+
+def find_existing_branch_for_issue(
+    repo_root: Path, issue: str, preferred: str | None = None
+) -> str | None:
+    """Return the name of an existing branch that belongs to *issue*, or ``None``.
+
+    Matches by the stable issue *number* — first the worktrees, then local and
+    remote branches — never by a freshly slugified title. The slug is frozen into
+    the branch at ``wade implement`` time, so a title edited afterward (commonly:
+    the issue renamed to conventional-commit form when its PR opens) would make a
+    reconstructed name drift from the real branch. A worktree's branch is
+    preferred because it is the exact ref checked out for the issue.
+
+    When more than one branch carries the issue number (e.g. a closed PR was
+    retitled and implementation restarted), selection is deterministic:
+    ``list_branch_names`` returns an unordered set, so prefer *preferred* — the
+    name reconstructed from the issue's *current* title, i.e. the freshest
+    branch — and otherwise fall back to sorted order rather than returning a
+    hash-ordered (across-run nondeterministic) element.
+    """
+    with contextlib.suppress(GitError):
+        for wt in git_worktree.list_worktrees(repo_root):
+            if wt.branch and extract_issue_from_branch(wt.branch) == issue:
+                return wt.branch
+
+    # No live worktree (e.g. it was cleaned up while the PR stayed open) — fall
+    # back to any local or remote branch carrying the issue number so callers
+    # act on the *real* branch rather than a drifted name.
+    with contextlib.suppress(GitError):
+        matches: set[str] = set()
+        for name in git_branch.list_branch_names(repo_root):
+            short = name[len("origin/") :] if name.startswith("origin/") else name
+            if extract_issue_from_branch(short) == issue:
+                matches.add(short)
+        if preferred is not None and preferred in matches:
+            return preferred
+        if matches:
+            return sorted(matches)[0]
+
+    return None
+
+
+def resolve_task_branch(
+    repo_root: Path,
+    issue_id: int | str,
+    title: str,
+    branch_prefix: str,
+) -> str:
+    """Resolve the branch name for a task by its stable issue *number*.
+
+    Resolution order:
+
+    1. the currently checked-out branch, when it already carries this issue
+       (an in-worktree caller — authoritative);
+    2. an existing worktree / local / remote branch carrying this issue number
+       (see :func:`find_existing_branch_for_issue`);
+    3. a name reconstructed from the current title — only when nothing for this
+       issue exists yet (first-time creation).
+
+    Resolving by number rather than by re-slugifying ``title`` is deliberate: the
+    branch slug is frozen at ``wade implement`` time, so a title edited afterward
+    regenerates a *different* name and orphans the real worktree/PR. ``done``
+    routinely rewrites the title to add the required conventional-commit prefix,
+    so ``implement``/``smart_start`` re-runs would otherwise miss the live PR and
+    re-bootstrap a duplicate.
+    """
+    issue = str(int(issue_id))
+
+    with contextlib.suppress(GitError):
+        current_branch = git_repo.get_current_branch(repo_root)
+        if extract_issue_from_branch(current_branch) == issue:
+            return current_branch
+
+    # Reconstruct the current-title name once: it is both the tiebreaker
+    # preference for find_existing_branch_for_issue (prefer the freshest branch
+    # when an issue has several) and the fallback when no branch exists yet.
+    reconstructed = git_branch.make_branch_name(branch_prefix, int(issue_id), title)
+    existing = find_existing_branch_for_issue(repo_root, issue, preferred=reconstructed)
+    return existing if existing is not None else reconstructed

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -522,9 +522,21 @@ def start(
         #      reconstruct — so the session's worktree and the draft PR agree rather
         #      than diverging onto the stale branch.
         if not pr_lookup.is_open:
-            resume_branch = find_open_pr_branch_for_issue(
-                repo_root, task.id
-            ) or git_branch.make_branch_name(config.project.branch_prefix, int(task.id), task.title)
+            try:
+                open_pr_branch = find_open_pr_branch_for_issue(repo_root, task.id)
+            except git_pr.GhCliError:
+                # Could NOT list open PRs — this is not "no open PR". Bootstrapping
+                # now could scaffold a duplicate over a live PR that lives on another
+                # same-issue branch we simply cannot see. Abort, like a failed PR
+                # lookup, rather than treat an unknown listing as absence (#428).
+                console.error_with_fix(
+                    f"Could not list open PRs for issue #{task.id}",
+                    "Transient gh error — try again shortly",
+                )
+                return ImplementResult(success=False)
+            resume_branch = open_pr_branch or git_branch.make_branch_name(
+                config.project.branch_prefix, int(task.id), task.title
+            )
             if resume_branch != branch_name:
                 branch_name = resume_branch
                 pr_lookup = git_pr.get_pr_for_branch(repo_root, branch_name)

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -40,6 +40,7 @@ from wade.services.ai_resolution import (
 )
 from wade.services.implementation_service._shared import (
     extract_issue_from_branch,
+    find_open_pr_branch_for_issue,
     find_worktree_path,
     resolve_task_branch,
 )
@@ -511,21 +512,21 @@ def start(
             )
             return ImplementResult(success=False)
 
-        # resolve_task_branch matches by issue number, so it also adopts a branch
-        # left behind by a CLOSED/MERGED PR (or one that never got a PR). Those are
-        # not resumable: this run starts fresh, and bootstrap_draft_pr reconstructs
-        # a NEW title-based branch for its draft PR — so keeping the stale branch
-        # here would set up the session's worktree on it while the draft PR points
-        # at a different branch (#428 review). When the resolved branch has no open
-        # PR, fall back to the current-title name so the worktree and the
-        # bootstrapped PR agree; the re-lookup can also still surface an open PR
-        # that lives on the title-based branch.
+        # resolve_task_branch matches by issue number, so it can adopt a branch left
+        # behind by a CLOSED/MERGED PR (or one that never got a PR) — and, when an
+        # issue has several such branches, a branch-name tiebreak could pick a dead
+        # one over a live one. When the resolved branch is not itself an open PR,
+        # settle the branch by PR *state* (#428 review):
+        #   1. resume the issue's OPEN PR if one exists (on any branch), else
+        #   2. start fresh on the current-title name — what bootstrap_draft_pr will
+        #      reconstruct — so the session's worktree and the draft PR agree rather
+        #      than diverging onto the stale branch.
         if not pr_lookup.is_open:
-            reconstructed_branch = git_branch.make_branch_name(
-                config.project.branch_prefix, int(task.id), task.title
-            )
-            if branch_name != reconstructed_branch:
-                branch_name = reconstructed_branch
+            resume_branch = find_open_pr_branch_for_issue(
+                repo_root, task.id
+            ) or git_branch.make_branch_name(config.project.branch_prefix, int(task.id), task.title)
+            if resume_branch != branch_name:
+                branch_name = resume_branch
                 pr_lookup = git_pr.get_pr_for_branch(repo_root, branch_name)
                 if pr_lookup.lookup_failed:
                     console.error_with_fix(

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -510,6 +510,29 @@ def start(
                 "Transient gh error — try again shortly",
             )
             return ImplementResult(success=False)
+
+        # resolve_task_branch matches by issue number, so it also adopts a branch
+        # left behind by a CLOSED/MERGED PR (or one that never got a PR). Those are
+        # not resumable: this run starts fresh, and bootstrap_draft_pr reconstructs
+        # a NEW title-based branch for its draft PR — so keeping the stale branch
+        # here would set up the session's worktree on it while the draft PR points
+        # at a different branch (#428 review). When the resolved branch has no open
+        # PR, fall back to the current-title name so the worktree and the
+        # bootstrapped PR agree; the re-lookup can also still surface an open PR
+        # that lives on the title-based branch.
+        if not pr_lookup.is_open:
+            reconstructed_branch = git_branch.make_branch_name(
+                config.project.branch_prefix, int(task.id), task.title
+            )
+            if branch_name != reconstructed_branch:
+                branch_name = reconstructed_branch
+                pr_lookup = git_pr.get_pr_for_branch(repo_root, branch_name)
+                if pr_lookup.lookup_failed:
+                    console.error_with_fix(
+                        f"Could not look up the PR for branch {branch_name}",
+                        "Transient gh error — try again shortly",
+                    )
+                    return ImplementResult(success=False)
         existing_pr = pr_lookup.pr if pr_lookup.is_open else None
         plan_content: str | None = None
         proceed_needs_bootstrap = False

--- a/src/wade/services/implementation_service/core.py
+++ b/src/wade/services/implementation_service/core.py
@@ -41,6 +41,7 @@ from wade.services.ai_resolution import (
 from wade.services.implementation_service._shared import (
     extract_issue_from_branch,
     find_worktree_path,
+    resolve_task_branch,
 )
 from wade.services.implementation_service.bootstrap import (
     _resolve_worktrees_dir,
@@ -484,12 +485,16 @@ def start(
         console.rule(f"implement #{task.id}")
         console.kv("Issue", console.issue_ref(task.id, task.title))
 
-        # Generate deterministic branch name early — only needs config + task, so it
-        # can be computed before AI selection to allow the PR/plan check below.
-        branch_name = git_branch.make_branch_name(
-            config.project.branch_prefix,
-            int(task.id),
-            task.title,
+        # Resolve the branch early — needs only config + task, so it can be
+        # computed before AI selection to allow the PR/plan check below. Resolve
+        # by the stable issue *number* rather than re-slugifying the title: the
+        # slug is frozen at the first ``wade implement``, but ``done`` later
+        # rewrites the issue title to add the required conventional-commit prefix.
+        # A reconstructed name would then drift from the real branch, so the
+        # PR/plan lookup below would miss the live draft PR and re-bootstrap a
+        # duplicate — leaving the resumed task with "no plan attached".
+        branch_name = resolve_task_branch(
+            repo_root, task.id, task.title, config.project.branch_prefix
         )
 
         # Check for existing draft PR (from plan flow) before AI selection so that

--- a/src/wade/services/smart_start.py
+++ b/src/wade/services/smart_start.py
@@ -19,7 +19,6 @@ from crossby.models.ai import AIToolID
 from pydantic import BaseModel
 
 from wade.config.loader import load_config
-from wade.git import branch as git_branch
 from wade.git import pr as git_pr
 from wade.git import repo as git_repo
 from wade.git.repo import GitError
@@ -28,7 +27,11 @@ from wade.models.session import MergeStatus, SessionRecord
 from wade.models.worktree import Worktree
 from wade.providers.base import AbstractTaskProvider
 from wade.providers.registry import get_provider
-from wade.services.implementation_service import _merge_pr, check_tracking_issue_and_batch
+from wade.services.implementation_service import (
+    _merge_pr,
+    check_tracking_issue_and_batch,
+    resolve_task_branch,
+)
 from wade.ui.console import console
 from wade.utils.markdown import parse_sessions_from_body
 
@@ -165,12 +168,13 @@ def smart_start(
     if batch_result is not None:
         return batch_result
 
-    # Build the expected branch name
-    branch_name = git_branch.make_branch_name(
-        config.project.branch_prefix,
-        int(task.id),
-        task.title,
-    )
+    # Resolve the branch by the stable issue *number*, not a re-slugified title.
+    # The slug is frozen at ``wade implement`` time, so once the issue is retitled
+    # (commonly: renamed to conventional-commit form when ``done`` opens/updates
+    # its PR) a reconstructed name drifts from the real branch and the PR lookup
+    # below misses the live PR — sending an in-flight task back through a fresh
+    # implement instead of resuming it.
+    branch_name = resolve_task_branch(repo_root, task.id, task.title, config.project.branch_prefix)
 
     # Check for existing PR
     lookup = git_pr.get_pr_for_branch(repo_root, branch_name)

--- a/src/wade/services/smart_start.py
+++ b/src/wade/services/smart_start.py
@@ -30,6 +30,7 @@ from wade.providers.registry import get_provider
 from wade.services.implementation_service import (
     _merge_pr,
     check_tracking_issue_and_batch,
+    find_open_pr_branch_for_issue,
     resolve_task_branch,
 )
 from wade.ui.console import console
@@ -183,6 +184,20 @@ def smart_start(
         # implement flow rather than acting on an unknown PR state.
         console.warn("Could not look up the PR for this branch — proceeding with implement.")
         return ctx.run_implement()
+    if not lookup.is_open:
+        # The resolved branch is not a live PR — a stale same-issue branch (closed
+        # PR) or a drifted title can shadow the issue's real open PR. Prefer the
+        # open PR's branch so we resume it here rather than mislabelling it closed
+        # and routing to a fresh implement (#428 review).
+        open_branch = find_open_pr_branch_for_issue(repo_root, task.id)
+        if open_branch and open_branch != branch_name:
+            branch_name = open_branch
+            lookup = git_pr.get_pr_for_branch(repo_root, branch_name)
+            if lookup.lookup_failed:
+                console.warn(
+                    "Could not look up the PR for this branch — proceeding with implement."
+                )
+                return ctx.run_implement()
     if not lookup.found or lookup.pr is None:
         # No PR → normal implement flow
         return ctx.run_implement()

--- a/src/wade/services/smart_start.py
+++ b/src/wade/services/smart_start.py
@@ -189,7 +189,13 @@ def smart_start(
         # PR) or a drifted title can shadow the issue's real open PR. Prefer the
         # open PR's branch so we resume it here rather than mislabelling it closed
         # and routing to a fresh implement (#428 review).
-        open_branch = find_open_pr_branch_for_issue(repo_root, task.id)
+        try:
+            open_branch = find_open_pr_branch_for_issue(repo_root, task.id)
+        except git_pr.GhCliError:
+            # Could not list PRs — route on the original lookup. The implement flow
+            # (the only path that bootstraps) makes the authoritative, failure-aware
+            # call, so we never open a duplicate PR from here.
+            open_branch = None
         if open_branch and open_branch != branch_name:
             branch_name = open_branch
             lookup = git_pr.get_pr_for_branch(repo_root, branch_name)

--- a/tests/unit/test_git/test_pr_lookup.py
+++ b/tests/unit/test_git/test_pr_lookup.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from wade.git.pr import PRLookup, PRRef, get_pr_for_branch
+import pytest
+
+from wade.git.pr import GhCliError, PRLookup, PRRef, get_pr_for_branch, list_prs
 
 
 def _gh_result(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -113,3 +115,39 @@ class TestPRLookupProperties:
         assert lookup.is_open is True
         merged = PRLookup(found=True, pr=PRRef(number=1, state="merged"))
         assert merged.is_merged is True
+
+
+class TestListPrsRaiseOnError:
+    """``list_prs`` must be able to distinguish a failed listing from 'no PRs'."""
+
+    _ROW = (
+        '[{"number": 1, "url": "u", "headRefName": "feat/1-x", "state": "OPEN", "isDraft": false}]'
+    )
+
+    @patch("wade.git.pr._run_gh")
+    def test_default_swallows_failure_to_empty(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = _gh_result(1, stderr="boom")
+        assert list_prs(Path("/repo")) == []
+
+    @patch("wade.git.pr._run_gh")
+    def test_raises_on_nonzero_exit_when_requested(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = _gh_result(1, stderr="boom")
+        with pytest.raises(GhCliError):
+            list_prs(Path("/repo"), raise_on_error=True)
+
+    @patch("wade.git.pr._run_gh")
+    def test_raises_on_bad_json_when_requested(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = _gh_result(0, stdout="not json at all")
+        with pytest.raises(GhCliError):
+            list_prs(Path("/repo"), raise_on_error=True)
+
+    @patch("wade.git.pr._run_gh")
+    def test_success_returns_prs_even_with_raise_on_error(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = _gh_result(0, stdout=self._ROW)
+        prs = list_prs(Path("/repo"), state="open", raise_on_error=True)
+        assert [p.head_ref_name for p in prs] == ["feat/1-x"]
+
+    @patch("wade.git.pr._run_gh")
+    def test_empty_success_is_not_an_error(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = _gh_result(0, stdout="[]")
+        assert list_prs(Path("/repo"), raise_on_error=True) == []

--- a/tests/unit/test_services/test_implementation_done_sync.py
+++ b/tests/unit/test_services/test_implementation_done_sync.py
@@ -48,8 +48,17 @@ class TestExtractIssueFromBranch:
         assert extract_issue_from_branch("feature-branch") is None
 
     def test_multiple_numbers(self) -> None:
-        # Should match the first number after a slash
+        # The issue is the number before the slug (``/{issue}-``), not later ones.
         assert extract_issue_from_branch("feat/42-add-auth-99") == "42"
+
+    def test_numeric_multi_segment_prefix(self) -> None:
+        # A numeric prefix segment (e.g. branch_prefix="release/2026") must not
+        # shadow the real issue number that precedes the slug (#428 review).
+        assert extract_issue_from_branch("release/2026/42-title") == "42"
+
+    def test_hyphenless_branch_falls_back(self) -> None:
+        # No slug/hyphen (non-wade branch) → bare ``/{digits}`` still resolves.
+        assert extract_issue_from_branch("feat/42") == "42"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services/test_implementation_service.py
+++ b/tests/unit/test_services/test_implementation_service.py
@@ -705,6 +705,21 @@ class TestDetectAiCliEnv:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _default_no_open_pr_for_issue() -> object:
+    """Default the issue→open-PR resolver to 'none' so any start() test in this
+    module skips the not-open-PR gate's ``gh pr list`` (which now raises on
+    failure). Tests that exercise resume-by-open-PR override this with their own
+    patch. Module-scoped so it also covers start() tests outside
+    ``TestImplementationStart`` (e.g. tracking-detection).
+    """
+    with patch(
+        "wade.services.implementation_service.core.find_open_pr_branch_for_issue",
+        return_value=None,
+    ):
+        yield
+
+
 class TestImplementationStart:
     """Tests for implementation_service.start() — exercises the full start() orchestration."""
 
@@ -714,18 +729,6 @@ class TestImplementationStart:
     def _make_config(self) -> ProjectConfig:
         """ProjectConfig with main_branch set to avoid detect_main_branch subprocess call."""
         return ProjectConfig(project=ProjectSettings(main_branch="main"))
-
-    @pytest.fixture(autouse=True)
-    def _default_no_open_pr(self):
-        """Default the issue→open-PR resolver to 'none' so start() tests don't spawn
-        a real ``gh pr list`` in the not-open-PR gate. Tests that exercise
-        resume-by-open-PR override this with their own patch.
-        """
-        with patch(
-            "wade.services.implementation_service.core.find_open_pr_branch_for_issue",
-            return_value=None,
-        ):
-            yield
 
     def test_creates_worktree(self, tmp_path: Path) -> None:
         """Happy path: no existing worktree, no draft PR → create_worktree called, returns True."""
@@ -933,6 +936,53 @@ class TestImplementationStart:
 
         assert result.success is True
         # Resumed the open PR's branch; no fresh branch created, no third PR bootstrapped.
+        mock_bootstrap.assert_not_called()
+        mock_create.assert_not_called()
+
+    def test_aborts_when_open_pr_listing_fails(self, tmp_path: Path) -> None:
+        """A `gh pr list` failure in the not-open gate must abort, not bootstrap.
+
+        Otherwise a transient listing failure would look like 'no open PR' and
+        scaffold a duplicate over a live PR on another same-issue branch (#428).
+        """
+        from wade.git.pr import GhCliError
+
+        task = Task(id="42", title="renamed title")
+        mock_provider = MagicMock()
+        mock_provider.read_task.return_value = task
+
+        with (
+            patch(
+                "wade.services.implementation_service.core.load_config",
+                return_value=self._make_config(),
+            ),
+            patch(
+                "wade.services.implementation_service.core.get_provider", return_value=mock_provider
+            ),
+            patch("wade.git.repo.get_repo_root", return_value=tmp_path),
+            patch(
+                "wade.services.implementation_service._shared.git_repo.get_current_branch",
+                return_value="main",
+            ),
+            patch("wade.git.worktree.list_worktrees", return_value=[]),
+            # Resolved branch has a CLOSED PR → gate consults the open-PR listing…
+            patch(
+                "wade.git.pr.get_pr_for_branch",
+                return_value=PRLookup(found=True, pr=PRRef(number=7, state="CLOSED")),
+            ),
+            # …and that listing fails: must abort rather than treat as absence.
+            patch(
+                "wade.services.implementation_service.core.find_open_pr_branch_for_issue",
+                side_effect=GhCliError("gh pr list failed"),
+            ),
+            patch("wade.git.worktree.create_worktree") as mock_create,
+            patch("wade.services.implementation_service.core.bootstrap_draft_pr") as mock_bootstrap,
+            patch("wade.services.implementation_service.core.prompts") as mock_prompts,
+        ):
+            mock_prompts.is_tty.return_value = False
+            result = start("42", project_root=tmp_path)
+
+        assert result.success is False
         mock_bootstrap.assert_not_called()
         mock_create.assert_not_called()
 

--- a/tests/unit/test_services/test_implementation_service.py
+++ b/tests/unit/test_services/test_implementation_service.py
@@ -715,6 +715,18 @@ class TestImplementationStart:
         """ProjectConfig with main_branch set to avoid detect_main_branch subprocess call."""
         return ProjectConfig(project=ProjectSettings(main_branch="main"))
 
+    @pytest.fixture(autouse=True)
+    def _default_no_open_pr(self):
+        """Default the issue→open-PR resolver to 'none' so start() tests don't spawn
+        a real ``gh pr list`` in the not-open-PR gate. Tests that exercise
+        resume-by-open-PR override this with their own patch.
+        """
+        with patch(
+            "wade.services.implementation_service.core.find_open_pr_branch_for_issue",
+            return_value=None,
+        ):
+            yield
+
     def test_creates_worktree(self, tmp_path: Path) -> None:
         """Happy path: no existing worktree, no draft PR → create_worktree called, returns True."""
         task = self._make_task()
@@ -839,6 +851,8 @@ class TestImplementationStart:
                 "wade.services.implementation_service.core._detect_ai_cli_env", return_value=None
             ),
             patch("wade.git.pr.get_pr_for_branch", side_effect=pr_by_branch),
+            # No live open PR for the issue (autouse _default_no_open_pr) → gate
+            # falls back to the title branch.
             patch(
                 "wade.services.implementation_service.core.bootstrap_draft_pr",
                 return_value={"number": 1, "url": "http://test"},
@@ -853,6 +867,74 @@ class TestImplementationStart:
         mock_bootstrap.assert_called_once()
         mock_create.assert_called_once()
         assert mock_create.call_args.kwargs["branch_name"] == reconstructed
+
+    def test_open_pr_on_other_branch_is_resumed_not_rebootstrapped(self, tmp_path: Path) -> None:
+        """Ambiguity is settled by PR state, not branch-name ordering (#428 review).
+
+        The issue has a stale branch (closed PR) that resolution adopts by number,
+        AND a live open PR on a different branch. start() must resume the open PR's
+        branch rather than bootstrap a third PR on the reconstructed title branch.
+        """
+        task = Task(id="42", title="renamed title")
+        stale_branch = "feat/42-original-slug"
+        live_branch = "feat/42-open-pr-branch"
+
+        mock_provider = MagicMock()
+        mock_provider.read_task.return_value = task
+
+        def pr_by_branch(_repo_root: Path, branch: str) -> PRLookup:
+            if branch == live_branch:
+                return PRLookup(found=True, pr=PRRef(number=9, state="OPEN"))
+            if branch == stale_branch:
+                return PRLookup(found=True, pr=PRRef(number=7, state="CLOSED"))
+            return PRLookup(found=False)
+
+        with (
+            patch(
+                "wade.services.implementation_service.core.load_config",
+                return_value=self._make_config(),
+            ),
+            patch(
+                "wade.services.implementation_service.core.get_provider", return_value=mock_provider
+            ),
+            patch("wade.git.repo.get_repo_root", return_value=tmp_path),
+            patch(
+                "wade.services.implementation_service._shared.git_repo.get_current_branch",
+                return_value="main",
+            ),
+            patch(
+                "wade.git.worktree.list_worktrees",
+                return_value=[Worktree(path=str(tmp_path / "wt"), branch=stale_branch)],
+            ),
+            patch("wade.git.branch.branch_exists", return_value=True),
+            patch("wade.services.implementation_service.core.git_repo.fetch_ref"),
+            patch("wade.git.worktree.checkout_existing_branch_worktree"),
+            patch("wade.git.worktree.create_worktree") as mock_create,
+            patch("wade.services.implementation_service.core.write_plan_md"),
+            patch("wade.services.implementation_service.core.bootstrap_worktree"),
+            patch("crossby.ai_tools.base.AbstractAITool.detect_installed", return_value=[]),
+            patch(
+                "wade.services.implementation_service.core._detect_ai_cli_env", return_value=None
+            ),
+            patch("wade.git.pr.get_pr_for_branch", side_effect=pr_by_branch),
+            patch("wade.git.pr.get_pr_body", return_value=None),
+            # A live open PR exists for the issue on a different branch.
+            patch(
+                "wade.services.implementation_service.core.find_open_pr_branch_for_issue",
+                return_value=live_branch,
+            ),
+            patch(
+                "wade.services.implementation_service.core.bootstrap_draft_pr",
+            ) as mock_bootstrap,
+            patch("wade.services.implementation_service.core.prompts") as mock_prompts,
+        ):
+            mock_prompts.is_tty.return_value = False
+            result = start("42", project_root=tmp_path)
+
+        assert result.success is True
+        # Resumed the open PR's branch; no fresh branch created, no third PR bootstrapped.
+        mock_bootstrap.assert_not_called()
+        mock_create.assert_not_called()
 
     def test_returns_false_on_creation_failure(self, tmp_path: Path) -> None:
         """create_worktree raises GitError → start() returns False."""

--- a/tests/unit/test_services/test_implementation_service.py
+++ b/tests/unit/test_services/test_implementation_service.py
@@ -792,6 +792,68 @@ class TestImplementationStart:
             assert result.success is True
             mock_create.assert_not_called()
 
+    def test_closed_pr_branch_falls_back_to_title_branch(self, tmp_path: Path) -> None:
+        """A retitled issue whose stale branch has a CLOSED PR must start fresh.
+
+        Resolution matches the stale branch by issue number, but its PR is closed
+        (not resumable). If start() kept that branch, the session's worktree would
+        sit on it while bootstrap_draft_pr opens the new draft PR on a different
+        title-based branch. Verify start() falls back to the reconstructed name so
+        the worktree and the bootstrapped PR agree (#428 review).
+        """
+        task = Task(id="42", title="renamed title")
+        stale_branch = "feat/42-original-slug"
+        reconstructed = "feat/42-renamed-title"
+
+        mock_provider = MagicMock()
+        mock_provider.read_task.return_value = task
+
+        def pr_by_branch(_repo_root: Path, branch: str) -> PRLookup:
+            if branch == stale_branch:
+                return PRLookup(found=True, pr=PRRef(number=7, state="CLOSED"))
+            return PRLookup(found=False)
+
+        with (
+            patch(
+                "wade.services.implementation_service.core.load_config",
+                return_value=self._make_config(),
+            ),
+            patch(
+                "wade.services.implementation_service.core.get_provider", return_value=mock_provider
+            ),
+            patch("wade.git.repo.get_repo_root", return_value=tmp_path),
+            patch(
+                "wade.services.implementation_service._shared.git_repo.get_current_branch",
+                return_value="main",
+            ),
+            patch(
+                "wade.git.worktree.list_worktrees",
+                return_value=[Worktree(path=str(tmp_path / "wt"), branch=stale_branch)],
+            ),
+            patch("wade.git.branch.branch_exists", return_value=False),
+            patch("wade.git.worktree.create_worktree") as mock_create,
+            patch("wade.services.implementation_service.core.write_plan_md"),
+            patch("wade.services.implementation_service.core.bootstrap_worktree"),
+            patch("crossby.ai_tools.base.AbstractAITool.detect_installed", return_value=[]),
+            patch(
+                "wade.services.implementation_service.core._detect_ai_cli_env", return_value=None
+            ),
+            patch("wade.git.pr.get_pr_for_branch", side_effect=pr_by_branch),
+            patch(
+                "wade.services.implementation_service.core.bootstrap_draft_pr",
+                return_value={"number": 1, "url": "http://test"},
+            ) as mock_bootstrap,
+            patch("wade.services.implementation_service.core.prompts") as mock_prompts,
+        ):
+            mock_prompts.is_tty.return_value = False
+            result = start("42", project_root=tmp_path)
+
+        assert result.success is True
+        # Started fresh on the title-based branch, never the closed PR's stale one.
+        mock_bootstrap.assert_called_once()
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["branch_name"] == reconstructed
+
     def test_returns_false_on_creation_failure(self, tmp_path: Path) -> None:
         """create_worktree raises GitError → start() returns False."""
         task = self._make_task()

--- a/tests/unit/test_services/test_post_implementation_lifecycle.py
+++ b/tests/unit/test_services/test_post_implementation_lifecycle.py
@@ -4,6 +4,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from wade.git.pr import PRLookup, PRRef
 from wade.git.repo import GitError
 from wade.models.config import AIConfig, ProjectConfig, ProjectSettings
@@ -23,6 +25,19 @@ def _config(strategy: MergeStrategy) -> ProjectConfig:
         project=ProjectSettings(main_branch="main", merge_strategy=strategy),
         ai=AIConfig(default_tool="claude"),
     )
+
+
+@pytest.fixture(autouse=True)
+def _default_no_open_pr_for_issue() -> object:
+    """Skip the start() not-open-PR gate's ``gh pr list`` (which now raises on
+    failure) so these lifecycle tests exercise the merge flow, not a resolver
+    abort.
+    """
+    with patch(
+        "wade.services.implementation_service.core.find_open_pr_branch_for_issue",
+        return_value=None,
+    ):
+        yield
 
 
 @patch(_IS_HEAD_ATTACHED, return_value=True)

--- a/tests/unit/test_services/test_resolve_task_branch.py
+++ b/tests/unit/test_services/test_resolve_task_branch.py
@@ -14,14 +14,27 @@ from pathlib import Path
 from unittest.mock import patch
 
 from wade.git.branch import make_branch_name
+from wade.git.pr import PRSummary
 from wade.git.repo import GitError
 from wade.models.worktree import Worktree
 from wade.services.implementation_service._shared import (
     find_existing_branch_for_issue,
+    find_open_pr_branch_for_issue,
     resolve_task_branch,
 )
 
 _S = "wade.services.implementation_service._shared"
+
+
+def _pr(number: int, head: str, updated: str | None = None) -> PRSummary:
+    return PRSummary(
+        number=number,
+        url=f"https://example/pr/{number}",
+        headRefName=head,
+        state="OPEN",
+        isDraft=False,
+        updatedAt=updated,
+    )
 
 
 class TestFindExistingBranchForIssue:
@@ -138,3 +151,47 @@ class TestResolveTaskBranch:
         ):
             got = resolve_task_branch(tmp_path, "42", "Renamed", "feat")
         assert got == "feat/42-frozen-slug"
+
+
+class TestFindOpenPrBranchForIssue:
+    """Resume ambiguity settled by PR *state*, not branch-name ordering."""
+
+    def test_returns_open_pr_head_branch(self, tmp_path: Path) -> None:
+        with patch(
+            f"{_S}.git_pr.list_prs",
+            return_value=[_pr(9, "feat/42-live-branch")],
+        ):
+            assert find_open_pr_branch_for_issue(tmp_path, 42) == "feat/42-live-branch"
+
+    def test_ignores_other_issues(self, tmp_path: Path) -> None:
+        with patch(
+            f"{_S}.git_pr.list_prs",
+            return_value=[_pr(9, "feat/99-other"), _pr(10, "feat/420-not-42")],
+        ):
+            assert find_open_pr_branch_for_issue(tmp_path, 42) is None
+
+    def test_none_when_no_open_prs(self, tmp_path: Path) -> None:
+        with patch(f"{_S}.git_pr.list_prs", return_value=[]):
+            assert find_open_pr_branch_for_issue(tmp_path, 42) is None
+
+    def test_picks_live_branch_over_stale_same_issue_branch(self, tmp_path: Path) -> None:
+        """The exact P1: a closed PR's branch coexists with the live open PR's.
+
+        list_prs(state="open") only returns the open one, so the live branch is
+        selected regardless of how the branch names sort.
+        """
+        with patch(
+            f"{_S}.git_pr.list_prs",
+            return_value=[_pr(9, "feat/42-zzz-open")],  # sorts after a hypothetical closed 'aaa'
+        ):
+            assert find_open_pr_branch_for_issue(tmp_path, 42) == "feat/42-zzz-open"
+
+    def test_multiple_open_prs_prefers_most_recently_updated(self, tmp_path: Path) -> None:
+        with patch(
+            f"{_S}.git_pr.list_prs",
+            return_value=[
+                _pr(9, "feat/42-older", updated="2026-08-01T00:00:00Z"),
+                _pr(10, "feat/42-newer", updated="2026-08-15T00:00:00Z"),
+            ],
+        ):
+            assert find_open_pr_branch_for_issue(tmp_path, 42) == "feat/42-newer"

--- a/tests/unit/test_services/test_resolve_task_branch.py
+++ b/tests/unit/test_services/test_resolve_task_branch.py
@@ -215,3 +215,26 @@ class TestFindOpenPrBranchForIssue:
         with patch(f"{_S}.git_pr.list_prs", return_value=[]) as mock_list:
             find_open_pr_branch_for_issue(tmp_path, 42)
         assert mock_list.call_args.kwargs.get("raise_on_error") is True
+
+    def test_full_page_without_match_is_indeterminate(self, tmp_path: Path) -> None:
+        """A full page and no match can't prove absence — must raise, not return None.
+
+        Otherwise, in a repo with more open PRs than one page fetches, a live PR
+        beyond the page would look like 'no open PR' and a caller could bootstrap a
+        duplicate (#428 review).
+        """
+        full_page = [_pr(i, f"feat/99-{i}") for i in range(3)]
+        with (
+            patch(f"{_S}._OPEN_PR_SCAN_LIMIT", 3),
+            patch(f"{_S}.git_pr.list_prs", return_value=full_page),
+            pytest.raises(GhCliError),
+        ):
+            find_open_pr_branch_for_issue(tmp_path, 42)
+
+    def test_partial_page_without_match_is_absence(self, tmp_path: Path) -> None:
+        """Fewer results than the page limit → None genuinely proves absence."""
+        with (
+            patch(f"{_S}._OPEN_PR_SCAN_LIMIT", 10),
+            patch(f"{_S}.git_pr.list_prs", return_value=[_pr(1, "feat/99-other")]),
+        ):
+            assert find_open_pr_branch_for_issue(tmp_path, 42) is None

--- a/tests/unit/test_services/test_resolve_task_branch.py
+++ b/tests/unit/test_services/test_resolve_task_branch.py
@@ -1,0 +1,140 @@
+"""Tests for branch resolution by stable issue number.
+
+``resolve_task_branch`` / ``find_existing_branch_for_issue`` resolve a task's
+branch by its issue *number* rather than a re-slugified title. The slug is
+frozen at ``wade implement`` time, so a title edited afterward (commonly:
+``done`` renaming the issue to conventional-commit form when its PR opens) must
+NOT change which branch/worktree/PR a re-run acts on. Regression coverage for
+the ``implement``/``smart_start`` resume paths and #417's review path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from wade.git.branch import make_branch_name
+from wade.git.repo import GitError
+from wade.models.worktree import Worktree
+from wade.services.implementation_service._shared import (
+    find_existing_branch_for_issue,
+    resolve_task_branch,
+)
+
+_S = "wade.services.implementation_service._shared"
+
+
+class TestFindExistingBranchForIssue:
+    """Resolve / disambiguate an existing branch by issue number (#417 review)."""
+
+    def test_prefers_reconstructed_name_on_ambiguity(self, tmp_path: Path) -> None:
+        """>1 same-issue branch, no worktree → prefer the freshest (reconstructed) name."""
+        with (
+            patch(f"{_S}.git_worktree.list_worktrees", return_value=[]),
+            patch(
+                f"{_S}.git_branch.list_branch_names",
+                return_value={"main", "feat/42-old-slug", "feat/42-new-slug"},
+            ),
+        ):
+            got = find_existing_branch_for_issue(tmp_path, "42", preferred="feat/42-new-slug")
+        assert got == "feat/42-new-slug"
+
+    def test_ambiguity_without_preference_is_deterministic(self, tmp_path: Path) -> None:
+        """Ambiguous match without a preference is sorted (stable), not hash-ordered."""
+        branches = {"main", "feat/42-old-slug", "feat/42-new-slug"}
+        with (
+            patch(f"{_S}.git_worktree.list_worktrees", return_value=[]),
+            patch(f"{_S}.git_branch.list_branch_names", return_value=branches),
+        ):
+            first = find_existing_branch_for_issue(tmp_path, "42")
+            second = find_existing_branch_for_issue(tmp_path, "42")
+        assert first == second == "feat/42-new-slug"  # sorted(): "new" < "old"
+
+    def test_worktree_branch_wins_over_reconstructed(self, tmp_path: Path) -> None:
+        """A live worktree's branch is authoritative even when a preferred name is given."""
+        with patch(
+            f"{_S}.git_worktree.list_worktrees",
+            return_value=[Worktree(path=str(tmp_path / "wt"), branch="feat/42-frozen-slug")],
+        ):
+            got = find_existing_branch_for_issue(tmp_path, "42", preferred="feat/42-renamed")
+        assert got == "feat/42-frozen-slug"
+
+    def test_remote_branch_matched_when_no_worktree(self, tmp_path: Path) -> None:
+        """A cleaned-up worktree still resolves to the real remote branch."""
+        with (
+            patch(f"{_S}.git_worktree.list_worktrees", return_value=[]),
+            patch(
+                f"{_S}.git_branch.list_branch_names",
+                return_value={"main", "origin/feat/42-frozen-slug"},
+            ),
+        ):
+            got = find_existing_branch_for_issue(tmp_path, "42")
+        assert got == "feat/42-frozen-slug"
+
+    def test_no_match_returns_none(self, tmp_path: Path) -> None:
+        with (
+            patch(f"{_S}.git_worktree.list_worktrees", return_value=[]),
+            patch(f"{_S}.git_branch.list_branch_names", return_value={"main", "feat/99-other"}),
+        ):
+            assert find_existing_branch_for_issue(tmp_path, "42") is None
+
+    def test_sub_issue_number_is_not_matched(self, tmp_path: Path) -> None:
+        """Issue 42 must not match branch for issue 420 (full-number extraction)."""
+        with (
+            patch(f"{_S}.git_worktree.list_worktrees", return_value=[]),
+            patch(f"{_S}.git_branch.list_branch_names", return_value={"feat/420-unrelated"}),
+        ):
+            assert find_existing_branch_for_issue(tmp_path, "42") is None
+
+
+class TestResolveTaskBranch:
+    """Full resolution order: checked-out branch → existing branch → reconstruct."""
+
+    def test_current_checked_out_branch_wins(self, tmp_path: Path) -> None:
+        """An in-worktree caller on the issue's branch gets that exact ref."""
+        with patch(f"{_S}.git_repo.get_current_branch", return_value="feat/42-frozen-slug"):
+            got = resolve_task_branch(tmp_path, "42", "Renamed title", "feat")
+        assert got == "feat/42-frozen-slug"
+
+    def test_retitled_issue_resolves_to_existing_worktree_branch(self, tmp_path: Path) -> None:
+        """The core bug: title changed since implement → resume the real branch.
+
+        Running ``wade 42`` from the main repo (not on the issue branch) with a
+        title that would now re-slugify differently must still resolve to the
+        branch the worktree/PR actually live on, not the drifted reconstruction.
+        """
+        frozen = "feat/42-original-title-slug"
+        with (
+            patch(f"{_S}.git_repo.get_current_branch", return_value="main"),
+            patch(
+                f"{_S}.git_worktree.list_worktrees",
+                return_value=[Worktree(path=str(tmp_path / "wt"), branch=frozen)],
+            ),
+        ):
+            got = resolve_task_branch(tmp_path, "42", "fix: completely renamed title", "feat")
+        assert got == frozen
+        # Guard: the naive path would have produced a different, orphaning name.
+        assert got != make_branch_name("feat", 42, "fix: completely renamed title")
+
+    def test_first_time_reconstructs_from_title(self, tmp_path: Path) -> None:
+        """No checked-out/worktree/local/remote branch → reconstruct from title."""
+        with (
+            patch(f"{_S}.git_repo.get_current_branch", side_effect=GitError("detached")),
+            patch(f"{_S}.git_worktree.list_worktrees", return_value=[]),
+            patch(f"{_S}.git_branch.list_branch_names", return_value={"main"}),
+        ):
+            got = resolve_task_branch(tmp_path, "42", "Add user auth", "feat")
+        assert got == make_branch_name("feat", 42, "Add user auth")
+
+    def test_detached_head_falls_through_to_existing_branch(self, tmp_path: Path) -> None:
+        """A GitError reading the current branch must not abort resolution."""
+        with (
+            patch(f"{_S}.git_repo.get_current_branch", side_effect=GitError("detached")),
+            patch(f"{_S}.git_worktree.list_worktrees", return_value=[]),
+            patch(
+                f"{_S}.git_branch.list_branch_names",
+                return_value={"main", "feat/42-frozen-slug"},
+            ),
+        ):
+            got = resolve_task_branch(tmp_path, "42", "Renamed", "feat")
+        assert got == "feat/42-frozen-slug"

--- a/tests/unit/test_services/test_resolve_task_branch.py
+++ b/tests/unit/test_services/test_resolve_task_branch.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from wade.git.branch import make_branch_name
-from wade.git.pr import PRSummary
+from wade.git.pr import GhCliError, PRSummary
 from wade.git.repo import GitError
 from wade.models.worktree import Worktree
 from wade.services.implementation_service._shared import (
@@ -195,3 +197,21 @@ class TestFindOpenPrBranchForIssue:
             ],
         ):
             assert find_open_pr_branch_for_issue(tmp_path, 42) == "feat/42-newer"
+
+    def test_listing_failure_propagates_not_swallowed(self, tmp_path: Path) -> None:
+        """A `gh pr list` failure must raise, not look like 'no open PR' (#428 review).
+
+        Treating an unknown listing as absence would let a caller bootstrap a
+        duplicate PR while a live one exists on another same-issue branch.
+        """
+        with (
+            patch(f"{_S}.git_pr.list_prs", side_effect=GhCliError("gh boom")),
+            pytest.raises(GhCliError),
+        ):
+            find_open_pr_branch_for_issue(tmp_path, 42)
+
+    def test_requests_failure_aware_listing(self, tmp_path: Path) -> None:
+        """The resolver must opt into raise-on-error so failures are distinguishable."""
+        with patch(f"{_S}.git_pr.list_prs", return_value=[]) as mock_list:
+            find_open_pr_branch_for_issue(tmp_path, 42)
+        assert mock_list.call_args.kwargs.get("raise_on_error") is True

--- a/tests/unit/test_services/test_smart_start.py
+++ b/tests/unit/test_services/test_smart_start.py
@@ -25,7 +25,7 @@ class TestSmartStartNoPR:
         "wade.services.smart_start.git_pr.get_pr_for_branch",
         return_value=PRLookup(found=False),
     )
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -52,7 +52,7 @@ class TestSmartStartMergedPR:
     """When PR is merged, shows info message."""
 
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -83,7 +83,7 @@ class TestSmartStartOpenPR:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch("wade.git.worktree.list_worktrees", return_value=[])
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -118,7 +118,7 @@ class TestSmartStartOpenPR:
     @patch("wade.ui.prompts.is_tty", return_value=False)
     @patch("wade.git.worktree.list_worktrees", return_value=[])
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -160,7 +160,7 @@ class TestSmartStartOpenPR:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch("wade.git.worktree.list_worktrees", return_value=[])
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -193,7 +193,7 @@ class TestSmartStartOpenPR:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch("wade.git.worktree.list_worktrees", return_value=[])
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -231,7 +231,7 @@ class TestSmartStartDraftPR:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch("wade.git.worktree.list_worktrees", return_value=[])
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -275,7 +275,7 @@ class TestSmartStartDraftPR:
         return_value=[Worktree(branch="feat/42-fix", path="/tmp/wt")],
     )
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -315,7 +315,7 @@ class TestSmartStartDraftPR:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch("wade.git.worktree.list_worktrees", return_value=[])
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -417,7 +417,7 @@ class TestSmartStartTrackingDetection:
         "wade.services.smart_start.git_pr.get_pr_for_branch",
         return_value=PRLookup(found=False),
     )
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -514,9 +514,7 @@ class TestSmartStartTrackingDetection:
         "wade.services.smart_start.git_pr.get_pr_for_branch",
         return_value=PRLookup(found=False),
     )
-    @patch(
-        "wade.services.smart_start.git_branch.make_branch_name", return_value="feat/173-tracking"
-    )
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/173-tracking")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -549,9 +547,7 @@ class TestSmartStartTrackingDetection:
         "wade.services.smart_start.git_pr.get_pr_for_branch",
         return_value=PRLookup(found=False),
     )
-    @patch(
-        "wade.services.smart_start.git_branch.make_branch_name", return_value="feat/173-tracking"
-    )
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/173-tracking")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -613,7 +609,7 @@ class TestSmartStartTrackingDetection:
         "wade.services.smart_start.git_pr.get_pr_for_branch",
         return_value=PRLookup(found=False),
     )
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -638,6 +634,63 @@ class TestSmartStartTrackingDetection:
         call_kwargs = mock_do_start.call_args.kwargs
         assert call_kwargs["effort"] == "high"
         assert call_kwargs["effort_explicit"] is True
+
+
+class TestSmartStartResolvesByIssueNumber:
+    """Regression: a retitled issue must still resolve to its existing branch/PR.
+
+    ``done`` rewrites the issue title to add the required conventional-commit
+    prefix, so re-running ``wade <id>`` would re-slugify to a *different* branch.
+    smart_start must look up the PR by the branch the worktree actually lives on
+    (resolved via the stable issue number) instead of the drifted reconstruction,
+    or it would miss the live PR and send an in-flight task back to implement.
+    """
+
+    _SHARED = "wade.services.implementation_service._shared"
+
+    @patch("wade.services.smart_start.SmartStartContext.run_implement", return_value=True)
+    @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
+    @patch("wade.services.smart_start.git_repo.get_repo_root")
+    @patch("wade.services.smart_start.get_provider")
+    @patch("wade.services.smart_start.load_config")
+    def test_looks_up_pr_by_existing_branch_not_retitled_slug(
+        self,
+        mock_config: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_repo_root: MagicMock,
+        mock_pr: MagicMock,
+        mock_implement: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_repo_root.return_value = tmp_path
+        mock_config.return_value.project.branch_prefix = "feat"
+        # The issue title was rewritten to conventional form after implement; its
+        # frozen branch still carries the original slug.
+        frozen_branch = "feat/104-llm-safety-gate-original-slug"
+        mock_get_provider.return_value.read_task.return_value = Task(
+            id="104",
+            title="fix: LLM safety gate always returns 6 unique numbers",
+            state=TaskState.OPEN,
+            body="",
+        )
+        mock_pr.return_value = PRLookup(
+            found=True, pr=PRRef(number=228, state="OPEN", isDraft=False)
+        )
+
+        with (
+            patch(f"{self._SHARED}.git_repo.get_current_branch", return_value="main"),
+            patch(
+                f"{self._SHARED}.git_worktree.list_worktrees",
+                return_value=[Worktree(path=str(tmp_path / "wt"), branch=frozen_branch)],
+            ),
+        ):
+            # cd_only short-circuits the interactive menu once the open PR is found.
+            result = smart_start("104", project_root=tmp_path, cd_only=True)
+
+        assert result is True
+        # The PR was resolved by the branch the worktree lives on — not the
+        # branch a fresh slug of the new title would produce.
+        mock_pr.assert_called_once_with(tmp_path, frozen_branch)
 
 
 class TestRunReviewPrComments:

--- a/tests/unit/test_services/test_smart_start.py
+++ b/tests/unit/test_services/test_smart_start.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from wade.git.pr import PRLookup, PRRef
 from wade.git.repo import GitError
 from wade.models.review import PollOutcome
@@ -15,6 +17,16 @@ from wade.services.smart_start import SmartStartContext, _run_review_pr_comments
 
 def _make_task() -> Task:
     return Task(id="42", title="Fix the widget", state=TaskState.OPEN, body="")
+
+
+@pytest.fixture(autouse=True)
+def _default_no_open_pr() -> object:
+    """Default the issue→open-PR resolver to 'none' so routing tests don't spawn a
+    real ``gh pr list`` in the not-open-PR path. The resume-by-open-PR test
+    overrides this with its own patch.
+    """
+    with patch("wade.services.smart_start.find_open_pr_branch_for_issue", return_value=None):
+        yield
 
 
 class TestSmartStartNoPR:
@@ -691,6 +703,53 @@ class TestSmartStartResolvesByIssueNumber:
         # The PR was resolved by the branch the worktree lives on — not the
         # branch a fresh slug of the new title would produce.
         mock_pr.assert_called_once_with(tmp_path, frozen_branch)
+
+    @patch("wade.services.smart_start.SmartStartContext.run_implement", return_value=True)
+    @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
+    @patch("wade.services.smart_start.git_repo.get_repo_root")
+    @patch("wade.services.smart_start.get_provider")
+    @patch("wade.services.smart_start.load_config")
+    def test_resumes_open_pr_when_resolved_branch_is_closed(
+        self,
+        mock_config: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_repo_root: MagicMock,
+        mock_pr: MagicMock,
+        mock_implement: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Ambiguity settled by PR state: a stale closed branch must not shadow the
+        issue's live open PR on another branch (#428 review)."""
+        mock_repo_root.return_value = tmp_path
+        mock_config.return_value.project.branch_prefix = "feat"
+        stale_branch = "feat/42-closed-pr-branch"
+        live_branch = "feat/42-open-pr-branch"
+        mock_get_provider.return_value.read_task.return_value = _make_task()
+
+        def pr_by_branch(_repo_root: Path, branch: str) -> PRLookup:
+            if branch == live_branch:
+                return PRLookup(found=True, pr=PRRef(number=9, state="OPEN", isDraft=False))
+            return PRLookup(found=True, pr=PRRef(number=7, state="CLOSED"))
+
+        mock_pr.side_effect = pr_by_branch
+
+        with (
+            patch(f"{self._SHARED}.git_repo.get_current_branch", return_value="main"),
+            patch(
+                f"{self._SHARED}.git_worktree.list_worktrees",
+                return_value=[Worktree(path=str(tmp_path / "wt"), branch=stale_branch)],
+            ),
+            patch(
+                "wade.services.smart_start.find_open_pr_branch_for_issue",
+                return_value=live_branch,
+            ),
+        ):
+            result = smart_start("42", project_root=tmp_path, cd_only=True)
+
+        assert result is True
+        # Re-looked up the live open PR's branch rather than treating the issue as
+        # closed and starting fresh.
+        assert mock_pr.call_args_list[-1].args == (tmp_path, live_branch)
 
 
 class TestRunReviewPrComments:

--- a/tests/unit/test_services/test_smart_start_resume.py
+++ b/tests/unit/test_services/test_smart_start_resume.py
@@ -256,7 +256,7 @@ class TestSmartStartResumeIntegration:
         return_value=[Worktree(branch="feat/42-fix", path="/tmp/wt")],
     )
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -302,7 +302,7 @@ class TestSmartStartResumeIntegration:
         return_value=[Worktree(branch="feat/42-fix", path="/tmp/wt")],
     )
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -346,7 +346,7 @@ class TestSmartStartResumeIntegration:
         return_value=[Worktree(branch="feat/42-fix", path="/tmp/wt")],
     )
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")
@@ -383,7 +383,7 @@ class TestSmartStartResumeIntegration:
     @patch("wade.ui.prompts.is_tty", return_value=True)
     @patch("wade.git.worktree.list_worktrees", return_value=[])
     @patch("wade.services.smart_start.git_pr.get_pr_for_branch")
-    @patch("wade.services.smart_start.git_branch.make_branch_name", return_value="feat/42-fix")
+    @patch("wade.services.smart_start.resolve_task_branch", return_value="feat/42-fix")
     @patch("wade.services.smart_start.git_repo.get_repo_root")
     @patch("wade.services.smart_start.get_provider")
     @patch("wade.services.smart_start.load_config")


### PR DESCRIPTION
## Problem

Re-running `wade <id>` on an issue that already has an open PR sometimes fails to find that PR — `smart_start` silently sends the task back through a fresh implement, and the implement core reports **"This task has no plan attached"** and offers to re-plan / re-bootstrap a duplicate.

### Root cause

The task branch is derived by re-slugifying the issue **title** and the PR is looked up by that exact branch:

- `core.py` / `smart_start.py` → `git_branch.make_branch_name(prefix, id, title)`
- → `git_pr.get_pr_for_branch(repo_root, branch)` → `gh pr view <branch>`

But the `done` flow **rewrites the issue title** to add the required conventional-commit prefix (`done.require_conventional_title`). After that rename, a re-run recomputes a *different* branch than the PR's head, so the exact lookup misses the live PR entirely.

Concrete example from the report (issue #104):

| | Issue title | Derived branch |
|---|---|---|
| 1st run (PR opened) | `LLM Safety Gate: Always Return 6 Unique Numbers (1-60)` | `feat/104-llm-safety-gate-always-return-6-unique-numbers-1` |
| re-run `wade 104` | `fix: LLM safety gate always returns 6 unique numbers (1-60)` | `feat/104-fix-llm-safety-gate-always-returns-6-unique` |

The recomputed branch doesn't match the PR's head → `existing_pr` is `None` → "no plan attached".

## Fix

Resolve the branch by the **stable issue number** instead of a re-slugified title — the same strategy #417 already applied to the `review pr-comments` flow. Extracted into a shared `resolve_task_branch` helper in `implementation_service/_shared.py`:

1. the currently checked-out branch, if it carries this issue (authoritative);
2. an existing **worktree / local / remote branch** carrying the issue number;
3. title reconstruction — only when nothing for the issue exists yet (first-time creation).

`smart_start` and the implement `core` now use it, so both resume the real worktree / PR / plan after a title change. Because the original worktree/branch (`feat/104-…-numbers-1`) still carries the issue number, resolution finds it and the PR lookup succeeds.

## Tests

- `test_resolve_task_branch.py` — unit coverage for the shared resolver (checked-out branch wins, worktree wins, local/remote fallback, retitled-issue resolution, first-time reconstruction, sub-issue-number collision guard).
- `test_smart_start.py::TestSmartStartResolvesByIssueNumber` — end-to-end regression for the exact report: a retitled issue looks up the PR by the branch the worktree lives on, not the drifted slug.
- Existing `smart_start` tests repointed from the `make_branch_name` seam to the new `resolve_task_branch` seam.
- Full unit suite green (3259 passed); ruff + mypy clean.

## Follow-up (out of scope)

`review_service` keeps its own equivalent private resolver (`_resolve_task_branch` / `_find_existing_branch_for_issue` from #417). Migrating it onto the shared `_shared.resolve_task_branch` would remove the duplication, but its test fixtures patch `review_service`'s git-module aliases and would need careful repointing (~37 tests) — better done in a dedicated PR to keep this fix low-risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task branch detection using stable issue numbers across worktrees, local branches, and remote branches.
  * Preserved existing branches when issue titles change, preventing orphaned branches.
  * Avoided reusing branches associated with closed pull requests when starting new work.
  * Improved smart-start and implementation flows when resuming tasks or working from detached branches.
* **Tests**
  * Added coverage for branch selection priority, ambiguity handling, renamed titles, and closed pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->