### PR TITLE
chore(deps): bump crossby to adopt the Antigravity CLI hook-contract fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Version Control :: Git",
 ]
 dependencies = [
-    "crossby>=0.24.3,<0.25.0",
+    "crossby>=0.24.4,<0.25.0",
     "typer>=0.12,<0.26",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/tests/unit/test_hooks/test_hook_cli.py
+++ b/tests/unit/test_hooks/test_hook_cli.py
@@ -96,8 +96,11 @@ class TestWorktreeGuardCLI:
             "antigravity-cli",
             json.dumps({"tool_name": "Write", "tool_input": {"path": "/etc/passwd"}}),
         )
-        assert r.returncode == 2
-        # DECISION dialect: agy blocks via a top-level {"decision": "deny"}.
+        # DECISION dialect: agy reads the block from the top-level
+        # {"decision": "deny"} body, not the exit code — so the process exits 0
+        # even on a deny (crossby >= 0.24.4; see crossby#147). The decision field,
+        # not the exit code, is the contract.
+        assert r.returncode == 0
         assert json.loads(r.stdout)["decision"] == "deny"
         assert "BLOCKED" in r.stderr
 
@@ -520,8 +523,74 @@ class TestShellGuardCLI:
             "antigravity-cli",
             json.dumps({"toolCall": {"name": "run_command", "args": {"command": "cp a /etc/x"}}}),
         )
-        assert r.returncode == 2
+        # agy signals the block via the decision body, not the exit code (exit 0).
+        assert r.returncode == 0
         assert json.loads(r.stdout)["decision"] == "deny"
+
+
+class TestAntigravityPascalCaseDialect:
+    """Pin the agy PascalCase tool-arg dialect at the wade-hook boundary.
+
+    agy nests tool args under ``toolCall.args`` and names them in PascalCase
+    (``TargetFile``/``CommandLine``), and it reads the guard verdict from a
+    top-level ``{"decision": ...}`` body (never the exit code). Before crossby
+    0.24.4 (crossby#147) those args went unread, so every write/command reached
+    wade's guards as an empty event — denying an agy plan session its own
+    ``PLAN.md`` and silently no-op'ing shell containment. The rest of the unit
+    suite feeds already-normalized events, so these are the only tests that
+    exercise the raw agy arg names; they guard against a dialect regression.
+    """
+
+    def _agy(self, guard: str, payload: dict[str, object]):
+        return _run_lean("pre_tool_use", guard, "antigravity-cli", json.dumps(payload))
+
+    def test_plan_write_targetfile_allowed(self) -> None:
+        # agy's write arg is ``TargetFile`` — a plan-artifact write must be allowed.
+        r = self._agy(
+            "plan",
+            {
+                "toolCall": {
+                    "name": "write_to_file",
+                    "args": {"TargetFile": f"{WT}/.wade/plans/PLAN.md", "CodeContent": "x"},
+                },
+                "stepIdx": 1,
+            },
+        )
+        assert r.returncode == 0
+        assert json.loads(r.stdout)["decision"] == "allow"
+
+    def test_shell_read_commandline_allowed(self) -> None:
+        # agy's shell arg is ``CommandLine`` — a read command must be allowed and
+        # emit an explicit {"decision": "allow"} (a bare {} is read as deny by agy).
+        r = self._agy(
+            "plan",
+            {
+                "toolCall": {
+                    "name": "run_command",
+                    "args": {"CommandLine": "wade knowledge get --search tools", "Cwd": WT},
+                },
+                "stepIdx": 2,
+            },
+        )
+        assert r.returncode == 0
+        assert json.loads(r.stdout)["decision"] == "allow"
+
+    def test_shell_escape_commandline_denied(self) -> None:
+        # shell_containment must read ``CommandLine`` and block a redirect that
+        # resolves outside the worktree (the A2 gap in crossby#147).
+        r = self._agy(
+            "plan",
+            {
+                "toolCall": {
+                    "name": "run_command",
+                    "args": {"CommandLine": "echo x > /tmp/../etc/escape", "Cwd": WT},
+                },
+                "stepIdx": 3,
+            },
+        )
+        assert r.returncode == 0
+        assert json.loads(r.stdout)["decision"] == "deny"
+        assert "BLOCKED" in r.stderr
 
 
 class TestPerToolDialectsMatchCrossby:
@@ -882,4 +951,7 @@ class TestMemoryAllowlistCLI:
         # another out-of-worktree write for it — denied.
         stdin = json.dumps({"tool_name": "Write", "tool_input": {"path": str(self._mem_target())}})
         r = _run_lean("pre_tool_use", "worktree", "antigravity-cli", stdin)
-        assert r.returncode == 2
+        # agy's DECISION dialect exits 0 for both allow and deny — the block lives
+        # in the {"decision": "deny"} body, so assert that rather than the exit code.
+        assert r.returncode == 0
+        assert json.loads(r.stdout)["decision"] == "deny"


### PR DESCRIPTION
Closes #455

<!-- wade:plan:start -->

Wade is the consumer that surfaces the Antigravity CLI hook bugs filed as
**ivanviragine/crossby#147**. Once that lands and is released, bump the pin here
and verify the guards actually work end to end.

## Why wade is affected

Wade owns the *policies* (`src/wade/hooks/policies.py`) but crossby owns the
*dialect* — payload normalization and decision serialization
(`crossby.hooks.runtime`). Because crossby never extracts `file_path` or
`command` from an agy payload (it looks for `file_path`/`command`, agy sends
`TargetFile`/`CommandLine`), wade's guards receive an empty `HookEvent` and:

- every write is denied by wade's fail-closed `worktree_containment` /
  `plan_artifact_only` — an agy plan session can't even write its own
  `PLAN.md`;
- every `run_command` is denied by agy itself, because crossby emits `{}` for
  allow and agy requires an explicit `"decision"`;
- `shell_containment` is silently a no-op, since it has no `command` to
  inspect — a latent containment gap that becomes reachable as soon as the
  deny-everything behaviour is fixed.

Net effect today: `ai.implement`/`ai.plan` set to `antigravity-cli` is unusable
under wade guards. No wade-side code change is needed — the policies are
correct, they're just being handed empty events.

## Scope

- Bump `crossby` in `pyproject.toml` (currently `crossby>=0.24.3,<0.25.0`) to
  the release carrying the crossby#147 fix, and refresh `uv.lock`.
- No policy changes expected. If any wade test asserts the current (broken) agy
  behaviour, correct it rather than pinning the old version.

## Verification (don't merge on a green unit suite alone)

The unit suite passes today *with these bugs present*, because wade's tests feed
normalized `HookEvent`s and never exercise the agy dialect. Confirm against a
real agy payload instead:

1. Plan-guard write, using agy's actual arg name — must be **allowed**:

   ```bash
   echo '{"toolCall":{"name":"write_to_file","args":{"TargetFile":"<root>/.wade/plans/PLAN.md","CodeContent":"x"}},"stepIdx":1}' \
     | wade-hook pre_tool_use --guard plan --tool antigravity-cli --root <root>
   ```

   Today this exits 2 with *"no target path was present in the hook payload"*.

2. Shell read — must be **allowed**, and must emit an explicit
   `{"decision": "allow"}` (not `{}`, which agy denies):

   ```bash
   echo '{"toolCall":{"name":"run_command","args":{"CommandLine":"wade knowledge get --search tools","Cwd":"<root>"}},"stepIdx":2}' \
     | wade-hook pre_tool_use --guard plan --tool antigravity-cli --root <root>
   ```

3. Shell escape — must be **denied** with a readable reason. This is the A2 gap
   in crossby#147 and the one most worth checking by hand, since it currently
   passes for the wrong reason:

   ```bash
   echo '{"toolCall":{"name":"run_command","args":{"CommandLine":"echo x > /tmp/../etc/escape","Cwd":"<root>"}},"stepIdx":3}' \
     | wade-hook pre_tool_use --guard plan --tool antigravity-cli --root <root>
   ```

4. A real `wade plan` run driven by `antigravity-cli` that writes its plan
   files and runs `wade …` commands without a hook denial.

Blocked on: ivanviragine/crossby#147.


<!-- wade:plan:end -->

<!-- wade:summary:start -->

## Summary

## What was done

Bumped the `crossby` pin from `>=0.24.3` to `>=0.24.4` to adopt the
Antigravity CLI (agy) hook-contract fix released in
[crossby#147](https://github.com/ivanviragine/crossby/issues/147). This makes
`ai.implement`/`ai.plan` set to `antigravity-cli` usable under wade's write
guards. No wade policy changes were needed — the guards were already correct;
they were just being handed empty `HookEvent`s by the old crossby dialect.

## Why these changes

crossby owns the hook *dialect* (payload normalization and decision
serialization); wade owns the *policies*. On crossby 0.24.3, the agy dialect:

- never extracted agy's PascalCase tool args — agy sends `TargetFile` /
  `CommandLine`, crossby looked for `file_path` / `command` — so every write and
  command reached wade's guards as an empty event. Fail-closed containment then
  denied even an agy plan session writing its own `PLAN.md`, and
  `shell_containment` was a silent no-op (a latent containment gap).
- serialized an allow as a bare `{}`, which agy reads as a *deny*.

crossby 0.24.4 fixes both, so wade's existing policies now receive populated
events and emit an explicit `{"decision": ...}` body that agy understands.

## Changes

- `pyproject.toml`: `crossby>=0.24.3,<0.25.0` → `crossby>=0.24.4,<0.25.0`
  (`uv.lock` is gitignored here; refreshed locally to 0.24.4).
- `tests/unit/test_hooks/test_hook_cli.py`:
  - Corrected three tests that asserted the *old* agy deny contract (exit code
    2). The fixed agy DECISION dialect signals a block via the
    `{"decision": "deny"}` body with **exit 0** (agy reads the JSON body, not
    the exit code — the same exit 0 it uses for allow), so each now asserts the
    `decision` field rather than the exit code.
  - Added `TestAntigravityPascalCaseDialect`, which drives the raw agy payload
    shape (`toolCall.args` with `TargetFile` / `CommandLine`) through
    `wade-hook`. The rest of the suite only feeds already-normalized events, so
    these are the only tests that exercise the agy arg names and guard against a
    dialect regression.

## Testing

- Full suite: `./scripts/test.sh` — 3738 passed.
- Lint + strict types: `./scripts/check.sh` — clean.
- Manual verification against real agy payloads (plan's steps 1–3, via
  `wade-hook pre_tool_use --guard plan --tool antigravity-cli`):
  - Plan write with `TargetFile` → `{"decision": "allow"}`, exit 0 (was exit 2,
    "no target path was present in the hook payload").
  - Shell read with `CommandLine` → explicit `{"decision": "allow"}`, exit 0
    (was `{}`, which agy reads as deny).
  - Shell escape (`echo x > /tmp/../etc/escape`) → `{"decision": "deny", ...}`
    with a readable reason — `shell_containment` now actually inspects
    `CommandLine` and blocks the out-of-worktree redirect (the A2 gap).

## Notes for reviewers

Plan verification step 4 — a full `wade plan` run driven by `antigravity-cli`
that writes plan files and runs `wade …` commands under live guards — is an
end-to-end smoke test not run here (it requires the agy binary and creates real
session artifacts). Steps 1–3 exercise the exact crossby dialect boundary that
was broken and are now locked in as automated tests; step 4 is recommended as a
manual confirmation before/after merge.

<!-- wade:summary:end -->

<!-- wade:review-status:start -->

## Review Status

✅ Reviewed at `21edb65` via `wade review implementation`.

<!-- wade:review-status:end -->

<!-- wade:sessions:start -->

## AI Sessions

| Phase | Tool | Session |
| --- | --- | --- |
| Implement | `claude` | `d00d0dc9-e6ab-4b0b-a282-e70ed1fa0333` |

<!-- wade:sessions:end -->
