### PR TITLE
fix(hooks): scope the write guard to MultiEdit so batched edits can't bypass it

### DIFF
--- a/src/wade/services/implementation_service/bootstrap.py
+++ b/src/wade/services/implementation_service/bootstrap.py
@@ -226,8 +226,17 @@ def write_plan_md(
 # ``run_command``, Claude/Codex ``Bash`` unchanged), and ``wade-hook`` routes the
 # resulting payload to ``shell_containment`` because crossby deliberately reports
 # ``is_write=False`` for shell tool names.
+#
+# ``MultiEdit`` is the batched-edit counterpart of ``Edit`` and must be listed
+# separately: every tool matcher these compile to is matched **whole**, not by
+# substring, so agy's ``multi_replace_file_content`` is not covered by the
+# ``replace_file_content`` alternative that ``Edit`` produces — omitting it let a
+# batched agy edit through with no hook firing at all. crossby has mapped it
+# since 0.13 (agy ``multi_replace_file_content``, Cursor ``Write`` — deduped
+# against ``Edit``); on Claude/Codex it passes through unchanged and is simply
+# inert if the tool has no such name, which is the cheap side of the trade.
 _GUARD_SHELL_TOOL = "Bash"
-_GUARD_WRITE_TOOLS = ["Edit", "Write", "Delete", "NotebookEdit", _GUARD_SHELL_TOOL]
+_GUARD_WRITE_TOOLS = ["Edit", "MultiEdit", "Write", "Delete", "NotebookEdit", _GUARD_SHELL_TOOL]
 
 # Seconds before a tool abandons the PreToolUse guard. Deliberately short: this
 # runs on every write, and each tool's own default is generous enough (Cursor 60,
@@ -485,8 +494,10 @@ def _install_session_start_hook(worktree_path: Path, *, phase: SessionPhase) -> 
 # Canonical write-family tool names the PostToolUse lint feedback fires on. Scoped
 # to file-write tools (not Bash: a shell call has no path to lint; not Delete: the
 # file is gone, so linting it only injects "file not found" noise). crossby's hook
-# writers translate these per tool.
-_LINT_FEEDBACK_TOOLS = ["Edit", "Write", "NotebookEdit"]
+# writers translate these per tool. ``MultiEdit`` qualifies under that same rule —
+# it leaves a real path behind — and, like the write guard above, needs naming
+# because matchers are whole-name.
+_LINT_FEEDBACK_TOOLS = ["Edit", "MultiEdit", "Write", "NotebookEdit"]
 
 
 def _install_managed_git_hooks(worktree_path: Path, config: ProjectConfig) -> None:

--- a/tests/unit/test_services/test_bootstrap_guard_matcher.py
+++ b/tests/unit/test_services/test_bootstrap_guard_matcher.py
@@ -1,0 +1,67 @@
+"""Tests for the tool scope the PreToolUse write guard compiles to.
+
+The guard is only as good as its matcher: a write tool missing from
+``_GUARD_WRITE_TOOLS`` means no hook fires for that tool at all, so containment
+is not enforced — a silent bypass rather than a visible failure. These tests read
+the config crossby's writers actually emit, because the canonical-name list and
+the per-tool matcher are two different things and only the latter is what a tool
+matches against.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wade.services.implementation_service.bootstrap import (
+    _GUARD_WRITE_TOOLS,
+    _install_guard_hooks,
+)
+
+
+def _agy_matcher(worktree_path: Path) -> str:
+    """Return the PreToolUse matcher crossby wrote into agy's hooks.json."""
+    config = json.loads((worktree_path / ".agents" / "hooks.json").read_text())
+    return config["crossby-pretooluse"]["PreToolUse"][0]["matcher"]
+
+
+class TestGuardWriteToolScope:
+    """The canonical tool list feeding the guard matcher."""
+
+    def test_multiedit_is_scoped(self) -> None:
+        """Batched edits are a write channel and must be guarded like ``Edit``."""
+        assert "MultiEdit" in _GUARD_WRITE_TOOLS
+
+    @pytest.mark.parametrize("guard_type", ["worktree", "plan"])
+    def test_agy_matcher_covers_batched_edits(self, tmp_path: Path, guard_type: str) -> None:
+        """agy's ``multi_replace_file_content`` must be a matcher alternative.
+
+        Regression: matchers are matched **whole**, so the ``replace_file_content``
+        alternative (from ``Edit``) does not cover ``multi_replace_file_content``
+        despite being a substring of it. Asserting membership in the split
+        alternatives — not ``in matcher`` — is the point of this test.
+        """
+        _install_guard_hooks(tmp_path, guard_type=guard_type)
+
+        alternatives = _agy_matcher(tmp_path).split("|")
+
+        assert "multi_replace_file_content" in alternatives
+        # The single-edit and shell channels stay covered alongside it.
+        assert "replace_file_content" in alternatives
+        assert "write_to_file" in alternatives
+        assert "run_command" in alternatives
+
+    def test_matcher_alternatives_are_not_duplicated(self, tmp_path: Path) -> None:
+        """Adding ``MultiEdit`` must not double up a tool that collapses onto another.
+
+        crossby dedupes when several canonical names map to one native name, so
+        this pins that ``Edit``/``MultiEdit``/``Write`` collapsing (as they do on
+        Cursor) stays a single alternative rather than repeating one.
+        """
+        _install_guard_hooks(tmp_path, guard_type="worktree")
+
+        alternatives = _agy_matcher(tmp_path).split("|")
+
+        assert len(alternatives) == len(set(alternatives))

--- a/tests/unit/test_services/test_bootstrap_guard_matcher.py
+++ b/tests/unit/test_services/test_bootstrap_guard_matcher.py
@@ -27,6 +27,17 @@ def _agy_matcher(worktree_path: Path) -> str:
     return config["crossby-pretooluse"]["PreToolUse"][0]["matcher"]
 
 
+def _cursor_matcher(worktree_path: Path) -> str:
+    """Return the preToolUse matcher crossby wrote into Cursor's hooks.json.
+
+    Cursor is the tool where several canonical names collapse onto one native
+    name, so it — not agy, whose names all stay distinct — is where dedup is
+    observable.
+    """
+    config = json.loads((worktree_path / ".cursor" / "hooks.json").read_text())
+    return config["hooks"]["preToolUse"][0]["matcher"]
+
+
 class TestGuardWriteToolScope:
     """The canonical tool list feeding the guard matcher."""
 
@@ -53,15 +64,16 @@ class TestGuardWriteToolScope:
         assert "write_to_file" in alternatives
         assert "run_command" in alternatives
 
-    def test_matcher_alternatives_are_not_duplicated(self, tmp_path: Path) -> None:
-        """Adding ``MultiEdit`` must not double up a tool that collapses onto another.
+    def test_cursor_matcher_collapses_edit_family_without_duplicating(self, tmp_path: Path) -> None:
+        """Adding ``MultiEdit`` must not double up a name that collapses onto another.
 
-        crossby dedupes when several canonical names map to one native name, so
-        this pins that ``Edit``/``MultiEdit``/``Write`` collapsing (as they do on
-        Cursor) stays a single alternative rather than repeating one.
+        Cursor maps ``Edit``, ``MultiEdit`` and ``Write`` all onto ``Write``, so
+        it is the only tool here where crossby's dedup is observable — agy's
+        names all stay distinct, which would make this assertion vacuous there.
         """
         _install_guard_hooks(tmp_path, guard_type="worktree")
 
-        alternatives = _agy_matcher(tmp_path).split("|")
+        alternatives = _cursor_matcher(tmp_path).split("|")
 
+        assert alternatives.count("Write") == 1
         assert len(alternatives) == len(set(alternatives))


### PR DESCRIPTION
Closes the last open item from the Antigravity CLI hook work (crossby#147 /
#455) — the one the crossby fix commit flagged as downstream and the bump PR
(#456) did not pick up.

## The bug

`_GUARD_WRITE_TOOLS` omitted `MultiEdit`, so the guard's canonical list compiled
to a matcher without it.

Tool matchers are matched **whole**, not by substring. I verified this against
agy v1.1.14 directly: a hook registered with matcher `un_comm` does **not** fire
for the `run_command` tool. So `multi_replace_file_content` was never covered by
the `replace_file_content` alternative that `Edit` produces, despite the former
containing the latter as a substring.

Effect: a batched edit from an agy session fired **no PreToolUse hook at all** —
worktree/plan containment was never consulted. That's a silent bypass, not a
visible failure, which is what makes it worth closing. `multi_replace_file_content`
is a real tool name present in the agy binary, and crossby has mapped it since
0.13 (`sync/hooks.py:99`) — wade simply never asked for it.

## The fix

One name added to `_GUARD_WRITE_TOOLS`. Generated matchers before → after:

| tool | before | after |
| --- | --- | --- |
| agy | `replace_file_content\|write_to_file\|Delete\|NotebookEdit\|run_command` | `replace_file_content\|`**`multi_replace_file_content\|`**`write_to_file\|Delete\|NotebookEdit\|run_command` |
| claude | `Edit\|Write\|Delete\|NotebookEdit\|Bash` | `Edit\|`**`MultiEdit\|`**`Write\|Delete\|NotebookEdit\|Bash` |
| cursor | `Write\|Delete\|NotebookEdit\|Shell` | unchanged — `Edit`/`MultiEdit`/`Write` dedupe onto `Write` |
| codex | `Bash` | unchanged — sandboxes writes, so narrowed to the shell token |

On Claude/Codex `MultiEdit` passes through unchanged and is inert if the tool has
no such name — the cheap side of the trade, versus leaving a write channel
unguarded.

Also scopes `_LINT_FEEDBACK_TOOLS` to `MultiEdit`: it qualifies under that list's
own stated rule (unlike `Bash`, which has no path, and `Delete`, whose file is
gone, a batched edit leaves a real path behind to lint).

## Testing

New `tests/unit/test_services/test_bootstrap_guard_matcher.py`. The three
regression assertions **fail without this change and pass with it** — confirmed
by stashing the source edit and re-running.

They read the config crossby's writers actually emit rather than trusting the
canonical list, and assert membership in the `split("|")` alternatives rather
than `in matcher` — substring containment is the exact trap being closed, so a
naive `in` check would pass while broken. A fourth test pins that the added name doesn't duplicate an alternative where
several canonical names collapse onto one native name. That one reads **Cursor's**
matcher, not agy's: Cursor is the only tool here that maps `Edit`/`MultiEdit`/`Write`
all onto `Write`, whereas agy's three stay distinct — asserting uniqueness there
would be vacuous. (It originally did exactly that; caught in review and fixed in
e2ae780. Confirmed non-vacuous by disabling crossby's dedup, which makes Cursor emit
`Write|Write|Write|...` and fails the assertion.)

Full unit suite: 3487 passed. Lint/format/mypy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batched file edits now trigger write safeguards consistently.
  * Batched edits now receive lint feedback after changes.

* **Tests**
  * Added coverage to verify batched-edit matching across worktree and plan safeguards.
  * Added checks to ensure duplicate matcher entries are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
