### PR TITLE
feat: adopt crossby 0.24.0 refreshed AI-tool model catalogs

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -647,7 +647,7 @@ On a crossby bump, re-verify the Codex hooks feature-flag key in the `.codex/con
 
 ## fb2a067bb103 | 2026-08-16 | implementation | tags: crossby, ai-tools, model-registry | Issue #433
 
-WADE owns zero AI-tool model catalogs — every selectable model comes from crossby's static registry (crossby.data.get_models_for_tool) and per-tool complexity defaults come from crossby.config.defaults.get_defaults. Refreshing the available models for any tool is purely a crossby dependency bump in pyproject.toml + uv.lock regen; no WADE source or template edits are needed. antigravity-cli defaults intentionally use effort-suffixed IDs (e.g. gemini-3.6-flash-medium) that are not literal members of get_models_for_tool('antigravity-cli'); the init model pickers handle this by inserting the tier default into the option list (prompts_ai._prompt_model_mapping).
+WADE owns zero AI-tool model catalogs — catalog models come from crossby's static registry (crossby.data.get_models_for_tool) and per-tool complexity defaults come from crossby.config.defaults.get_defaults. Refreshing the available models for any tool is purely a crossby dependency bump in pyproject.toml + uv.lock regen; no WADE source or template edits are needed. antigravity-cli defaults intentionally use effort-suffixed IDs (e.g. gemini-3.6-flash-medium) that are not literal members of get_models_for_tool('antigravity-cli'); the init model pickers handle this by inserting the tier default into the option list (prompts_ai._prompt_model_mapping).
 
 ---
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -644,3 +644,15 @@ _pull_main_after_merge (services/implementation_service/lifecycle.py) is now ato
 On a crossby bump, re-verify the Codex hooks feature-flag key in the `.codex/config.toml` crossby writes: crossby #136 (v0.23.5) migrated the deprecated `[features].codex_hooks` alias to the canonical `[features].hooks=true` (and removes the old key). The wade bootstrap test `test_bootstrap_allowlist.py::test_codex_hooks_feature_flag_enabled` asserts the exact key, so it breaks on any crossby bump that crosses this migration — assert `[features].hooks`, not `[features].codex_hooks`. Same manual-mirror class as the `_TOOL_DIALECTS` re-sync gotcha.
 
 ---
+
+## fb2a067bb103 | 2026-08-16 | implementation | tags: crossby, ai-tools, model-registry | Issue #433
+
+WADE owns zero AI-tool model catalogs — every selectable model comes from crossby's static registry (crossby.data.get_models_for_tool) and per-tool complexity defaults come from crossby.config.defaults.get_defaults. Refreshing the available models for any tool is purely a crossby dependency bump in pyproject.toml + uv.lock regen; no WADE source or template edits are needed. antigravity-cli defaults intentionally use effort-suffixed IDs (e.g. gemini-3.6-flash-medium) that are not literal members of get_models_for_tool('antigravity-cli'); the init model pickers handle this by inserting the tier default into the option list (prompts_ai._prompt_model_mapping).
+
+---
+
+## 2112b028ab73 | 2026-08-16 | implementation | tags: dependencies, ci, crossby | Issue #433
+
+uv.lock is gitignored in the WADE repo (.gitignore:47) and NOT tracked. A dependency bump therefore commits only pyproject.toml (and the regenerated lock stays local for reproducibility). CI uses 'uv sync --all-extras' (not --locked/--frozen), so there is no lock-freshness gate. Do not 'git add -f uv.lock' during a dependency change.
+
+---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Version Control :: Git",
 ]
 dependencies = [
-    "crossby>=0.23.7,<0.24.0",
+    "crossby>=0.24.0,<0.25.0",
     "typer>=0.12,<0.26",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",


### PR DESCRIPTION
Closes #433

<!-- wade:plan:start -->

## Complexity
easy

## Context / Problem
Wade does not maintain its own AI-tool model catalogs. It reads every
selectable model from crossby's static registry — the interactive picker calls
`crossby.data.get_models_for_tool` (`src/wade/services/ai_resolution.py`), and
model/effort gating goes through `AbstractAITool.is_model_compatible` /
`.capabilities()`. There are no hardcoded model IDs in wade's source or
templates, no vendored `models.json`, and no doc/README that enumerates the
catalogs.

crossby issue #139 / PR #140 ("refresh supported model catalogs across AI
tools") refreshed that registry and shipped as **crossby v0.24.0**
(2026-08-16). Notably it adds `gemini-3.7-flash` to the Antigravity CLI catalog
(with valid low/medium/high effort translation), plus new verified IDs for
Cursor (Gemini 3.7 Flash / Grok 4.6 / Kimi K3 variants), GitHub Copilot CLI
(Gemini 3.1 Pro Preview, Gemini 3.5/3.6 Flash, GPT-5.4, MAI Code 1 Flash), and
OpenCode (provider-qualified Gemini 3.7 forms). No historical IDs were removed.

Wade currently pins `crossby>=0.23.7,<0.24.0` in `pyproject.toml`, which
**excludes** v0.24.0. The installed catalog is still the pre-refresh one — e.g.
`get_models_for_tool("antigravity-cli")` returns
`['gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3.1-pro', 'claude-sonnet-4-6',
'claude-opus-4-6-thinking', 'gpt-oss-120b']` with no Gemini 3.7 Flash. So wade
users cannot yet select the refreshed models. The only wade-side action needed
is to adopt crossby v0.24.0.

## Proposed Solution
Bump wade's crossby dependency to adopt the refreshed catalogs, regenerate the
lockfile, and verify the suite still passes. No wade code changes are expected —
the update is a dependency bump plus lockfile regen.

- In `pyproject.toml`, change `"crossby>=0.23.7,<0.24.0"` to
  `"crossby>=0.24.0,<0.25.0"` (matches wade's existing `>=X.Y.Z,<X.(Y+1).0`
  pinning convention).
- Regenerate `uv.lock` (`uv lock`) so it resolves crossby 0.24.0, and reinstall
  the dev environment (`uv pip install -e ".[dev]"`).
- Run the full check suite. If any test asserts on an exact per-tool catalog
  (none found during planning), update it to match the refreshed registry.

### Notes for the implementation session
- crossby v0.24.0 is a clean minor release containing **only** PR #140 (verified
  via the GitHub release notes / `v0.23.7...v0.24.0` compare). The public API
  wade uses (`get_models_for_tool`, `AbstractAITool`, `AIToolID`, capabilities /
  effort tiers) is unchanged; PR #140 touched `models.json`, Antigravity CLI
  effort tiers, a dev-only probe script, and crossby's own `CONTRIBUTING.md`.
- `_VALID_AI_TOOLS` in `check_service.py` derives from `AIToolID`, and 0.24.0
  adds no new tools — so config validation needs no change.
- `_validate_models_section` validates tool names and complexity keys only, never
  model-ID spellings, so `.wade.yml` model values are unaffected.
- **No test asserts on an exact catalog list (verified during planning):** grepped
  `tests/` for model-ID literals and for `get_models_for_tool` usage — the only
  hits are `test_ai_resolution.py`, which *mocks* `get_models_for_tool` (patch
  target `_MODELS_FOR_TOOL`), and arbitrary example IDs in
  `test_effort.py`/`test_ai_resolution.py` (`claude-sonnet-4-6` etc.) used as
  effort-parsing inputs, not catalog-membership assertions.
- **E2E is unaffected (verified during planning):** grepped `tests/e2e/` for
  `get_models_for_tool` and model-ID literals — no hits; the deterministic e2e
  contract tests drive a mocked `gh`, not the real crossby catalog. Still worth a
  quick `./scripts/test-e2e.sh` sanity run since `check-all.sh` excludes e2e.
- **CI has no strict lock-freshness gate:** `.github/workflows/ci.yml` and
  `auto-version.yml` run `uv sync --all-extras` (not `uv sync --locked` /
  `--frozen`), so a stale lock won't fail CI — but the regenerated `uv.lock`
  must still be committed alongside `pyproject.toml` for reproducibility. Do
  **not** hand-edit `uv.lock`; regenerate it with `uv lock`.
- **Do not bump wade's version in this PR.** Version bumps are a separate
  `chore:` step handled via `scripts/auto_version.py` / the `auto-version.yml`
  workflow (see the standalone `chore: bump version to vX.Y.Z` commits in
  history) — not part of this feature commit. Title uses `feat:` because it
  enables new user-selectable models; the release tooling derives the version
  bump from that prefix separately.
- Knowledge learning worth capturing in the implementation PR: wade owns **zero**
  AI-tool model catalogs; refreshing available models is purely a crossby
  dependency bump on wade's side. No wade code edits required for catalog
  updates.

## Tasks
- [ ] Bump the crossby pin in `pyproject.toml` from `>=0.23.7,<0.24.0` to
      `>=0.24.0,<0.25.0`.
- [ ] Run `uv lock` to regenerate `uv.lock` against crossby 0.24.0, then
      `uv pip install -e ".[dev]"` to sync the dev environment. Commit the
      regenerated `uv.lock` together with the `pyproject.toml` change.
- [ ] Confirm the refreshed catalog resolves — e.g.
      `uv run python -c "from crossby.data import get_models_for_tool; print(get_models_for_tool('antigravity-cli'))"`
      now includes `gemini-3.7-flash`.
- [ ] Run `./scripts/check-all.sh` (tests + strict types + lint/format). Fix any
      test that pins an exact per-tool model list to match the refreshed registry
      (none expected — see notes).
- [ ] Run `./scripts/test-e2e.sh` as a sanity check (it's excluded from
      `check-all.sh`); expected to pass unchanged since e2e mocks `gh` rather than
      reading the real crossby catalog.
- [ ] Update this repo's docs only if a real reference changed (none expected —
      no wade doc enumerates model catalogs).
- [ ] Capture the knowledge note above in the implementation PR (knowledge add is
      unavailable in planning sessions).

## Acceptance Criteria
- [ ] `pyproject.toml` pins `crossby>=0.24.0,<0.25.0` and `uv.lock` resolves
      crossby to 0.24.0.
- [ ] The dev environment installs cleanly with the new pin.
- [ ] `get_models_for_tool("antigravity-cli")` includes `gemini-3.7-flash`, and
      the other refreshed IDs (Cursor / Copilot CLI / OpenCode) are available
      through wade's model picker.
- [ ] `./scripts/check-all.sh` passes (tests, strict mypy, ruff lint/format).
- [ ] No hardcoded model catalogs are introduced into wade — models continue to
      be sourced solely from crossby's registry.

<!-- wade:plan:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how AI-tool model catalogs and complexity defaults are refreshed.
  * Clarified that the dependency lockfile is regenerated automatically in CI.

* **Chores**
  * Updated the crossby dependency to the 0.24.x release series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- wade:summary:start -->

## Summary

## What was done

Adopt crossby **0.24.0**, which refreshes the supported model catalogs across
AI tools (crossby #139 / PR #140). Bumping the pin lets wade's model pickers
surface the newly verified IDs — notably `gemini-3.7-flash` on Antigravity CLI,
plus new Cursor / GitHub Copilot CLI / OpenCode entries. Wade owns zero
AI-tool catalogs or defaults, so this is a pure dependency bump with no wade
source or template changes.

## Changes

- `pyproject.toml`: `crossby>=0.23.7,<0.24.0` → `crossby>=0.24.0,<0.25.0`
  (matches wade's `>=X.Y.Z,<X.(Y+1).0` pinning convention).
- `KNOWLEDGE.md`: two entries — (1) wade sources all models/defaults from
  crossby, so catalog refreshes are dependency-only; (2) `uv.lock` is gitignored
  here, so dependency bumps commit only `pyproject.toml`. Entry (1) was later
  refined during review (see below).
- `uv.lock` was regenerated locally to confirm crossby 0.24.0 resolves cleanly,
  but it is **gitignored** (`.gitignore:47`) and therefore not committed — the
  plan's assumption that it is tracked does not hold for this repo.

## Testing

- `get_models_for_tool("antigravity-cli")` now includes `gemini-3.7-flash`.
- Verified every per-tool complexity default from `crossby.config.defaults.get_defaults`
  is valid: catalog members for all tools; antigravity-cli's effort-suffixed
  defaults (`gemini-3.6-flash-{low,medium,high}`) are handled by the init model
  picker, which inserts the tier default into the option list.
- Confirmed the new `gemini-3.7-flash` is compatible with antigravity-cli and
  wade's effort gating exposes low/medium/high (rejects xhigh/max), matching
  crossby's effort translation.
- `./scripts/check-all.sh`: 3565 tests passed, ruff clean, mypy --strict clean.
- `./scripts/test-e2e.sh`: 75 passed.

## Review comments addressed

- **CodeRabbit** (`KNOWLEDGE.md:650`, thread `PRRT_kwDORW_uUM6Zqc9f`, resolved):
  the entry opened with "every selectable model comes from crossby's static
  registry", which contradicted its own later note that antigravity-cli's
  effort-suffixed tier defaults (from `crossby.config.defaults.get_defaults`)
  are inserted into the picker option list despite **not** being members of
  `get_models_for_tool`. Verified against crossby 0.24.0:
  `get_models_for_tool("antigravity-cli")` returns no effort-suffixed IDs,
  while `get_defaults` returns `gemini-3.6-flash-{low,medium,high}` — none in
  the catalog — and `prompts_ai._prompt_model_mapping` inserts them
  (`prompts_ai.py:233-234`). Narrowed the claim to "catalog models come from
  crossby's static registry", leaving the accurate remainder intact. Prose-only
  edit to a knowledge entry; no code paths touched.

## Notes for reviewers

- No hardcoded model catalogs enter wade — models stay sourced solely from
  crossby's registry.
- Version bump is intentionally **not** part of this PR; that is a separate
  `chore:` step via `scripts/auto_version.py`. The `feat:` prefix reflects that
  new user-selectable models become available.

<!-- wade:summary:end -->

<!-- wade:review-status:start -->

## Review Status

⚠️ Review skipped (`--skip-review`); review attempted on 1 distinct commit, but the final commit was not reviewed.

<!-- wade:review-status:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-haiku-4.5` |
| Total tokens | *unavailable* |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `cb3083a3-8ee4-4815-a894-7bdf246237fc` |
| Review | `claude` | `462b6e12-0885-413d-996b-8f5f54f7dace` |

<!-- wade:sessions:end -->
