### PR TITLE
docs: reconcile developer references with the current codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,14 +35,15 @@ uv pip install -e ".[dev]"
 
 ```
 CLI Layer      →  services, models, config, logging, ui
-Service Layer  →  providers, crossby (AI tool adapters), git, db, models, config, logging
+Service Layer  →  providers, crossby (AI tool adapters), git, models, config, logging
 Provider Layer →  models, config, logging  (no service imports)
 Git Layer      →  models, config, logging  (no service imports)
-DB Layer       →  models, logging          (no config imports)
 Models Layer   →  nothing (leaf)
 ```
 
-AI tool adapters live in the external [`crossby`](https://github.com/ivanviragine/crossby) package, not this repo — see `docs/dev/architecture.md`.
+Never import a higher layer from a lower one, and keep business logic out of `cli/`. One sanctioned exception runs the other way: services may import the lower `skills/` utility layer for skill-file management (`install_skills`, the `*_SKILLS` registries, gitignore/cross-tool constants), never the reverse.
+
+AI tool adapters live in the external [`crossby`](https://github.com/ivanviragine/crossby) package, not this repo — wade's services import `crossby.ai_tools` and `crossby.models.ai` directly. See `docs/dev/architecture.md`.
 
 CLI modules are thin dispatch — parse flags with Typer, call service methods. Business logic lives in `services/`, not `cli/`.
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -89,6 +89,8 @@ src/wade/
 │   ├── base.py          # AbstractTaskProvider
 │   ├── github.py        # GitHubProvider (gh CLI subprocess)
 │   ├── clickup.py       # ClickUpProvider (REST API)
+│   ├── markdown.py      # MarkdownIssueProvider (single central task file)
+│   ├── _pr_delegate.py  # GitHubPRDelegateMixin (routes PR/review APIs through gh)
 │   └── registry.py      # Provider registry (register_provider / get_provider)
 ├── git/                 # Git operations (all subprocess)
 │   ├── repo.py          # Repo introspection
@@ -132,14 +134,14 @@ src/wade/
 > per-worktree at `.wade/githooks/pre-push` (see *Completion Gates & the
 > `done`-marker* below).
 >
-> **The `db/` package is unused scaffolding** — deliberately omitted from the
-> tree above. No code path under `services/` or `cli/` writes
-> session/worktree/PR rows, so its sole reader
-> (`implementation_service/cleanup._preserve_session_data`, a single
-> `SessionRepository.get_by_worktree_path` call) always gets an empty result and
-> falls back to directory-presence detection. Real persisted state lives in
-> GitHub (PR/issue body markers, labels) and worktree files, not SQLite. The
-> `db/` code still exists but is inert; removal is tracked as **#357 C5**.
+> **There is no `db/` package** (hence its absence from the tree above). Earlier
+> wade versions scaffolded a SQLite layer, but no code path under `services/` or
+> `cli/` ever wrote session/worktree/PR rows. The package and its sole reader — a
+> `SessionRepository.get_by_worktree_path` lookup in
+> `implementation_service/cleanup._preserve_session_data`, which always returned
+> empty — were removed in **#357 C5**; that function now detects the AI tool by
+> worktree directory presence alone. Real persisted state lives in GitHub
+> (PR/issue body markers, labels) and worktree files — never SQLite.
 
 ## AI Tool Layer (external: crossby)
 
@@ -496,7 +498,7 @@ session from starting.
   omitted if absent) and points at the phase's `done` command and the gates it
   enforces; for plan (a detached worktree with no `PLAN.md` at the root) it points
   at writing a valid `PLAN*.md` then `plan-session done .wade/plans`, plus — for a
-  `wade plan --issue-id` session — the issue ref parsed from `.wade/plan-issue.md`
+  `wade plan --issue` session — the issue ref parsed from `.wade/plan-issue.md`
   (which `plan_service` persists so a resumed/compacted plan session re-injects
   *which* issue it is planning; omitted for a from-scratch plan). Import-light and
   stdout-safe — it reads the issue-ref file with a plain file read, never the `wade.git`
@@ -629,11 +631,11 @@ boundary.
 
 ## Command Dispatch
 
-`src/wade/cli/main.py` is the root Typer application. It registers subcommand groups (`task`, `worktree`, `plan-session`, `implementation-session`, `review-pr-comments-session`, `review`) and admin commands (`init`, `update`, `deinit`, `check-config`, `shell-init`). The `tasks` alias is registered as a hidden Typer group pointing to the same `task_app`. The `wade` entry point (defined in `pyproject.toml` as `wade.cli.main:cli_main`) invokes the root app.
+`src/wade/cli/main.py` is the root Typer application. It registers subcommand groups (`task`, `worktree`, `plan-session`, `implementation-session`, `review-pr-comments-session`, `review`, `knowledge`) and admin commands (`init`, `update`, `deinit`, `check-config`, `shell-init`). The `tasks` alias (for `task`) and `address-reviews-session` (for `review-pr-comments-session`) are hidden Typer groups pointing at the same apps, and `hook` is a hidden write-guard entry point invoked by AI tools. The `wade` entry point (defined in `pyproject.toml` as `wade.cli.main:cli_main`) invokes the root app.
 
 CLI modules are **thin dispatch layers** — they parse flags via Typer, then call service methods. Business logic lives in `services/`, not in `cli/`.
 
-**Interactive menus**: `wade task` and `wade worktree` with no subcommand show interactive menus. `wade task create` prompts interactively for title and body. Top-level commands `plan`, `implement`, `implement-batch`, and `cd` are registered directly on the root app. The `review` subcommand group provides `plan`, `implementation`, `pr-comments`, and `batch` commands. Hidden short aliases `p`, `i`, and `r` map to `plan`, `implement`, and `review pr-comments` respectively. The numeric shorthand `wade <N>` is rewritten to the hidden `smart-start` command in `cli_main()`, which detects PR state and routes to implement or review pr-comments.
+**Interactive menus**: `wade task` and `wade worktree` with no subcommand show interactive menus. `wade task create` prompts interactively for title and body. Top-level commands `plan`, `implement`, `implement-batch`, and `cd` are registered directly on the root app (alongside the hidden `smart-start` and `address-reviews` commands). The `review` subcommand group provides `plan`, `implementation`, `pr-comments`, `trigger`, and `batch` commands. Hidden short aliases `p`, `i`, and `r` map to `plan`, `implement`, and `review pr-comments` respectively. The numeric shorthand `wade <N>` is rewritten to the hidden `smart-start` command in `cli_main()`, which detects PR state and routes to implement or review pr-comments.
 
 **Shell integration**: `wade shell-init` outputs a shell function wrapper for `eval "$(wade shell-init)"` that intercepts `wade cd <n>` and `wade worktree cd <n>` to perform a real `cd` in the caller's shell.
 
@@ -802,15 +804,61 @@ Each AI tool adapter must implement the abstract method `capabilities()` (binary
 
 **Deps delegation modes**: `deps_service.py` runs analysis via the generic delegation infrastructure (`delegation_service.py`). The default mode is `headless`; it can be overridden to `interactive` or `prompt` via the `ai.deps.mode` config key or the `--mode` CLI flag. There is no automatic fallback between modes — the resolved mode is used directly. Prompt mode prints the raw dependency-analysis prompt with no AI-tool requirement or worktree bootstrap. Headless and interactive modes perform the real AI launch path and are the only modes that create the temporary analysis worktree.
 
-## Issue Detection (Snapshot/Diff Pattern)
+## Planning Lifecycle (plan-file contract)
 
-`wade plan` uses a snapshot/diff pattern to detect issues created during an AI session (Path A — fallback):
+`wade plan` (`services/plan_service.py`) is a **two-phase** flow. The AI **never
+creates issues** — it writes one `PLAN*.md` per issue to a plan directory, and
+after it exits **wade** validates those files and persists the issues and draft
+PRs itself. This is a deliberate determinism boundary (see *Determinism via
+Services*): the agent authors plan content; code decides what becomes an issue.
 
-1. **Before AI** — Snapshot all open issue numbers with the configured label
-2. **AI runs** — The agent creates issues via `wade task create` from within the AI CLI
-3. **After AI** — Compare current issue numbers against the pre-snapshot, returning only newly created ones
+**Phase 1 — generate plan files.** In a git repo the service creates a
+detached-HEAD **planning worktree** (`git/worktree.py:create_detached_worktree`),
+bootstraps it (`PLAN_SKILLS`, `plan_mode=True`, `SessionPhase.PLAN`), and points
+the AI at `<worktree>/.wade/plans/`. Isolating outputs to that subdirectory keeps
+ordinary repo markdown (e.g. `README.md`) from being misread as a generated plan.
+Outside a git repo it falls back to a `tempfile.mkdtemp(prefix="wade-plan-")`
+temp dir and skips draft-PR creation. The launch prompt (`plan-session.md`) tells
+the agent to write a plan file per issue and to **not** create the issues.
 
-This avoids requiring the AI to report back which issues it created — the service detects them deterministically. When no issues are detected (Path B), the service reads plan files from the session temp dir and creates lightweight issues + draft PRs.
+**Phase 2 — validate, then persist.** After the AI exits, wade discovers the
+title-parseable files (`validate_plan_files`) and runs the **strict**
+`_select_valid_plans` gate (`utils/plan_validation.py:validate_plan_dir`): every
+plan must carry a `## Complexity` and a conventional-commit title prefix. Invalid
+files are surfaced loudly and skipped — a TTY run confirms before proceeding with
+the valid subset; a non-TTY / `yolo` run proceeds after the warning. For a
+from-scratch plan, `_create_issues_from_plans` then, **per valid plan file**:
+
+1. Creates a **lightweight task** (title + a brief context excerpt) via the
+   configured provider's `create_task` — this may be a **non-GitHub** provider.
+2. Adds the `complexity:X` label.
+3. Bootstraps a **draft PR** carrying the full plan body (`bootstrap_draft_pr`),
+   then appends the PR link to the task body. Draft-PR / review APIs always flow
+   through GitHub (`gh`) regardless of the task provider: non-GitHub providers
+   compose `GitHubPRDelegateMixin` (`providers/_pr_delegate.py`), so task CRUD
+   uses the provider's own backend while PR/review operations delegate to `gh`.
+
+**`--issue <id>` (attach / supersede).** With an issue id, the session is
+pre-loaded with that issue's context (and the issue heading is persisted to
+`.wade/plan-issue.md` so a resumed/compacted plan session can re-inject it). A
+**single** valid plan is attached to the existing issue via a draft PR
+(`_attach_plan_to_existing_issue`, preserving the original body and appending the
+PR link); **multiple** plans **supersede** it — one new issue per plan, then the
+original is commented on and closed as *not planned*
+(`_supersede_issue_with_plans`), but only if every plan became an issue (a
+partial split leaves the original open).
+
+**Partial-plan preservation.** When the strict gate rejects a batch (all invalid,
+or the user aborted a partial run) or a draft PR can't be persisted (e.g. an
+unresolvable declared base), the generated `PLAN*.md` are salvaged to a stable
+temp dir (`_preserve_generated_plans`) instead of being discarded with the
+worktree — a one-line fix (a missing `## Complexity`) shouldn't force a full
+re-plan. On the success paths the planning worktree/temp dir is cleaned up.
+
+**Automatic dependency analysis.** When a run produces **2+** issues,
+`_finalize_issues` runs `deps_service.analyze_deps` over them and applies any
+dependency edges it finds (reusing the planning worktree). A single-issue run
+instead offers to start implementing it immediately.
 
 ## Merge Strategy
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -843,17 +843,24 @@ pre-loaded with that issue's context (and the issue heading is persisted to
 `.wade/plan-issue.md` so a resumed/compacted plan session can re-inject it). A
 **single** valid plan is attached to the existing issue via a draft PR
 (`_attach_plan_to_existing_issue`, preserving the original body and appending the
-PR link); **multiple** plans **supersede** it — one new issue per plan, then the
-original is commented on and closed as *not planned*
-(`_supersede_issue_with_plans`), but only if every plan became an issue (a
-partial split leaves the original open).
+PR link); **multiple** plans **supersede** it — one new issue per plan
+(`_supersede_issue_with_plans`). Only if every plan became an issue does it then
+comment on the original and — unless `yolo` — prompt to close it as *not
+planned*; declining that prompt leaves the original open even though every plan
+succeeded. A partial split (some plans failed to become issues) always leaves
+the original open, no prompt asked.
 
 **Partial-plan preservation.** When the strict gate rejects a batch (all invalid,
 or the user aborted a partial run) or a draft PR can't be persisted (e.g. an
 unresolvable declared base), the generated `PLAN*.md` are salvaged to a stable
 temp dir (`_preserve_generated_plans`) instead of being discarded with the
 worktree — a one-line fix (a missing `## Complexity`) shouldn't force a full
-re-plan. On the success paths the planning worktree/temp dir is cleaned up.
+re-plan. This covers the from-scratch multi-plan path and the single-plan attach
+failure path. The `--issue` **supersede** path is the exception: on a partial
+split, the failed plan files are *not* salvaged — `_supersede_issue_with_plans`
+returns only the successful issue numbers, and the caller finalizes those and
+removes the planning worktree/temp dir, discarding the failed plan(s) along with
+it. On the full-success paths the planning worktree/temp dir is cleaned up.
 
 **Automatic dependency analysis.** When a run produces **2+** issues,
 `_finalize_issues` runs `deps_service.analyze_deps` over them and applies any

--- a/docs/dev/extending.md
+++ b/docs/dev/extending.md
@@ -18,12 +18,14 @@ AI tool adapters (`AbstractAITool` subclasses, using `__init_subclass__` auto-re
 
 ## Adding a New Provider
 
-The provider system uses `AbstractTaskProvider` ABC (`src/wade/providers/base.py`) with `GitHubProvider` and `ClickUpProvider` as current implementations. Unlike AI tools (which are external, via crossby), providers are local to wade and use a registry pattern. To add a new provider (e.g., Linear, Jira):
+The provider system uses `AbstractTaskProvider` ABC (`src/wade/providers/base.py`) with `GitHubProvider`, `ClickUpProvider`, and `MarkdownIssueProvider` as current implementations. Unlike AI tools (which are external, via crossby), providers are local to wade and use a registry pattern. To add a new provider (e.g., Linear, Jira):
 
 1. Create `src/wade/providers/<provider_name>.py`
 2. Implement all abstract methods from `AbstractTaskProvider`
 3. Add the provider ID to `ProviderID` enum in `models/config.py`
 4. Register the provider in `providers/__init__.py` via `register_provider(ProviderID.YOUR_ID, YourProvider)` (use a lazy loader for optional dependencies)
+
+Non-GitHub providers (ClickUp, Markdown) still need PRs and PR-review APIs, which are GitHub-only. They get these by composing `GitHubPRDelegateMixin` (`providers/_pr_delegate.py`), which routes PR/review calls through `gh` while task CRUD stays on the provider's own backend.
 
 ## Version Bumping
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -14,27 +14,39 @@ tests/
 │   ├── test_config/         # Config parsing tests
 │   ├── test_utils/          # Utility function tests
 │   ├── test_cli/            # CLI command tests (shell-init, AI flags)
-│   ├── test_db/             # Database repository tests
 │   ├── test_git/            # Git operation tests (branch, sync, worktree)
-│   ├── test_hooks/          # Hook tests (plan write guard)
-│   └── test_providers/      # Provider tests (GitHub PR, ClickUp, labels)
+│   ├── test_hooks/          # Hook guard-policy tests (worktree/plan/shell/Stop)
+│   ├── test_providers/      # Provider tests (GitHub PR, ClickUp, Markdown, labels)
+│   └── test_skills/         # Skill helpers (doc targets, managed gitignore, knowledge attrs)
 ├── integration/             # Needs git repos, mock gh
+│   ├── test_autostash.py
 │   ├── test_check.py
-│   ├── test_init.py
 │   ├── test_git.py
 │   ├── test_implementation_lifecycle.py
+│   ├── test_init.py
+│   ├── test_knowledge.py
+│   ├── test_markdown_provider.py
+│   ├── test_skill_context_budget.py
 │   └── test_skill_install.py
 ├── e2e/                     # End-to-end contract tests (mocked gh, deterministic)
 │   ├── conftest.py
 │   ├── _support.py
 │   ├── mock_gh_script.py
+│   ├── test_admin_contract.py
 │   ├── test_check_contract.py
+│   ├── test_implement_work_done_contract.py
+│   ├── test_knowledge_contract.py
+│   ├── test_mock_gh_contract.py
 │   ├── test_plan_contract.py
-│   ├── test_review_contract.py # review plan/implementation/pr-comments + session fetch/resolve
+│   ├── test_review_contract.py     # review plan/implementation/pr-comments + session fetch/resolve
 │   ├── test_smart_start_contract.py
 │   ├── test_task_contract.py
-│   ├── test_implement_work_done_contract.py
 │   └── test_work_sync_list_contract.py
+├── concurrency/             # Deterministic forced-interleaving races (#357), mocked gh
+│   ├── test_batch_multi_pr.py     # multi-PR batch classification
+│   ├── test_knowledge_merge.py    # concurrent KNOWLEDGE.md merges
+│   ├── test_lock_retry.py         # lock contention
+│   └── test_stash_race.py         # stash-stack races
 ├── live/                    # Manual live lanes (env-gated)
 │   ├── test_wade_live_gh.py
 │   ├── test_wade_live_ai.py
@@ -60,6 +72,9 @@ tests/
 
 # Integration tests only (needs git, uses mock gh)
 ./scripts/test.sh tests/integration/
+
+# Concurrency lane only (deterministic forced-interleaving; real git + mock gh)
+./scripts/test-concurrency.sh
 
 # Specific test file
 ./scripts/test.sh tests/unit/test_services/test_implementation_done_sync.py
@@ -105,6 +120,7 @@ credentials, or binaries are missing.
 
 - `e2e_docker`: deterministic e2e tests executed in docker/CI lanes
 - `contract`: behavior contract tests for CLI/service integration
+- `concurrency`: deterministic forced-interleaving tests for shared git/remote state (#357)
 - `live_gh`: manual live tests requiring gh auth + network
 - `live_ai`: manual live tests requiring real AI credentials
 
@@ -137,9 +153,9 @@ The recommended manual sandbox repo for both live GH and live AI workflow runs i
   [smoke.sh](/Users/ivanviragine/Documents/workspace/taskr/scripts/smoke.sh).
 
 Current live AI coverage is split deliberately:
-- [tests/live/test_wade_live_ai.py](/Users/ivanviragine/.codex/worktrees/c780/wade/tests/live/test_wade_live_ai.py)
+- [tests/live/test_wade_live_ai.py](../../tests/live/test_wade_live_ai.py)
   is the minimal provider smoke (API key + Claude headless + parseable output).
-- [tests/live/test_wade_live_ai_taskr.py](/Users/ivanviragine/.codex/worktrees/c780/wade/tests/live/test_wade_live_ai_taskr.py)
+- [tests/live/test_wade_live_ai_taskr.py](../../tests/live/test_wade_live_ai_taskr.py)
   is the taskr workflow lane (real repo, real edits, real tests, real PR lifecycle).
   It uses WADE's real issue/worktree/bootstrap flow plus WADE's implementation
   prompt, then completes via `wade implementation-session done`.
@@ -172,7 +188,7 @@ The taskr workflow lane is host-only and destructive by design:
 ## CI Execution Model
 
 - Full non-live validation requires both `./scripts/test.sh` and `./scripts/test-e2e-docker.sh`.
-- Unit + integration + top-level CLI smoke (`tests/test_cli_basics.py`) run directly on the CI host.
+- Unit + integration + concurrency + top-level CLI smoke (`tests/test_cli_basics.py`) run directly on the CI host — the default `./scripts/test.sh` (i.e. `tests/`, minus `tests/live/`) already includes `tests/concurrency/`; `./scripts/test-concurrency.sh` runs only that lane.
 - Deterministic E2E contract tests run via `./scripts/test-e2e-docker.sh` and `docker-compose.e2e.yml`.
 - Live lanes remain manual and env-gated (`test-live-gh.sh`, `test-live-ai.sh`, `test-live-ai-taskr.sh`).
 


### PR DESCRIPTION
Closes #439

<!-- wade:plan:start -->

## Complexity
medium

## Context / Problem
The developer documentation contains source-facing drift that can mislead
contributors. CONTRIBUTING.md still models a DB layer even though no `db/`
package or database test directory exists; docs/dev/testing.md lists a
`test_db/` tree that is absent; and docs/dev/architecture.md describes a retired
snapshot/diff planning path in which agents create tasks during `wade plan`.
The live plan service instead strictly validates PLAN*.md files after the AI
session and creates/attaches lightweight tasks and draft PRs itself. These
documents must remain an accurate extension and maintenance reference.

## Proposed Solution
Perform a source-led reconciliation of CONTRIBUTING.md and docs/dev/. Preserve
useful architectural explanation, but replace obsolete implementation details
with the present command dispatch, planning lifecycle, package layout, and test
lanes. Make the resulting docs a dependable map for contributors rather than a
second, drifting specification.

## Tasks
- [ ] Align CONTRIBUTING.md's dependency-layer diagram and explanatory prose
  with AGENTS.md and the actual `src/wade/` package tree: remove the nonexistent
  DB layer/import path and retain the sanctioned service-to-skills boundary and
  external crossby responsibility where relevant.
- [ ] Refresh docs/dev/testing.md's repository tree and test-lane guidance from
  the actual `tests/` and `scripts/` layout, including the deterministic E2E and
  concurrency lanes; remove the nonexistent database test entry.
- [ ] Replace architecture.md's retired snapshot/diff planning description with
  the current plan-file contract: plan worktree/temp directory, strict
  PLAN*.md validation, automatic task/draft-PR persistence, partial-plan
  preservation, `--issue` attach/supersede behavior, and automatic dependency
  analysis for multi-plan output.
- [ ] Reconcile command-dispatch and lifecycle passages with `cli/main.py`,
  smart-start service behavior, the plan/implementation/review services, and
  the current provider split (tasks may be non-GitHub; PR operations use GitHub).
- [ ] Audit the remaining docs/dev references and CONTRIBUTING links/examples
  against source, CLI help, and current templates; update any direct contradiction
  found during that audit while keeping the documents focused on development,
  not duplicating README onboarding.

## Acceptance Criteria
- [ ] CONTRIBUTING.md and docs/dev/testing.md no longer claim a DB package or
  `tests/unit/test_db/` directory exists.
- [ ] docs/dev/architecture.md describes the implemented PLAN*.md flow and no
  longer tells contributors that planning agents create issues via a snapshot/
  diff fallback.
- [ ] Developer documentation accurately distinguishes task-provider behavior
  from GitHub PR/review behavior and matches the current CLI dispatch.
- [ ] Every changed technical statement is checked against the named source
  modules, test tree, or `wade --help` output; all internal Markdown links still
  resolve.

<!-- wade:plan:end -->

<!-- wade:summary:start -->

## Summary

## What was done

Reconciled the developer documentation (`CONTRIBUTING.md`, `docs/dev/`) with the
current codebase so it maps the code contributors actually work in, rather than a
second, drifting specification. Removed obsolete implementation details (a DB
layer that no longer exists, a retired snapshot/diff planning path) and replaced
them with the present package layout, planning lifecycle, command dispatch, and
test lanes. Every changed technical statement was checked against `src/wade/`,
the `tests/` tree, and the CLI.

## Changes

- **CONTRIBUTING.md** — Removed the nonexistent `DB Layer` line and the `db`
  import from the Service Layer in the dependency diagram (now matches
  `AGENTS.md` and the real `src/wade/` tree). Added the sanctioned
  `service -> skills` boundary note and the direct `crossby.ai_tools` import
  detail.
- **docs/dev/testing.md** — Refreshed the `tests/` tree: removed the nonexistent
  `test_db/`, added `test_skills/` and the new `tests/concurrency/` lane, and
  filled in the current `integration/` and `e2e/` files. Documented
  `./scripts/test-concurrency.sh` and the `concurrency` pytest marker, reconciled
  the CI-execution model, and fixed two stale machine-specific live-AI links to
  repo-relative paths.
- **docs/dev/architecture.md** — Replaced the retired "Issue Detection
  (Snapshot/Diff Pattern)" section with a "Planning Lifecycle (plan-file
  contract)" section describing the implemented flow: detached-HEAD planning
  worktree (or temp-dir fallback), strict `PLAN*.md` validation, automatic
  task + draft-PR persistence, `--issue` attach/supersede behavior, partial-plan
  preservation, and automatic dependency analysis for multi-plan output. Added
  the Markdown provider and `GitHubPRDelegateMixin` to the package tree,
  reconciled Command Dispatch (added the `knowledge` group, the hidden `hook`
  entry point and aliases, and `review trigger`), corrected the `db/` note (the
  package was removed in #357 C5), and fixed a `--issue-id` -> `--issue` flag
  typo.
- **docs/dev/extending.md** — Listed `MarkdownIssueProvider` among current
  providers and explained that non-GitHub providers compose
  `GitHubPRDelegateMixin` to route PR/review APIs through `gh`.

## Testing

- `./scripts/test.sh tests/unit/test_skills/ tests/integration/test_skill_context_budget.py`
  — 50 passed (the only tests that reference these doc files use filenames, not
  content). No Python changed, so the code test suite is unaffected.
- `wade review implementation` — passed; it caught one real error (a
  `MarkdownProvider` -> `MarkdownIssueProvider` class-name mismatch), which was
  fixed and folded into the commit.
- Manually verified every referenced symbol, path, and internal link resolves
  against source (providers, CLI flags/dispatch, plan-service helpers, the
  `tests/`/`scripts/` layout).

## Notes for reviewers

- `AGENTS.md` carries the same now-stale `db/` scaffolding note as the one fixed
  in `architecture.md`, but it is a wade-managed **skip-worktree** file (worktree
  bootstrap injects the per-session `## Git Workflow` pointer and suppresses
  session-local diffs), so it is intentionally left untouched here and is outside
  this issue's stated scope (CONTRIBUTING.md + docs/dev/). Recommend a dedicated
  follow-up that unsets the bit, edits the note, and re-sets it.

## Review round — addressed 2 comments (chatgpt-codex-connector)

- **`docs/dev/architecture.md:854`** — "Partial-plan preservation" claimed
  generated `PLAN*.md` are unconditionally salvaged instead of discarded with
  the worktree. Verified against `plan_service.py`: on the `--issue` supersede
  path (`_supersede_issue_with_plans`), a partial split's failed plan files are
  *not* salvaged — the caller finalizes the successful issues and removes the
  worktree/temp dir regardless, unlike the from-scratch multi-plan and
  single-plan attach-failure paths, which do call `_preserve_generated_plans`
  on partial/total failure. Qualified the doc to call out this exception.
- **`docs/dev/architecture.md:849`** — The supersede description said the
  original issue is commented on and closed as *not planned* whenever every
  plan became an issue, omitting the interactive confirmation step. Verified
  `_supersede_issue_with_plans` (plan_service.py:1196-1203): closing is gated
  behind a `prompts.confirm` (skipped only with `yolo`), and declining it
  leaves the original open even on full success. Added this to the doc.

Both threads verified against current code and resolved. No threads left
unresolved.

<!-- wade:summary:end -->

<!-- wade:review-status:start -->

## Review Status

✅ Reviewed at `eece328` via `wade review implementation`.

<!-- wade:review-status:end -->

<!-- wade:review-usage:start -->

## Token Usage (Review)

### Session 1

| Metric | Value |
| --- | --- |
| Tool | `claude` |
| Model | `claude-sonnet-5` |
| Total tokens | *unavailable* |

<!-- wade:review-usage:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `6cdf2c29-c760-4ff1-ad12-9492bf39af9e` |
| Review | `claude` | `3bbce3f8-559b-4683-879b-12d607250f23` |

<!-- wade:sessions:end -->
