### PR TITLE
fix(codex): adopt crossby 0.23.7 to drop deprecated codex_hooks flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Version Control :: Git",
 ]
 dependencies = [
-    "crossby>=0.17.1,<0.18.0",
+    "crossby>=0.23.7,<0.24.0",
     "typer>=0.12,<0.26",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/src/wade/skills/installer.py
+++ b/src/wade/skills/installer.py
@@ -147,7 +147,7 @@ def get_worktree_gitignore_entries() -> list[str]:
     # AI tool settings (written per-session to worktrees only)
     entries.append(".claude/settings.json")
     entries.append(".cursor/cli.json")
-    # Codex config — crossby's hook writer sets [features].codex_hooks = true here
+    # Codex config — crossby's hook writer sets [features].hooks = true here
     # per-session so Codex loads the installed hooks; not user content in a worktree.
     entries.append(".codex/config.toml")
 

--- a/tests/unit/test_services/test_bootstrap_allowlist.py
+++ b/tests/unit/test_services/test_bootstrap_allowlist.py
@@ -375,7 +375,9 @@ class TestBootstrapPlanMode:
         assert "session-complete" in (worktree_path / ".codex" / "hooks.json").read_text("utf-8")
 
     def test_codex_hooks_feature_flag_enabled(self, tmp_path: Path) -> None:
-        """crossby's Codex writer enables [features].codex_hooks so hooks load."""
+        """crossby's Codex writer enables the canonical [features].hooks so hooks
+        load, and does not write the deprecated ``codex_hooks`` alias (which newer
+        Codex builds warn on)."""
         import tomllib
 
         worktree_path = tmp_path / "worktree"
@@ -389,7 +391,8 @@ class TestBootstrapPlanMode:
         config = worktree_path / ".codex" / "config.toml"
         assert config.is_file(), "Codex hooks are inert without .codex/config.toml"
         parsed = tomllib.loads(config.read_text("utf-8"))
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True
+        assert "codex_hooks" not in parsed["features"]
 
     def test_stop_hook_guard_differs_by_mode(self, tmp_path: Path) -> None:
         """Impl/review sessions install a ``session-complete`` Stop hook; plan

--- a/tests/unit/test_skills/test_managed_gitignore.py
+++ b/tests/unit/test_skills/test_managed_gitignore.py
@@ -40,7 +40,7 @@ class TestGetWorktreeGitignoreEntries:
         entries = get_worktree_gitignore_entries()
         assert ".claude/settings.json" in entries
         assert ".cursor/cli.json" in entries
-        # crossby's Codex hook writer enables [features].codex_hooks here per-session.
+        # crossby's Codex hook writer enables [features].hooks here per-session.
         assert ".codex/config.toml" in entries
 
     def test_includes_session_artifacts(self) -> None:


### PR DESCRIPTION
## Problem

Every `wade plan` / `wade implement` launch with the Codex tool prints:

```
⚠ `[features].codex_hooks` is deprecated. Use `[features].hooks` instead.
```

The warning is emitted by Codex itself when it reads `.codex/config.toml`, which contained the deprecated `[features].codex_hooks = true` alias. That key is written by crossby's `CodexHooksWriter` during bootstrap.

The fix already exists in **crossby** (PR #136, released in 0.23.6/0.23.7): it writes only the canonical `[features].hooks = true` and *migrates* existing configs by removing the deprecated alias. But wade's pin was `crossby>=0.17.1,<0.18.0`, so wade kept shipping 0.17.1 — which deliberately writes **both** keys (`_CODEX_FEATURE_KEYS = ("hooks", "codex_hooks")`). The `<0.18.0` cap forbade the fixed release, so the warning persisted regardless of wade version.

## Change

- Bump the crossby pin: `crossby>=0.17.1,<0.18.0` → `>=0.23.7,<0.24.0`.
- Update the bootstrap feature-flag test to assert the **canonical** `[features].hooks` is set and the deprecated `codex_hooks` alias is **absent**.
- Refresh two now-stale comments referencing `codex_hooks`.

After upgrade, the next bootstrap migrates any existing `.codex/config.toml` (removes the alias), so the warning stops for good.

## Verification

- Smoke-tested every crossby import site wade uses against 0.23.7 — all resolve.
- Full test suite: **3523 passed** (the single failure was the test asserting the old buggy behavior, now updated).
- `ruff check` + `ruff format --check` clean on touched files.

Note: `uv.lock` is gitignored in this repo, so the resolved-lock change (`crossby 0.17.1 → 0.23.7`) isn't part of the diff.