### PR TITLE
docs: refresh public onboarding and product positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ These are invoked by the AI during a session — you normally don't run them by 
 | `wade implementation-session sync` | Sync the branch onto the base branch |
 | `wade implementation-session done` | Completion gate — runs the gates, pushes, and opens/updates the PR |
 | `wade review-pr-comments-session check \| sync \| done` | Same lifecycle for a review session |
-| `wade review-pr-comments-session fetch` | Fetch unresolved PR review comments as markdown |
+| `wade review-pr-comments-session fetch <N>` | Fetch unresolved PR review comments as markdown |
 | `wade review-pr-comments-session resolve <thread>` | Mark a PR review thread as resolved on GitHub |
-| `wade plan-session done` | Finalize a planning session |
+| `wade plan-session done <plan_dir>` | Finalize a planning session |
 
 Most workflow commands accept `--ai <tool>`, `--model <model>`, `--effort <level>`, `--permission-mode <tier>`, and `--yolo` to override configured defaults. `implement`, `review pr-comments`, and the `wade <N>` shorthand also accept `--network` / `--no-network` (see [Codex sandbox](#codex-sandbox--network-policy)); the shorthand forwards the flag to whichever session it routes to. `implement` additionally supports `--detach` (new terminal tab), `--cd` (print worktree path only), and `--base <branch>` (see [Planning & base branches](#planning--base-branches)).
 
@@ -276,7 +276,7 @@ WADE splits review into an **AI review pass** you or the agent can invoke, and
 | `wade review trigger <N>` | Posts configured bot-review trigger comments on the task's PR |
 
 To fetch the unresolved comments themselves during a review session, the agent
-runs `wade review-pr-comments-session fetch`; it resolves individual threads with
+runs `wade review-pr-comments-session fetch <N>`; it resolves individual threads with
 `wade review-pr-comments-session resolve`.
 
 ### The auto-launched review session

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ while WADE handles the git and GitHub plumbing around every AI session.
   sessions never collide or stash-juggle.
 - **Full context, zero copy-paste** — the task, its description, labels, and your
   project conventions are loaded into the AI automatically.
-- **Agent guardrails** — per-session hooks keep the AI inside its worktree and
-  route it through a completion gate before any push.
+- **Agent guardrails** — on hook-capable AI tools, per-session hooks keep the AI
+  inside its worktree and route it through a completion gate before any push;
+  hookless tools fall back to skill rules (see the tool support table).
 - **Quality gates** — opt-in pre-commit lint/test and conventional-commit checks,
   plus an AI code-review pass before the PR is marked ready.
 - **Pluggable task providers** — GitHub Issues, ClickUp, or a committed Markdown
@@ -150,11 +151,13 @@ wade 42
 
 `wade <N>` routes on the task's **PR state**, not on whether a plan exists:
 
-- **No open PR** → starts (or resumes) an implementation session.
+- **No PR yet, or a closed unmerged one** → starts (or resumes) an implementation
+  session.
 - **Open draft PR** → continue the in-flight session (or start it if the
   worktree is gone).
 - **Open ready PR** → choose to continue working, address review comments, merge,
   or open the PR in your browser.
+- **Merged PR** → reports the task is already merged and stops — no session.
 
 It never launches a planning session on its own — reach for `wade plan` when you
 want planning.

--- a/README.md
+++ b/README.md
@@ -8,18 +8,40 @@
 
 *Every Wade does the dirty work so the heroes don't have to.*
 
-Branches, worktrees, context loading, model selection, PR creation — all the workflow friction that surrounds AI coding sessions. WADE eliminates it. Works with `Claude Code`, `Copilot`, `Antigravity CLI`, `Codex`, and more. Run `wade init` once per project, then just point it at a GitHub *(more to come!)* issue number.
+Branches, worktrees, context loading, model routing, PR creation — all the
+workflow friction that surrounds AI coding sessions. WADE eliminates it. It
+works with `Claude Code`, `Codex`, `Copilot`, `Cursor`, `Antigravity CLI`, and
+more, and pulls tasks from **GitHub Issues, ClickUp, or a committed Markdown
+file**. Run `wade init` once per project, then drive your work from task numbers
+while WADE handles the git and GitHub plumbing around every AI session.
+
+**Highlights**
+
+- **Deterministic planning** — `wade plan` turns a goal into validated plan
+  files that become lightweight tasks plus draft PRs, each labeled by complexity.
+- **Isolated worktrees** — every task gets its own git worktree, so parallel
+  sessions never collide or stash-juggle.
+- **Full context, zero copy-paste** — the task, its description, labels, and your
+  project conventions are loaded into the AI automatically.
+- **Agent guardrails** — per-session hooks keep the AI inside its worktree and
+  route it through a completion gate before any push.
+- **Quality gates** — opt-in pre-commit lint/test and conventional-commit checks,
+  plus an AI code-review pass before the PR is marked ready.
+- **Pluggable task providers** — GitHub Issues, ClickUp, or a committed Markdown
+  file; PRs and reviews always run through GitHub.
+- **Multi-tool** — automatic model routing by task complexity across every
+  supported AI coding tool.
 
 ## See It in Action
 
-Starting work on Issue #42:
+Starting work on task #42:
 
 *Without* WADE:
 
 ```bash
 git fetch origin && git checkout main && git pull
 git checkout -b feat/issue-42-user-auth
-# paste issue title + description into AI chat
+# paste task title + description into AI chat
 # explain your branching rules, test locations, linters to run...
 ```
 
@@ -29,7 +51,12 @@ git checkout -b feat/issue-42-user-auth
 wade 42
 ```
 
-WADE fetches the issue, detects whether it's been planned, and starts the right session automatically — planning if no plan exists yet, implementation if it does. Creates an isolated git worktree, launches your AI tool with the full issue loaded — title, description, labels, and all your project conventions — and Skills guide the AI from first commit to open PR without you touching git again.
+With no open PR for task #42 yet, WADE starts an implementation session: it
+creates an isolated git worktree, launches your AI tool with the full task
+loaded — title, description, labels, and all your project conventions — and
+Skills guide the AI from first commit to open PR without you touching git again.
+Want the AI to break the work down first? Run `wade plan` — planning is a
+deliberate step, not something `wade 42` guesses at from a missing plan.
 
 Finishing work and opening the PR:
 
@@ -50,9 +77,11 @@ gh pr create --title "User Auth (#42)" --body "..."   # write description manual
 wade implementation-session done
 ```
 
-The AI merges the latest main into the branch, resolves any conflicts, writes the PR description from what it built, and marks it ready for review — you get a clean, already-integrated diff with no noise for your reviewer.
+The AI merges the latest main into the branch, resolves any conflicts, writes the
+PR description from what it built, and marks it ready for review — you get a
+clean, already-integrated diff with no noise for your reviewer.
 
-Working on multiple issues at once:
+Working on multiple tasks at once:
 
 ```bash
 wade implement-batch 42 43 44   # three worktrees, three AI sessions, zero stashing
@@ -63,14 +92,14 @@ wade implement-batch 42 43 44   # three worktrees, three AI sessions, zero stash
 | Without WADE | With WADE |
 |---|---|
 | `git fetch && checkout && pull && checkout -b ...` before every task | `wade 42` — one command, done |
-| Copy-paste issue title + description into AI chat every time | Full issue context + project conventions loaded automatically |
-| One task at a time, or stash-juggle between branches | Parallel issues in isolated worktrees, zero conflicts |
+| Copy-paste task title + description into AI chat every time | Full task context + project conventions loaded automatically |
+| One task at a time, or stash-juggle between branches | Parallel tasks in isolated worktrees, zero conflicts |
 | Re-explain your branching rules, test commands, linters every session | Skills teach the AI your conventions once |
 | PRs opened on stale branches — reviewer sees conflict noise, asks for a rebase, CI fails | AI merges the latest main and resolves conflicts before the PR — reviewer sees only your changes |
-| Write the PR description, link the issue, clean up the branch — manually | The AI ships the PR. You just review |
-| Manually pick the right model for each task | Automatic model routing based on issue complexity |
-| Which terminal tab has which issue? No idea | Terminal title shows `wade implement #42 — Feature Name` |
-| Which AI session worked on this issue? Which tool? Which model? | Every PR and issue logs the tool, model, and session resume command — for both Plan and Implement phases |
+| Write the PR description, link the task, clean up the branch — manually | The AI ships the PR. You just review |
+| Manually pick the right model for each task | Automatic model routing based on task complexity |
+| Which terminal tab has which task? No idea | Terminal title shows `wade implement #42 — Feature Name` |
+| Which AI session worked on this task? Which tool? Which model? | Every PR and task logs the tool, model, and session resume command — for both Plan and Implement phases |
 
 ## Installation
 
@@ -108,34 +137,63 @@ Initialize WADE in your project (once):
 wade init
 ```
 
-Then start working:
+Then work in two deliberate steps — plan, then implement:
 
 ```bash
-# Plan a feature — AI creates GitHub issues and draft PRs
+# Plan deliberately — the AI writes validated plan files, each becoming a
+# lightweight task plus a draft PR
 wade plan
 
-# Start working — WADE detects plan state and picks the right session automatically
+# Start (or resume) implementation on task 42
 wade 42
 ```
 
+`wade <N>` routes on the task's **PR state**, not on whether a plan exists:
+
+- **No open PR** → starts (or resumes) an implementation session.
+- **Open draft PR** → continue the in-flight session (or start it if the
+  worktree is gone).
+- **Open ready PR** → choose to continue working, address review comments, merge,
+  or open the PR in your browser.
+
+It never launches a planning session on its own — reach for `wade plan` when you
+want planning.
+
+### The WADE lifecycle
+
+```
+wade plan ─▶ tasks + draft PRs ─▶ wade <N> ─▶ AI implements in an isolated worktree ─▶ PR opened ─▶ wade review pr-comments <N> ─▶ merge
+```
+
+- **You run** the entry points: `wade plan`, `wade <N>` / `wade implement <N>`,
+  `wade review pr-comments <N>`, and `wade cd <N>`.
+- **The AI runs** the session commands that enforce the workflow and open/update
+  the PR: `wade implementation-session {check,sync,done}`,
+  `wade review-pr-comments-session {check,sync,done,fetch,resolve}`, and
+  `wade plan-session done`.
+
 ## Commands
+
+### Commands you run
 
 | Command | Description |
 |---------|-------------|
-| `wade <N>` | Smart shorthand — routes to implement or review pr-comments automatically |
-| `wade plan` | AI planning session — creates issues + draft PRs |
-| `wade implement <N>` | Create worktree and start AI session for an issue |
-| `wade implement-batch <N> <M> ...` | Start parallel sessions for multiple issues *(beta)* |
-| `wade review pr-comments <N>` | Address PR review comments |
-| `wade review trigger <N>` | Post configured bot-review triggers on the issue's PR |
+| `wade <N>` | Smart entry — routes by the task's PR state to implement, continue, review, merge, or open-in-browser |
+| `wade plan` | AI planning session — writes validated plans that become tasks + draft PRs |
+| `wade implement <N>` | Create a worktree and start an implementation session for a task |
+| `wade implement-batch <N> <M> ...` | Start parallel sessions for multiple tasks *(beta)* |
+| `wade review pr-comments <N>` | Start a session to address PR review comments |
+| `wade review trigger <N>` | Post configured bot-review triggers on the task's PR |
 | `wade review plan <file>` | AI-powered plan review |
-| `wade review implementation` | AI-powered code review |
+| `wade review implementation` | AI-powered code review of the current diff |
 | `wade review batch <N>` | Coherence review across parallel implementation branches |
-| `wade cd <N>` | Navigate to a worktree (requires shell integration) |
-| `wade task create` | Create a GitHub issue interactively |
-| `wade task list` | List open issues |
-| `wade task read <N>` | Show issue details |
-| `wade task deps <N> <M> ...` | Analyze dependencies between issues |
+| `wade cd <N>` | Navigate to a task's worktree (requires shell integration) |
+| `wade task create` | Create a task interactively (in your configured provider) |
+| `wade task list` | List open tasks |
+| `wade task read <N>` | Show task details |
+| `wade task update <N>` | Update a task body or add a comment |
+| `wade task close <N>` | Close a task |
+| `wade task deps <N> <M> ...` | Analyze dependencies between tasks |
 | `wade worktree list` | List active worktrees |
 | `wade worktree remove <N>` | Remove a worktree |
 | `wade init` | Initialize WADE in the current project |
@@ -151,7 +209,39 @@ wade 42
 
 Short aliases: `wade p` (plan), `wade i <N>` (implement), `wade r <N>` (review pr-comments).
 
-Most workflow commands accept `--ai <tool>`, `--model <model>`, `--effort <level>`, `--permission-mode <tier>`, and `--yolo` to override configured defaults. `implement`, `review pr-comments`, and the `wade <N>` shorthand also accept `--network` / `--no-network` (see [Codex sandbox](#codex-sandbox--network-policy)); the shorthand forwards the flag to whichever session it routes to. `implement` additionally supports `--detach` (new terminal tab), `--cd` (print worktree path only), and `--base <branch>` (see below).
+### Session commands the AI runs
+
+These are invoked by the AI during a session — you normally don't run them by hand.
+
+| Command | Description |
+|---------|-------------|
+| `wade implementation-session check` | Verify the AI is in a writable worktree before it edits anything |
+| `wade implementation-session sync` | Sync the branch onto the base branch |
+| `wade implementation-session done` | Completion gate — runs the gates, pushes, and opens/updates the PR |
+| `wade review-pr-comments-session check \| sync \| done` | Same lifecycle for a review session |
+| `wade review-pr-comments-session fetch` | Fetch unresolved PR review comments as markdown |
+| `wade review-pr-comments-session resolve <thread>` | Mark a PR review thread as resolved on GitHub |
+| `wade plan-session done` | Finalize a planning session |
+
+Most workflow commands accept `--ai <tool>`, `--model <model>`, `--effort <level>`, `--permission-mode <tier>`, and `--yolo` to override configured defaults. `implement`, `review pr-comments`, and the `wade <N>` shorthand also accept `--network` / `--no-network` (see [Codex sandbox](#codex-sandbox--network-policy)); the shorthand forwards the flag to whichever session it routes to. `implement` additionally supports `--detach` (new terminal tab), `--cd` (print worktree path only), and `--base <branch>` (see [Planning & base branches](#planning--base-branches)).
+
+## Planning & base branches
+
+`wade plan` runs an AI planning session and then, from the validated plan files
+it produces, creates a lightweight task plus a draft PR for each one (labeled by
+complexity). Plan files are **strictly validated** before they become tasks — a
+`PLAN*.md` missing a valid `## Complexity` or a conventional-commit title is
+dropped with a loud error rather than silently becoming a task with no complexity
+label.
+
+`wade plan --issue <N>` re-plans an existing task. If the session produces a
+single plan file, it's attached to `#N` and the task stays open. If the
+session decides the work should be split into several independent pieces
+(2+ plan files), `#N` is **superseded**: a new task + draft PR is created
+per plan file, a comment and a `> **Superseded by ...**` banner are added to
+`#N`, and it's closed as *not planned* (confirmed via prompt unless
+`--yolo`/non-interactive). If any plan file fails to become a task, `#N` is
+left open with a warning instead of superseding on a partial split.
 
 ### Base branch
 
@@ -172,99 +262,24 @@ wade implement 42 --base develop   # branch from, target, and merge into develop
 
 `--base` overrides the plan-declared base and retargets the existing draft PR to match. A malformed base value is rejected up front — whether declared in the plan (fails `wade plan-session done`) or passed as `--base` (fails fast when you run `wade implement`); a well-formed base branch that does not exist fails draft-PR creation with an actionable message. Changing the base of a PR whose work is already in flight — whether by re-running planning or by `wade implement --base` — is not applied silently: it requires explicit confirmation, because the branch's existing history cannot be moved onto the new base without discarding it.
 
-`--permission-mode` sets how much autonomy the AI tool is granted — an axis
-independent of the delegation `--mode` (which controls *how* a tool is
-dispatched: prompt/interactive/headless). The tiers, most→least permissive, are
-`yolo` > `auto` > `accept-edits` > `default`:
+## Reviews & bot triggers
 
-| Tier | Behavior |
-|------|----------|
-| `default` | Prompt for every action (no autonomy grant). |
-| `accept-edits` | Auto-apply file edits; still prompt for shell/commands. Claude and Antigravity CLI. |
-| `auto` | Classifier-mediated auto mode (a model reviews each non-read action). Claude only. |
-| `yolo` | Full autonomy — no prompts. |
+WADE splits review into an **AI review pass** you or the agent can invoke, and
+**external bot triggers** for services like CodeRabbit, Codex, and Bugbot.
 
-`--yolo` is a back-compat alias for `--permission-mode yolo`; an explicit
-`--permission-mode` wins when both are given. The same values are accepted in
-`.wade.yml` as `ai.permission_mode` (global) or `ai.<command>.permission_mode`
-(per-command), with `yolo: true` still honored as the alias. A tier a tool
-doesn't support is downgraded automatically (e.g. `auto` → `accept-edits` on
-non-Claude tools) with a warning — WADE forwards the requested tier and
-[`crossby`](https://github.com/ivanviragine/crossby) owns the downgrade ladder.
-**Headless launches are always read-only** — any of `deps` /
-`review_plan` / `review_implementation` / `review_batch` dispatched in headless
-delegation mode runs at `default` regardless of the configured tier, and no
-`--yolo` is forwarded to the subprocess. The *interactive* variants honor the
-tier: `wade review plan`, `wade review implementation`, `wade review batch`, and
-`wade task deps` all accept `--yolo` / `--permission-mode` (matching `wade review
-pr-comments`), and `ai.review_batch.yolo: true` / `ai.deps.yolo: true` apply when
-those commands run interactively; the auto-launched review session honors its own
-tier via `ai.review_pr_comments` (see below). `plan` is not a permission mode —
-it's driven separately — and is rejected (warn + fall back to `default`) if
-configured.
+| Command | What it reviews |
+|---------|-----------------|
+| `wade review plan <file>` | A plan file, before it becomes tasks |
+| `wade review implementation` | The current implementation diff (mandatory gate before `done`) |
+| `wade review batch <N>` | Coherence across parallel implementation branches |
+| `wade review pr-comments <N>` | Starts a session to address human/bot PR comments |
+| `wade review trigger <N>` | Posts configured bot-review trigger comments on the task's PR |
 
-The **resolved permission mode is always displayed** at launch, on every path
-(TTY, non-TTY, headless, all-flags-explicit), with a one-line descriptor — so a
-`default` session states what `default` means, and what is shown always equals
-what is applied.
+To fetch the unresolved comments themselves during a review session, the agent
+runs `wade review-pr-comments-session fetch`; it resolves individual threads with
+`wade review-pr-comments-session resolve`.
 
-Those headless commands **auto-scale** their subprocess budget from the prompt
-size and reasoning effort (600s floor → 1500s ceiling), so a large diff or a
-high-effort run no longer times out at a flat budget. If a run does time out,
-wade keeps whatever partial output the reviewer produced (rather than discarding
-it) and **retries once** with a longer budget (1.5x the first attempt, always
-strictly more time than the run that just timed out), bounded to a ~62.5-minute
-worst-case total that the pre-launch advisory announces. Set `ai.<command>.timeout`
-(seconds) to override: an explicit value is used verbatim and **turns off both
-the scaling and the retry** — the escape hatch when your terminal/orchestrator
-enforces a hard tool-timeout (set it just under that limit).
-
-### Codex sandbox & network policy
-
-When WADE launches [Codex](https://github.com/openai/codex) in a linked
-worktree, Codex runs under `--sandbox workspace-write`, which confines writes to
-the worktree tree. A worktree's git metadata, however, lives **outside** that
-tree (`<main>/.git/worktrees/<wt>` and `<main>/.git`), so without extra grants
-every git write — `git add`/commit, ref updates, stash, and `wade
-sync`/`done` — fails with `Unable to create …/index.lock` or `could not write
-index`. WADE fixes this automatically: it passes the worktree's absolute path to
-the launcher, which grants those out-of-root git-metadata dirs as sandbox
-writable roots (the OS sandbox otherwise stays fully enabled — this widens
-nothing else). This is transparent; no Codex config or manual approval is
-needed, and it only affects Codex (every other tool ignores it).
-
-**Filesystem writes and network access are independent.** The metadata grant
-above makes **local** git work (stage, commit, stash, ref updates, and the
-local legs of `sync`/`done`) succeed with **network off**. Only operations that
-reach the network — `git fetch` (hence `sync`) and `git push` (hence the network
-leg of `done`) — need network access, which is **disabled by default**. Enable
-it explicitly per invocation with `--network` on `wade implement` / `wade review
-pr-comments`, or in `.wade.yml`:
-
-```yaml
-ai:
-  network_access: true          # default for the interactive session commands
-  implement:
-    network_access: false       # per-command override wins
-```
-
-The policy applies to the **interactive session commands** — `wade implement`
-and `wade review pr-comments` — which are the ones that run `sync`/`done` and so
-may need `fetch`/`push`. The headless/analytical paths (`plan`, `deps`,
-`review plan`/`implementation`/`batch`) are **always** network-off by design:
-they never fetch or push, so `ai.network_access` does not apply to them and no
-flag enables it there. Precedence for the commands that honor it is
-`--network`/`--no-network` > `ai.<command>.network_access` >
-`ai.network_access` > **off**. WADE always passes an explicit pin, so an ambient
-`network_access = true` in your own Codex `config.toml` can never silently
-enable network for a WADE-managed sandbox. Enabling network never disables the
-sandbox and never changes approval-policy semantics.
-
-`wade implementation-session check` (and the review equivalent) verifies this is
-actually working: on top of `IN_WORKTREE` / `IN_MAIN_CHECKOUT` /
-`NOT_IN_GIT_REPO`, it now reports **`WORKTREE_GIT_BLOCKED`** (exit code **3**)
-when a worktree's git metadata is not writable — naming the blocked path — so a
-session launched without the correct grant is caught before it wastes work.
+### The auto-launched review session
 
 The auto-launched **review session** — the one started when you pick **"Wait
 for reviews"** after `wade implementation-session done` and comments land —
@@ -341,35 +356,7 @@ same-SHA `done` still auto-triggers independently. `wade init` can enable
 back is **untrusted context** — the review session's verify-before-fixing rule
 still applies.
 
-`wade plan --issue <N>` re-plans an existing issue. If the session produces a
-single plan file, it's attached to `#N` and the issue stays open. If the
-session decides the work should be split into several independent pieces
-(2+ plan files), `#N` is **superseded**: a new issue + draft PR is created
-per plan file, a comment and a `> **Superseded by ...**` banner are added to
-`#N`, and it's closed as *not planned* (confirmed via prompt unless
-`--yolo`/non-interactive). If any plan file fails to become an issue, `#N` is
-left open with a warning instead of superseding on a partial split.
-
-## Supported AI Tools
-
-Adapters, model/effort resolution, and per-tool config (allowlists, hooks) are powered by [`crossby`](https://github.com/ivanviragine/crossby), WADE's AI-tool-integration dependency.
-
-| Tool | Binary |
-|------|--------|
-| [Claude Code](https://claude.com/product/claude-code) | `claude` |
-| [Cursor](https://www.cursor.com/) | `cursor` |
-| [GitHub Copilot](https://github.com/features/copilot/cli) | `copilot` |
-| [OpenAI Codex](https://developers.openai.com/codex/cli/) | `codex` |
-| [OpenCode](https://opencode.ai/) | `opencode` |
-| [VS Code](https://github.com/features/copilot/ai-code-editor) | `code` |
-| [Antigravity IDE](https://antigravity.google/) | `antigravity` |
-| [Antigravity CLI](https://antigravity.google/) | `agy` |
-
-> In `.wade.yml`, refer to a tool by its **config ID**, which matches the binary
-> above except for VS Code (`vscode`) and Antigravity CLI (`antigravity-cli`).
-> Antigravity IDE (config ID `antigravity`) is launch-only — WADE opens your
-> workspace in the desktop app; its workflow files are provisioned via the
-> Antigravity CLI's shared `.agents/` layout.
+## Guardrails & completion gates
 
 ### Session guards
 
@@ -395,21 +382,21 @@ with a conventional-commit prefix plus a `## Complexity`). Both fail **open** �
 session is never trapped.
 
 Independently of that nudge, `wade plan` now **strictly validates** plan files
-before creating issues: a `PLAN*.md` missing a valid `## Complexity` or a
+before creating tasks: a `PLAN*.md` missing a valid `## Complexity` or a
 conventional-commit title is dropped with a loud error instead of silently
-becoming an issue with no complexity label.
+becoming a task with no complexity label.
 
 `wade task create` enforces the same conventional-commit **title** rule (the type
 list is the single Python source in `utils/conventional.py`): a non-conventional
 `--title` (or a plan file's `# Title`) is rejected, and interactive create
-re-prompts. The PR title is derived from the issue title verbatim, so this is
+re-prompts. The PR title is derived from the task title verbatim, so this is
 what keeps a wade-opened PR from ever failing the `PR Title Lint` CI check;
 `done` also blocks on — and syncs — a stale non-conventional title on an already
 open PR (see the completion-gate table below).
 
 If some files pass and others fail, an interactive run asks whether to continue
 with the valid ones; `--yolo` and non-interactive runs continue without asking.
-If you decline, or if every plan file fails validation, no issues are created —
+If you decline, or if every plan file fails validation, no tasks are created —
 the generated `PLAN*.md` are preserved to a temp directory so you can fix the
 reported errors and re-run instead of regenerating from scratch.
 
@@ -443,7 +430,7 @@ escape hatch under a `done:` block in `.wade.yml` (all default on):
 | Sync | the branch is behind main — auto-syncs first, refuses only on conflict (implementation only) | `done.require_sync: false` |
 | Review ran | `wade review implementation` did not run for the current commit. **Implementation sessions bound this loop:** after `done.max_review_passes` (default 2) review→fix→re-review cycles, `done` completes anyway with a notice instead of looping forever | `--skip-review`, `done.require_review: false` (auto-off when `ai.review_implementation.enabled: false`) |
 | Resolved threads | unresolved PR review threads remain (review-comments only) | `done.require_resolved_threads: false` |
-| Conventional title | the issue title is not a conventional-commit title (the PR title is derived from it, so it would fail `PR Title Lint`) — blocks; when valid but the open PR's title differs, syncs the PR title to match (both session types) — if that sync fails while the PR's current title is itself non-conventional (lint would fail), `done` fails so it can be retried | `done.require_conventional_title: false` |
+| Conventional title | the task title is not a conventional-commit title (the PR title is derived from it, so it would fail `PR Title Lint`) — blocks; when valid but the open PR's title differs, syncs the PR title to match (both session types) — if that sync fails while the PR's current title is itself non-conventional (lint would fail), `done` fails so it can be retried | `done.require_conventional_title: false` |
 | Knowledge valid | the knowledge file is structurally corrupt — duplicate entry IDs or unresolved conflict markers (e.g. from a `merge=union` merge) | *none — gated by `knowledge.enabled`; no `done.*` hatch* |
 
 A **pre-push git hook** (`done.pre_push_backstop`, default on) backs the gate up:
@@ -465,20 +452,23 @@ the worktree-local `.wade/` markers that are discarded when the session ends.
 
 WADE can pull tasks from three backends — pick one when you run `wade init`:
 
-| Provider | Where issues live | Auth |
+| Provider | Where tasks live | Auth |
 |----------|-------------------|------|
 | `github` *(default)* | GitHub Issues | `gh` CLI |
 | `clickup` | ClickUp list | API token in env var |
 | `markdown` | A single committed `ISSUES.md` | None |
 
-PRs always flow through GitHub regardless of choice — `wade fetch-reviews`,
-the auto-poll loop, and review-thread resolution work identically across
-providers.
+**PRs and reviews always flow through GitHub, regardless of the task provider.**
+Non-GitHub providers compose a delegate that forwards every PR/review operation —
+review-thread listing and resolution, PR comments, and review status — to GitHub
+via the `gh` CLI, so `wade review pr-comments`, the auto-poll loop, and
+`wade review-pr-comments-session fetch` / `resolve` behave identically across
+providers. Only where a task itself lives differs.
 
 ### Markdown provider
 
-Useful when you want issues versioned alongside the code, with no external
-service. Each issue is one `##` heading in the file:
+Useful when you want tasks versioned alongside the code, with no external
+service. Each task is one `##` heading in the file:
 
 ```markdown
 # Wade Issues
@@ -515,26 +505,147 @@ Description body here. Sub-headings, code blocks, anything markdown.
   wade commit the change with a `chore: close #N` message; failures
   (not a git repo, hook rejection, signing required) are logged and
   swallowed so the close itself never blocks.
-- Tracking issues with `- [ ] #N` checklist bodies work the same as with
+- Tracking tasks with `- [ ] #N` checklist bodies work the same as with
   GitHub Issues — markdown's `find_parent_issue` scans every section's
   body for child refs.
 
+## Permission modes, autonomy & sandboxing
+
+### Permission modes
+
+`--permission-mode` sets how much autonomy the AI tool is granted — an axis
+independent of the delegation `--mode` (which controls *how* a tool is
+dispatched: prompt/interactive/headless). The tiers, most→least permissive, are
+`yolo` > `auto` > `accept-edits` > `default`:
+
+| Tier | Behavior |
+|------|----------|
+| `default` | Prompt for every action (no autonomy grant). |
+| `accept-edits` | Auto-apply file edits; still prompt for shell/commands. Claude and Antigravity CLI. |
+| `auto` | Classifier-mediated auto mode (a model reviews each non-read action). Claude only. |
+| `yolo` | Full autonomy — no prompts. |
+
+`--yolo` is a back-compat alias for `--permission-mode yolo`; an explicit
+`--permission-mode` wins when both are given. The same values are accepted in
+`.wade.yml` as `ai.permission_mode` (global) or `ai.<command>.permission_mode`
+(per-command), with `yolo: true` still honored as the alias. A tier a tool
+doesn't support is downgraded automatically (e.g. `auto` → `accept-edits` on
+non-Claude tools) with a warning — WADE forwards the requested tier and
+[`crossby`](https://github.com/ivanviragine/crossby) owns the downgrade ladder.
+**Headless launches are always read-only** — any of `deps` /
+`review_plan` / `review_implementation` / `review_batch` dispatched in headless
+delegation mode runs at `default` regardless of the configured tier, and no
+`--yolo` is forwarded to the subprocess. The *interactive* variants honor the
+tier: `wade review plan`, `wade review implementation`, `wade review batch`, and
+`wade task deps` all accept `--yolo` / `--permission-mode` (matching `wade review
+pr-comments`), and `ai.review_batch.yolo: true` / `ai.deps.yolo: true` apply when
+those commands run interactively; the auto-launched review session honors its own
+tier via `ai.review_pr_comments` (see above). `plan` is not a permission mode —
+it's driven separately — and is rejected (warn + fall back to `default`) if
+configured.
+
+The **resolved permission mode is always displayed** at launch, on every path
+(TTY, non-TTY, headless, all-flags-explicit), with a one-line descriptor — so a
+`default` session states what `default` means, and what is shown always equals
+what is applied.
+
+### Headless review budget
+
+Those headless commands **auto-scale** their subprocess budget from the prompt
+size and reasoning effort (600s floor → 1500s ceiling), so a large diff or a
+high-effort run no longer times out at a flat budget. If a run does time out,
+wade keeps whatever partial output the reviewer produced (rather than discarding
+it) and **retries once** with a longer budget (1.5x the first attempt, always
+strictly more time than the run that just timed out), bounded to a ~62.5-minute
+worst-case total that the pre-launch advisory announces. Set `ai.<command>.timeout`
+(seconds) to override: an explicit value is used verbatim and **turns off both
+the scaling and the retry** — the escape hatch when your terminal/orchestrator
+enforces a hard tool-timeout (set it just under that limit).
+
+### Codex sandbox & network policy
+
+When WADE launches [Codex](https://github.com/openai/codex) in a linked
+worktree, Codex runs under `--sandbox workspace-write`, which confines writes to
+the worktree tree. A worktree's git metadata, however, lives **outside** that
+tree (`<main>/.git/worktrees/<wt>` and `<main>/.git`), so without extra grants
+every git write — `git add`/commit, ref updates, stash, and `wade
+sync`/`done` — fails with `Unable to create …/index.lock` or `could not write
+index`. WADE fixes this automatically: it passes the worktree's absolute path to
+the launcher, which grants those out-of-root git-metadata dirs as sandbox
+writable roots (the OS sandbox otherwise stays fully enabled — this widens
+nothing else). This is transparent; no Codex config or manual approval is
+needed, and it only affects Codex (every other tool ignores it).
+
+**Filesystem writes and network access are independent.** The metadata grant
+above makes **local** git work (stage, commit, stash, ref updates, and the
+local legs of `sync`/`done`) succeed with **network off**. Only operations that
+reach the network — `git fetch` (hence `sync`) and `git push` (hence the network
+leg of `done`) — need network access, which is **disabled by default**. Enable
+it explicitly per invocation with `--network` on `wade implement` / `wade review
+pr-comments`, or in `.wade.yml`:
+
+```yaml
+ai:
+  network_access: true          # default for the interactive session commands
+  implement:
+    network_access: false       # per-command override wins
+```
+
+The policy applies to the **interactive session commands** — `wade implement`
+and `wade review pr-comments` — which are the ones that run `sync`/`done` and so
+may need `fetch`/`push`. The headless/analytical paths (`plan`, `deps`,
+`review plan`/`implementation`/`batch`) are **always** network-off by design:
+they never fetch or push, so `ai.network_access` does not apply to them and no
+flag enables it there. Precedence for the commands that honor it is
+`--network`/`--no-network` > `ai.<command>.network_access` >
+`ai.network_access` > **off**. WADE always passes an explicit pin, so an ambient
+`network_access = true` in your own Codex `config.toml` can never silently
+enable network for a WADE-managed sandbox. Enabling network never disables the
+sandbox and never changes approval-policy semantics.
+
+`wade implementation-session check` (and the review equivalent) verifies this is
+actually working: on top of `IN_WORKTREE` / `IN_MAIN_CHECKOUT` /
+`NOT_IN_GIT_REPO`, it now reports **`WORKTREE_GIT_BLOCKED`** (exit code **3**)
+when a worktree's git metadata is not writable — naming the blocked path — so a
+session launched without the correct grant is caught before it wastes work.
+
+## Supported AI Tools
+
+Adapters, model/effort resolution, and per-tool config (allowlists, hooks) are powered by [`crossby`](https://github.com/ivanviragine/crossby), WADE's AI-tool-integration dependency.
+
+| Tool | Binary |
+|------|--------|
+| [Claude Code](https://claude.com/product/claude-code) | `claude` |
+| [Cursor](https://www.cursor.com/) | `cursor` |
+| [GitHub Copilot](https://github.com/features/copilot/cli) | `copilot` |
+| [OpenAI Codex](https://developers.openai.com/codex/cli/) | `codex` |
+| [OpenCode](https://opencode.ai/) | `opencode` |
+| [VS Code](https://github.com/features/copilot/ai-code-editor) | `code` |
+| [Antigravity IDE](https://antigravity.google/) | `antigravity` |
+| [Antigravity CLI](https://antigravity.google/) | `agy` |
+
+> In `.wade.yml`, refer to a tool by its **config ID**, which matches the binary
+> above except for VS Code (`vscode`) and Antigravity CLI (`antigravity-cli`).
+> Antigravity IDE (config ID `antigravity`) is launch-only — WADE opens your
+> workspace in the desktop app; its workflow files are provisioned via the
+> Antigravity CLI's shared `.agents/` layout.
+
 ## Agent Skills
 
-wade installs Skills that teach your AI agent the workflow — issue format, planning rules, implementation session rules, and dependency analysis. Skills, the `AGENTS.md` workflow pointer, and any tool-specific configuration are set up automatically for every session (when you run `wade plan`/`wade implement`/`wade review`, or a standalone `wade task deps`), for every supported tool. Nothing to configure manually.
+wade installs Skills that teach your AI agent the workflow — task format, planning rules, implementation session rules, and dependency analysis. Skills, the `AGENTS.md` workflow pointer, and any tool-specific configuration are set up automatically for every session (when you run `wade plan`/`wade implement`/`wade review`, or a standalone `wade task deps`), for every supported tool. Nothing to configure manually.
 
 | Skill | Purpose |
 |-------|---------|
-| `task` | GitHub issue creation and plan format |
+| `task` | Task creation and plan format |
 | `plan-session` | Planning session rules and workflow |
 | `implementation-session` | Implementation session rules and workflow |
 | `review-pr-comments-session` | Review session rules and workflow |
-| `deps` | Dependency analysis between issues |
+| `deps` | Dependency analysis between tasks |
 
 ### Session communication
 
 Sessions report **by exception**: terse on success — just the actionable
-handles (issue/PR numbers, URLs, the next command), never a list of completed
+handles (task/PR numbers, URLs, the next command), never a list of completed
 steps or a reassurance that nothing broke. When something needs your
 attention or a decision only you can make, the agent reports it in 1–2
 sentences with brief context, its complexity
@@ -542,7 +653,7 @@ sentences with brief context, its complexity
 through the native question component, with the recommended option first and
 labelled "(recommended)".
 
-## Worktree Hooks
+## Extension Hooks
 
 Configure automated setup when worktrees are created via `wade implement` or `wade implement-batch`. Add a `hooks` section to `.wade.yml`:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ git checkout feat/issue-42-user-auth
 git merge main          # resolve conflicts yourself, if any
 git push
 gh pr create --title "User Auth (#42)" --body "..."   # write description manually
-# don't forget to link the issue, clean up the branch...
+# don't forget to link the task, clean up the branch...
 ```
 
 *With* WADE (the AI handles all of this):

--- a/src/wade/providers/_pr_delegate.py
+++ b/src/wade/providers/_pr_delegate.py
@@ -1,11 +1,11 @@
 """Shared mixin: delegate PR-review APIs to a GitHub provider.
 
-Issue providers whose tasks live elsewhere (Markdown file, ClickUp, etc.)
+Task providers whose tasks live elsewhere (Markdown file, ClickUp, etc.)
 still flow PRs through GitHub. Without this mixin they would raise
 ``NotImplementedError`` for review threads / PR comments and silently
-degrade ``wade fetch-reviews`` and the auto-poll loop. Composing the mixin
-makes those operations transparently delegate to a lazily-constructed
-:class:`wade.providers.github.GitHubProvider`.
+degrade ``wade review-pr-comments-session fetch`` and the auto-poll loop.
+Composing the mixin makes those operations transparently delegate to a
+lazily-constructed :class:`wade.providers.github.GitHubProvider`.
 
 Usage::
 


### PR DESCRIPTION
Closes #437

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem
The README is a strong reference but its first-run story misstates the executable
workflow. `wade <N>` uses PR state: it falls through to implementation when no
open PR exists, presents contextual continuation/review/merge choices for an
open PR, and does not start a planning session based on a missing plan. The
opening copy also says users point WADE at a GitHub issue while the code ships
GitHub, ClickUp, and Markdown task providers, and it still says "more to come".
The accurate product strengths—deterministic planning, draft PRs, isolated
worktrees, agent guardrails, quality gates, and multi-provider tasks—are present
but buried in a long, operationally dense README.

## Proposed Solution
Rework README.md around an accurate, provider-neutral getting-started narrative
and a clear "why WADE" message. Keep the detailed configuration and safety
reference, but make the primary paths easy to scan and make every command claim
match the current CLI/service behavior.

## Tasks
- [ ] Rewrite the hero and first value proposition to describe WADE as a workflow
  layer for AI coding sessions with pluggable task providers and GitHub-backed
  PRs; remove the obsolete GitHub-only and "more to come" language.
- [ ] Replace the `wade <N>` walkthrough with the source-accurate lifecycle:
  `wade plan` creates validated plan files that become lightweight tasks plus
  draft PRs, `wade <N>` starts/resumes implementation when no open PR exists,
  and an open PR exposes continuation, review, merge, and browser actions as
  applicable.
- [ ] Add a compact lifecycle map and concise command table that distinguish
  human entry points from agent session commands, retain `implement-batch` as
  beta, and use provider-neutral "task" terminology except where GitHub is a
  deliberate PR/review dependency.
- [ ] Restructure advanced material into discoverable sections (planning and
  alternate base branches, reviews/bot triggers, guardrails/completion gates,
  providers, configuration/sandboxing, and extension hooks) without weakening
  the existing safety and escape-hatch guidance.
- [ ] Correct provider/review wording, including the nonexistent
  `wade fetch-reviews` reference; accurately state that task providers delegate
  PR review operations to GitHub and point readers to the supported review
  commands.
- [ ] Verify every public command, flag, tool, and provider statement against
  `wade --help`, relevant subcommand help, `src/wade/cli/`, and service behavior;
  keep examples runnable and Markdown links valid.

## Acceptance Criteria
- [ ] README's first screen accurately communicates WADE's differentiated value
  and supports GitHub, ClickUp, and Markdown task providers without overclaiming
  that non-GitHub providers own PR/review operations.
- [ ] The quick-start flow never claims that `wade <N>` selects planning based
  on a missing plan; it tells readers to use `wade plan` deliberately for
  planning.
- [ ] No README reference remains to `wade fetch-reviews`, a GitHub-only task
  workflow, or obsolete "more to come" provider copy.
- [ ] The documented examples and command descriptions agree with `wade --help`
  and the relevant subcommand help output.

<!-- wade:plan:end -->

<!-- wade:summary:start -->

## Summary

## What was done

Refreshed `README.md` around an accurate, provider-neutral getting-started
narrative and a clearer "why WADE" message, and corrected every command claim
against the current CLI/service behavior. The README's first screen now
communicates WADE's differentiated value (deterministic planning, isolated
worktrees, agent guardrails, quality gates, multi-provider tasks) and states the
three supported task providers (GitHub, ClickUp, Markdown) without overclaiming
that non-GitHub providers own PR/review operations. Advanced material was
reorganized into discoverable top-level sections without weakening the existing
safety and escape-hatch guidance.

## Changes

- **Hero + highlights**: reframed WADE as a workflow layer for AI coding sessions
  with pluggable task providers and GitHub-backed PRs; removed the obsolete
  GitHub-only and "more to come" language and added a scannable highlights list.
- **Corrected the `wade <N>` walkthrough** to the source-accurate lifecycle
  (`src/wade/services/smart_start.py`): `wade plan` is the deliberate planning
  step that produces validated plans → lightweight tasks + draft PRs; `wade <N>`
  routes on **PR state** (implement/resume when no open PR; continue / review /
  merge / open-in-browser for an open PR) and never starts planning on a missing
  plan.
- **Added a lifecycle map** and split the command reference into "Commands you
  run" vs "Session commands the AI runs"; kept `implement-batch` as beta.
- **Restructured advanced sections** into discoverable H2s: Planning & base
  branches, Reviews & bot triggers, Guardrails & completion gates, Task
  Providers, Permission modes/autonomy & sandboxing, Supported AI Tools, Agent
  Skills, Extension Hooks. The dense reference blocks (permission tiers, network
  policy, completion-gate table) were preserved intact.
- **Corrected the nonexistent `wade fetch-reviews` reference** — in the README
  and in the `src/wade/providers/_pr_delegate.py` docstring — to the real command
  `wade review-pr-comments-session fetch`, and clarified that all task providers
  delegate PR/review operations to GitHub via `gh`.
- Applied provider-neutral "task" terminology throughout except where GitHub is a
  deliberate PR/review dependency.
- **Review round (codex)**: added the required positional arguments to the session
  command examples that omitted them — `wade review-pr-comments-session fetch <N>`
  (command table + prose) and `wade plan-session done <plan_dir>` (command table).
  Verified against the required `typer.Argument(...)` declarations in
  `src/wade/cli/review_pr_comments_session.py` and `src/wade/cli/plan_session.py`.
- **Review round 2 (codex)**: two P2 accuracy fixes.
  - Qualified the **Agent guardrails** highlight so it no longer promises the
    write/completion guards to hookless tools — it now scopes the per-session-hook
    guarantee to hook-capable tools and points to the support table. Verified
    against that table (`README.md`), which lists OpenCode, VS Code, and
    Antigravity IDE as receiving no hook-installed guard.
  - Split the **merged-PR** case out of the `wade <N>` routing table's "no open
    PR" row. `smart_start.py` (`is_merged` branch) reports "already merged" and
    returns without launching a session, whereas a closed *unmerged* PR starts a
    fresh implement — the table now states both accurately.

## Testing

- `./scripts/check.sh` — ruff check, ruff format --check, and mypy --strict all
  pass (114 source files).
- `./scripts/test.sh` — full suite, 3634 passed.
- `wade review implementation` — two review passes; both flagged findings
  (docstring line wrap, stale "issue"→"task" wording) addressed.
- Verified every command/flag/provider claim against `wade --help`, subcommand
  help (`implement`, `plan`, `review-pr-comments-session`, `task`), and the
  source (`smart_start.py`, `review.py`, `_pr_delegate.py`, `ai_resolution.py`).
- Confirmed internal anchors (`#codex-sandbox--network-policy`,
  `#planning--base-branches`) resolve and no other doc references the renamed
  README sections.

## Notes for reviewers

Only two files change: `README.md` (the bulk) and a docstring-only edit in
`src/wade/providers/_pr_delegate.py` (no behavioral change). The `_pr_delegate`
edit is included because it repeated the same nonexistent `wade fetch-reviews`
command name the README was correcting.

<!-- wade:summary:end -->

<!-- wade:review-status:start -->

## Review Status

✅ Reviewed at `56e90d8` via `wade review implementation`.

<!-- wade:review-status:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | *unavailable* |

### Session 2

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-opus-4.8` |
| Total tokens | *unavailable* |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `f413a3dc-f4c4-42b9-b133-df4d0bcac943` |
| Review | `claude` | `ba79f439-9e55-44c6-9d4e-a3831acad605` |
| Review | `claude` | `55d7537a-3080-47ad-b845-f269ae4151f0` |

<!-- wade:sessions:end -->
